### PR TITLE
fix: "ResizeObserver loop limit exceeded"

### DIFF
--- a/src/Utils.tsx
+++ b/src/Utils.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useLayoutEffect } from 'react'
+import { useRef, useState, useEffect, useLayoutEffect } from 'react'
 import ResizeObserver from 'resize-observer-polyfill'
 import { TInput, TOutput } from './rxio'
 
@@ -14,12 +14,13 @@ type UseHeight = (
 export const useHeight: UseHeight = (input, onMount, onResize) => {
   const ref = useRef<CallbackRefParam>(null)
   const currentHeight = useRef(0)
+  const animationFrameID = useRef<number>(0)
   const observer = new ResizeObserver(entries => {
     const newHeight = entries[0].contentRect.height
     if (currentHeight.current !== newHeight) {
       currentHeight.current = newHeight
       if (onResize) {
-        onResize(entries[0].target as HTMLElement)
+        animationFrameID.current = window.requestAnimationFrame(() => onResize(entries[0].target as HTMLElement))
       }
       input(newHeight)
     }
@@ -37,6 +38,8 @@ export const useHeight: UseHeight = (input, onMount, onResize) => {
       ref.current = null
     }
   }
+
+  useEffect(() => () => window.cancelAnimationFrame(animationFrameID.current), [])
   return callbackRef
 }
 


### PR DESCRIPTION
Copies the approach used in https://github.com/hshoff/vx/pull/335 to fix a "ResizeObserver loop limit exceeded" error