### PR TITLE
Made computeItemKey optional

### DIFF
--- a/src/Virtuoso.tsx
+++ b/src/Virtuoso.tsx
@@ -15,7 +15,7 @@ export interface VirtuosoProps {
   topItems?: number
   footer?: () => ReactElement
   item: (index: number) => ReactElement
-  computeItemKey: (index: number) => number
+  computeItemKey?: (index: number) => number
   itemHeight?: number
   endReached?: (index: number) => void
   scrollingStateChange?: (isScrolling: boolean) => void


### PR DESCRIPTION
#22 added `computeItemKey` but marked it as a required property. This PR makes it optional.