### PR TITLE
feat: allow custom item keys via `computeItemKey`

### DIFF
--- a/src/Virtuoso.tsx
+++ b/src/Virtuoso.tsx
@@ -15,6 +15,7 @@ export interface VirtuosoProps {
   topItems?: number
   footer?: () => ReactElement
   item: (index: number) => ReactElement
+  computeItemKey: (index: number) => number
   itemHeight?: number
   endReached?: (index: number) => void
   scrollingStateChange?: (isScrolling: boolean) => void
@@ -84,15 +85,15 @@ export class Virtuoso extends PureComponent<VirtuosoProps, VirtuosoState> {
   private itemRender: TRender = (item, props) => {
     const ItemContainer = this.props.ItemContainer
     const children = this.props.item(item.index)
-
+    const key = this.props.computeItemKey ? this.props.computeItemKey(item.index) : props.key
     if (ItemContainer) {
       return (
-        <ItemContainer key={props.key} {...props}>
+        <ItemContainer {...props} key={key}>
           {children}
         </ItemContainer>
       )
     } else {
-      return <div {...props}>{children}</div>
+      return <div {...props} key={key}>{children}</div>
     }
   }
 


### PR DESCRIPTION
This PR addresses an issue regarding sorting lists. Using raw indexes as keys is discouraged in react and giving consumers the ability to provide custom keys for each row allows for stable reconciliation. Without it issues like incorrectly updated DOM nodes will pop up and cause broken UI.

@petyosi Would be awesome to get this merged. I added this functionality to our local fork but figured it would make sense for everyone who has the use case of lists which are being sorted.