### PR TITLE
Fix scrollToIndex going negative

### DIFF
--- a/src/engines/scrollToIndexEngine.ts
+++ b/src/engines/scrollToIndexEngine.ts
@@ -70,7 +70,7 @@ export function scrollToIndexEngine({
 
         scrollTopReportedAfterScrollToIndex$.next(false)
         return {
-          top: Math.min(offset, Math.floor(totalHeight - viewportHeight)),
+          top: Math.max(0, Math.min(offset, Math.floor(totalHeight - viewportHeight))),
           behavior: location.behavior ?? 'auto',
         }
       })


### PR DESCRIPTION
Calling scrollToIndex with align="center" and a target index smaller than the range in view was sometimes setting scrollTop to a negative value. If the behavior="smooth" that was making it stop rendering on scroll. So this is a small change to clamp scrollTop to a positive number, which fixes the problem.

I can reproduce this on a list with fixed itemHeight=80 like this:
```
setTimeout(() => {
  refVirtualList.current.scrollToIndex({ index: 22, align: 'center', behavior: 'smooth' });
  setTimeout(() => {
    refVirtualList.current.scrollToIndex({ index: 3, align: 'center', behavior: 'smooth'});
  }, 1000)
}, 5000);
```