### PR TITLE
Remove inline style tag in favour of inline styled components

### DIFF
--- a/src/Style.tsx
+++ b/src/Style.tsx
@@ -1,44 +1,4 @@
-import { useLayoutEffect, useRef, FC, CSSProperties } from 'react'
-
-export const VirtuosoStyle: FC<{
-  stickyClassName: string
-}> = ({ stickyClassName }) => {
-  const style = useRef<HTMLStyleElement | null>(null)
-  useLayoutEffect(() => {
-    const styleEl = document.createElement('style')
-    document.head.appendChild(styleEl)
-    const sheet = styleEl.sheet as any
-
-    sheet.insertRule(
-      `.${stickyClassName} {
-      position: sticky;
-      position: -webkit-sticky;
-      z-index: 2;
-    } `,
-      0
-    )
-
-    style.current = styleEl
-
-    return () => {
-      document.head.removeChild(style.current!)
-      style.current = null
-    }
-  }, [stickyClassName])
-
-  return null
-}
-
-const START_CHAR = 97
-const END_CHAR = 122
-
-const randomChar = () => String.fromCharCode(Math.round(Math.random() * (END_CHAR - START_CHAR) + START_CHAR))
-
-export const randomClassName = () =>
-  new Array(12)
-    .fill(0)
-    .map(randomChar)
-    .join('')
+import { CSSProperties } from 'react'
 
 export const viewportStyle: CSSProperties = {
   top: 0,

--- a/src/Utils.tsx
+++ b/src/Utils.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect, useLayoutEffect } from 'react'
+import { useRef, useState, useEffect, useLayoutEffect, CSSProperties } from 'react'
 import ResizeObserver from 'resize-observer-polyfill'
 import { TInput, TOutput } from './rxio'
 
@@ -88,4 +88,23 @@ export const useSize: UseSize = callback => {
   }
 
   return callbackRef
+}
+
+export const useSticky = (): CSSProperties => {
+  const [stickyValue, setStickyValue] = useState<'sticky' | '-webkit-sticky'>('-webkit-sticky')
+
+  // Test if position '-webkit-sticky' value is supported. If not, 'sticky' is used.
+  useLayoutEffect(() => {
+    const node = document.createElement('div')
+
+    try {
+      node.style.position = stickyValue
+    } catch (err) {}
+
+    if (node.style.position !== stickyValue) {
+      setStickyValue('sticky')
+    }
+  }, [stickyValue])
+
+  return { position: stickyValue }
 }

--- a/src/VirtuosoList.tsx
+++ b/src/VirtuosoList.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, ReactElement, CSSProperties, ReactNode } from 'react'
-import { useOutput } from './Utils'
+import { useOutput, useSticky } from './Utils'
 import { VirtuosoContext } from './VirtuosoContext'
 import { ListItem } from './GroupIndexTransposer'
 
@@ -14,14 +14,14 @@ export type TRender = (item: ListItem, props: TRenderProps) => ReactElement
 
 interface TListProps {
   render: TRender
-  stickyClassName: string
 }
 
-export const VirtuosoList: React.FC<TListProps> = ({ render, stickyClassName }) => {
+export const VirtuosoList: React.FC<TListProps> = ({ render }) => {
   const { isSeeking, topList, list } = useContext(VirtuosoContext)!
   const items = useOutput<ListItem[]>(list, [])
   const topItems = useOutput<ListItem[]>(topList, [])
   const renderPlaceholder = useOutput(isSeeking, false)
+  const stickyProperty = useSticky()
 
   const renderedItems: ReactNode[] = []
   let topOffset = 0
@@ -38,13 +38,14 @@ export const VirtuosoList: React.FC<TListProps> = ({ render, stickyClassName }) 
     const style: CSSProperties = {
       top: `${topOffset}px`,
       marginTop: index === 0 ? `${-marginTop}px` : undefined,
+      zIndex: 2,
+      position: stickyProperty.position,
     }
 
     const props = {
       key: itemIndex,
       'data-index': itemIndex,
       'data-known-size': item.size,
-      className: stickyClassName,
       renderPlaceholder,
       style,
     }

--- a/src/VirtuosoView.tsx
+++ b/src/VirtuosoView.tsx
@@ -1,10 +1,10 @@
-import React, { ReactElement, useContext, FC, CSSProperties, useMemo } from 'react'
+import React, { ReactElement, useContext, FC, CSSProperties } from 'react'
 import { VirtuosoContext } from './VirtuosoContext'
 import { useHeight, CallbackRef, useOutput } from './Utils'
 import { VirtuosoScroller, TScrollContainer } from './VirtuosoScroller'
 import { VirtuosoList, TRender } from './VirtuosoList'
 import { ItemHeight } from 'VirtuosoStore'
-import { VirtuosoStyle, randomClassName, viewportStyle } from './Style'
+import { viewportStyle } from './Style'
 import { VirtuosoFiller } from './VirtuosoFiller'
 
 export const DefaultFooterContainer: React.FC<{ footerRef: CallbackRef }> = ({ children, footerRef }) => (
@@ -103,7 +103,6 @@ export const VirtuosoView: React.FC<{
 }> = ({ style, footer, item, fixedItemHeight, ScrollContainer, ListContainer, FooterContainer, className }) => {
   const { scrollTo, scrollTop, totalHeight, viewportHeight } = useContext(VirtuosoContext)!
   const fillerHeight = useOutput<number>(totalHeight, 0)
-  const stickyClassName = useMemo(randomClassName, [])
   const reportScrollTop = (st: number) => {
     scrollTop(Math.max(st, 0))
   }
@@ -120,13 +119,12 @@ export const VirtuosoView: React.FC<{
     >
       <div ref={viewportCallbackRef} style={viewportStyle}>
         <ListWrapper fixedItemHeight={fixedItemHeight} ListContainer={ListContainer}>
-          <VirtuosoList render={item} stickyClassName={stickyClassName} />
+          <VirtuosoList render={item} />
           {footer && <VirtuosoFooter footer={footer} FooterContainer={FooterContainer} />}
         </ListWrapper>
       </div>
 
       <VirtuosoFiller height={fillerHeight} />
-      <VirtuosoStyle {...{ stickyClassName }} />
     </VirtuosoScroller>
   )
 }


### PR DESCRIPTION
This PR is motivated by `VirtuosoStyle` injecting a style tag into the document's head, meaning that it collides with the recommended CSP guidelines, to remove any inlined style tags.

The sticky elements style attributes will now be passed directly to the component, not affecting possibly existing CSP rules.

