### PR TITLE
Fix scrolledToBottom timer isn't cleared

### DIFF
--- a/src/engines/scrolledToBottomEngine.ts
+++ b/src/engines/scrolledToBottomEngine.ts
@@ -21,7 +21,7 @@ export function scrolledToBottomEngine({ totalHeight$, viewportHeight$, scrollTo
     .subscribe(value => {
       clearTimeout(notAtBottom)
       if (!value) {
-        setTimeout(() => scrolledToBottom$.next(false))
+        notAtBottom = setTimeout(() => scrolledToBottom$.next(false))
       } else {
         scrolledToBottom$.next(true)
       }


### PR DESCRIPTION
I found that variable `notAtBottom` is always undefined but used in `clearTimeout`. I'm not sure whether we should clear the timer or we just need to remove `notAtBottom` with `clearTimeout`