### PR TITLE
Performance improvement in grid

### DIFF
--- a/src/VirtuosoGrid.tsx
+++ b/src/VirtuosoGrid.tsx
@@ -27,6 +27,7 @@ export interface VirtuosoGridProps {
   endReached?: (index: number) => void
   initialItemCount?: number
   rangeChanged?: TSubscriber<ListRange>
+  computeItemKey?: (index: number) => number
 }
 
 type VirtuosoGridState = ReturnType<typeof VirtuosoGridEngine>
@@ -37,7 +38,8 @@ type TItemBuilder = (
   range: [number, number],
   item: (index: number) => ReactElement,
   itemClassName: string,
-  ItemContainer: TContainer
+  ItemContainer: TContainer,
+  computeItemKey: (index: number) => number
 ) => ReactElement[]
 
 export class VirtuosoGrid extends React.PureComponent<VirtuosoGridProps, VirtuosoGridState> {
@@ -61,14 +63,15 @@ export class VirtuosoGrid extends React.PureComponent<VirtuosoGridProps, Virtuos
   }
 }
 
-const buildItems: TItemBuilder = ([startIndex, endIndex], item, itemClassName, ItemContainer) => {
+const buildItems: TItemBuilder = ([startIndex, endIndex], item, itemClassName, ItemContainer, computeItemKey) => {
   const items = []
   for (let index = startIndex; index <= endIndex; index++) {
+    const key = computeItemKey(index)
     items.push(
       React.createElement(
         ItemContainer,
         {
-          key: index,
+          key,
           className: itemClassName,
         },
         item(index)
@@ -89,6 +92,7 @@ const VirtuosoGridFC: React.FC<VirtuosoGridFCProps> = ({
   listClassName = 'virtuoso-grid-list',
   engine,
   style = { height: '40rem' },
+  computeItemKey = key => key,
 }) => {
   const { itemRange, listOffset, totalHeight, gridDimensions, scrollTo, scrollTop } = engine
 
@@ -117,7 +121,7 @@ const VirtuosoGridFC: React.FC<VirtuosoGridFCProps> = ({
             style: listStyle,
             className: listClassName,
           },
-          buildItems(itemIndexRange, item, itemClassName, ItemContainer)
+          buildItems(itemIndexRange, item, itemClassName, ItemContainer, computeItemKey)
         )}
       </div>
 

--- a/src/VirtuosoGrid.tsx
+++ b/src/VirtuosoGrid.tsx
@@ -4,7 +4,6 @@ import { VirtuosoGridEngine } from './VirtuosoGridEngine'
 import { VirtuosoScroller, TScrollContainer } from './VirtuosoScroller'
 import { useOutput, useSize } from './Utils'
 import { viewportStyle } from './Style'
-import { VirtuosoFiller } from './VirtuosoFiller'
 import { TScrollLocation } from './EngineCommons'
 import { ListRange } from './engines/scrollSeekEngine'
 
@@ -94,11 +93,11 @@ const VirtuosoGridFC: React.FC<VirtuosoGridFCProps> = ({
   style = { height: '40rem' },
   computeItemKey = key => key,
 }) => {
-  const { itemRange, listOffset, totalHeight, gridDimensions, scrollTo, scrollTop } = engine
+  const { itemRange, listOffset, remainingHeight, gridDimensions, scrollTo, scrollTop } = engine
 
-  const fillerHeight = useOutput<number>(totalHeight, 0)
+  const fillerHeight = useOutput<number>(remainingHeight, 0)
   const translate = useOutput<number>(listOffset, 0)
-  const listStyle = { transform: `translateY(${translate}px)` }
+  const listStyle = { paddingTop: `${translate}px`, paddingBottom: `${fillerHeight}px` }
   const itemIndexRange = useOutput(itemRange, [0, 0] as [number, number])
 
   const viewportCallbackRef = useSize(({ element, width, height }) => {
@@ -124,8 +123,6 @@ const VirtuosoGridFC: React.FC<VirtuosoGridFCProps> = ({
           buildItems(itemIndexRange, item, itemClassName, ItemContainer, computeItemKey)
         )}
       </div>
-
-      <VirtuosoFiller height={fillerHeight} />
     </VirtuosoScroller>
   )
 }

--- a/src/VirtuosoGridEngine.ts
+++ b/src/VirtuosoGridEngine.ts
@@ -25,7 +25,7 @@ export const VirtuosoGridEngine = (initialItemCount = 0) => {
   const scrollTop$ = subject(0)
   const overscan$ = subject(0)
   const itemRange$ = subject<GridItemRange>([0, max(initialItemCount - 1, 0)])
-  const totalHeight$ = subject(0)
+  const remainingHeight$ = subject(0)
   const listOffset$ = subject(0)
   const scrollToIndex$ = coldSubject<TScrollLocation>()
   const rangeChanged$ = coldSubject<ListRange>()
@@ -81,7 +81,7 @@ export const VirtuosoGridEngine = (initialItemCount = 0) => {
           updateRange(true)
         }
 
-        totalHeight$.next(itemHeight * toRowIndex(totalCount, ceil))
+        remainingHeight$.next(itemHeight * toRowIndex(totalCount - endIndex - 1, ceil))
       }
     )
 
@@ -140,7 +140,7 @@ export const VirtuosoGridEngine = (initialItemCount = 0) => {
     scrollToIndex: makeInput(scrollToIndex$),
 
     itemRange: makeOutput(itemRange$),
-    totalHeight: makeOutput(totalHeight$),
+    remainingHeight: makeOutput(remainingHeight$),
     listOffset: makeOutput(listOffset$),
     scrollTo: makeOutput(scrollTo$),
     isScrolling: makeOutput(isScrolling$),


### PR DESCRIPTION
This PR contains two improvements:

1. Add `computeItemKey` to the grid props
1.  Replace `transform` and filler component with `padding-top` and `padding-bottom`.

This technique is used in the implementation of virtual scrolling on Instagram. Based on my test changing `transform` will cause layout shifting. Also, the filler component was not necessary because we can update the `padding-bottom` to fill the remaining space(update style of one component instead of two components).