### PR TITLE
feat(grid-virtuoso): add `initialItemCount` prop

### DIFF
--- a/src/VirtuosoGrid.tsx
+++ b/src/VirtuosoGrid.tsx
@@ -23,6 +23,7 @@ export interface VirtuosoGridProps {
   itemClassName?: string
   scrollingStateChange?: (isScrolling: boolean) => void
   endReached?: (index: number) => void
+  initialItemCount?: number
 }
 
 type VirtuosoGridState = ReturnType<typeof VirtuosoGridEngine>

--- a/src/VirtuosoGrid.tsx
+++ b/src/VirtuosoGrid.tsx
@@ -38,7 +38,7 @@ type TItemBuilder = (
 ) => ReactElement[]
 
 export class VirtuosoGrid extends React.PureComponent<VirtuosoGridProps, VirtuosoGridState> {
-  public state = VirtuosoGridEngine()
+  public state = VirtuosoGridEngine(this.props.initialItemCount)
 
   public static getDerivedStateFromProps(props: VirtuosoGridProps, engine: VirtuosoGridState) {
     engine.overscan(props.overscan || 0)

--- a/src/VirtuosoGridEngine.ts
+++ b/src/VirtuosoGridEngine.ts
@@ -23,7 +23,7 @@ export const VirtuosoGridEngine = (initialItemCount = 0) => {
   const totalCount$ = subject(0)
   const scrollTop$ = subject(0)
   const overscan$ = subject(0)
-  const itemRange$ = subject<GridItemRange>([0, initialItemCount - 1])
+  const itemRange$ = subject<GridItemRange>([0, max(initialItemCount - 1, 0)])
   const totalHeight$ = subject(0)
   const listOffset$ = subject(0)
   const scrollToIndex$ = coldSubject<TScrollLocation>()

--- a/src/VirtuosoGridEngine.ts
+++ b/src/VirtuosoGridEngine.ts
@@ -18,12 +18,12 @@ const { ceil, floor, min, max } = Math
 
 const hackFloor = (val: number) => (ceil(val) - val < 0.03 ? ceil(val) : floor(val))
 
-export const VirtuosoGridEngine = () => {
+export const VirtuosoGridEngine = (initialItemCount = 0) => {
   const gridDimensions$ = subject<GridDimensions>([0, 0, undefined, undefined])
   const totalCount$ = subject(0)
   const scrollTop$ = subject(0)
   const overscan$ = subject(0)
-  const itemRange$ = subject<GridItemRange>([0, 0])
+  const itemRange$ = subject<GridItemRange>([0, initialItemCount - 1])
   const totalHeight$ = subject(0)
   const listOffset$ = subject(0)
   const scrollToIndex$ = coldSubject<TScrollLocation>()


### PR DESCRIPTION
This PR adds `initialItemCount` prop to `VirtuosoGrid` and use in `VirtuosoGridEngine` for initializing item range(useful for SSR). 