### PR TITLE
feat(endReached): inverted scrolling

### DIFF
--- a/playground/fakeData.ts
+++ b/playground/fakeData.ts
@@ -1,0 +1,44 @@
+import faker from 'faker'
+import { groupBy } from 'lodash'
+
+const generated = []
+
+export const getUser = index => {
+  if (!generated[index]) {
+    let firstName = faker.name.firstName()
+    let lastName = faker.name.lastName()
+    generated[index] = {
+      name: `${firstName} ${lastName}`,
+      initials: `${firstName.substr(0, 1)}${lastName.substr(0, 1)}`,
+      description: faker.company.catchPhrase(),
+      bgColor: faker.commerce.color(),
+      fgColor: faker.commerce.color(),
+      longText: faker.lorem.paragraphs(4),
+      avatar: faker.internet.avatar(),
+    }
+  }
+  return generated[index]
+}
+
+export const generateGroupedUsers = max => {
+  const users = []
+  for (let i = 0; i < max; i++) {
+    users.push(getUser(i))
+  }
+
+  users.sort((a, b) => {
+    if (a.name < b.name) {
+      return -1
+    }
+    if (a.name > b.name) {
+      return 1
+    }
+    return 0
+  })
+
+  const groupedUsers = groupBy(users, user => user.name[0])
+  const groupCounts = Object.values(groupedUsers).map(users => users.length)
+  const groups = Object.keys(groupedUsers)
+
+  return { users, groupCounts, groups }
+}

--- a/playground/grouped-inverted.html
+++ b/playground/grouped-inverted.html
@@ -1,0 +1,13 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta httpEquiv="X-UA-Compatible" content="ie=edge" />
+    <title>Grouped Inverted</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script src="./grouped-inverted.tsx"></script>
+  </body>
+</html>

--- a/playground/grouped-inverted.tsx
+++ b/playground/grouped-inverted.tsx
@@ -1,0 +1,61 @@
+import { generateGroupedUsers } from './fakeData'
+import React, { useMemo, useState, useRef, useCallback, useEffect } from 'react'
+import { render } from 'react-dom'
+import { GroupedVirtuoso } from '../src'
+
+// Slices the total groups to the groups
+// which contain the items so far
+// for example, if you have [10, 10, 10, 10]
+// groups in total, slicing them to 23 will result in [10, 10, 3]
+const calculateGroupsSoFar = (totalGroups: Array<any>, count: number) => {
+  const groups = []
+  let i = 0
+  do {
+    const group = totalGroups[i]
+    groups.push(Math.min(group, count))
+    count -= group
+    i++
+  } while (count > 0 && i <= totalGroups.length)
+  return groups
+}
+
+const App = () => {
+  const { groups, groupCounts } = useMemo(() => generateGroupedUsers(500), [])
+
+  const [currentGroupCounts, setCurrentGroupCounts] = useState([])
+  const loadedItems = useRef(0)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [_, setLoading] = useState(false)
+
+  const loadMore = useCallback(() => {
+    setLoading(true)
+
+    // the set timeout call is just for example purposes.
+    // In the real world,
+    // this can fetch and append data from a remote server.
+    setTimeout(() => {
+      loadedItems.current += 50
+      setLoading(false)
+      setCurrentGroupCounts(calculateGroupsSoFar(groupCounts, loadedItems.current))
+    }, 500)
+  }, [])
+
+  useEffect(loadMore, [])
+
+  return (
+    <GroupedVirtuoso
+      style={{ height: '350px', width: '400px' }}
+      groupCounts={currentGroupCounts}
+      group={(index: number) => <div>Group {groups[index]}</div>}
+      item={(index: number) => <div>User {index}</div>}
+      initialTopMostItemIndex={45}
+      endReached={index => {
+        console.warn('index', index)
+        loadMore()
+      }}
+      inverted={true}
+    />
+  )
+}
+
+render(<App />, document.getElementById('root'))

--- a/src/Virtuoso.tsx
+++ b/src/Virtuoso.tsx
@@ -56,6 +56,7 @@ export interface VirtuosoProps {
     exit: ScrollSeekToggle
     placeholder: TSeekPlaceholder
   }
+  inverted?: boolean
 }
 
 export interface TVirtuosoPresentationProps {

--- a/src/VirtuosoStore.tsx
+++ b/src/VirtuosoStore.tsx
@@ -27,6 +27,7 @@ interface TVirtuosoConstructorParams {
   itemHeight?: number
   defaultItemHeight?: number
   initialTopMostItemIndex?: number
+  inverted?: boolean
 }
 
 const VirtuosoStore = ({
@@ -35,6 +36,7 @@ const VirtuosoStore = ({
   itemHeight,
   initialTopMostItemIndex,
   defaultItemHeight,
+  inverted = false,
 }: TVirtuosoConstructorParams) => {
   const transposer$ = subject<Transposer>(new StubIndexTransposer())
   const viewportHeight$ = subject(0)
@@ -90,6 +92,7 @@ const VirtuosoStore = ({
     offsetList$,
     scrolledToTopMostItem$,
     transposer$,
+    inverted,
   })
 
   const { adjustForPrependedItems$, adjustmentInProgress$ } = adjustForPrependedItemsEngine({


### PR DESCRIPTION
I'm trying a scrolling chat like behaviour where when we reach the `top` it triggers the `endReached` callback. 

So basically, bottom --> up instead of the current implementation top --> bottom.

I added a debounce in the `listEngine` to prevent multiple calls to `endReached`

closes #80 