### PR TITLE
Fix bug with CSSStyleSheet.insertRule in IE

### DIFF
--- a/src/Style.tsx
+++ b/src/Style.tsx
@@ -13,7 +13,7 @@ export const VirtuosoStyle: FC<{
       position: sticky;
       position: -webkit-sticky;
       z-index: 2;
-    } `)
+    } `, 0)
 
     style.current = styleEl
 


### PR DESCRIPTION
In IE, CSSStyleSheet.insertRule must has `index` argument
https://developer.mozilla.org/ko/docs/Web/API/CSSStyleSheet/insertRule

Without this param, IndexSizeError will be executed
![IndexSizeError](https://user-images.githubusercontent.com/12757765/59659142-81545400-91e0-11e9-946f-30cc67464128.PNG)
