### PR TITLE
Make it possible to override tabIndex

### DIFF
--- a/src/VirtuosoScroller.tsx
+++ b/src/VirtuosoScroller.tsx
@@ -15,7 +15,7 @@ export type TScrollContainer = FC<{
   scrollTo: (callback: (scrollTop: ScrollToOptions) => void) => void
 }>
 
-const DefaultScrollContainer: TScrollContainer = ({ className, style, reportScrollTop, scrollTo, children }) => {
+const DefaultScrollContainer: TScrollContainer = ({ className, style, tabIndex='0', reportScrollTop, scrollTo, children }) => {
   const elRef = useRef<HTMLElement | null>(null)
   const smoothScrollTarget = useRef<number | null>(null)
   const currentScrollTop = useRef<number | null>()
@@ -63,7 +63,7 @@ const DefaultScrollContainer: TScrollContainer = ({ className, style, reportScro
   })
 
   return (
-    <div ref={ref} style={style} tabIndex={0} className={className}>
+    <div ref={ref} style={style} tabIndex={tabIndex} className={className}>
       {children}
     </div>
   )


### PR DESCRIPTION
In my case I don't want to give scroller a tab focus, but right now I can't override this behaviour