### PR TITLE
Add `header` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Check the [responsive grid columns](https://virtuoso.dev/grid-responsive-columns
 The component accepts an optional
 `header` [render property](https://reactjs.org/docs/render-props.html),
 which is rendered before all items.
-The header can be used to host an indicator that the user has reached the top of the list.
+The header can be used to host an indicator that the user has reached the top of the list when using it bottom up.
 
 ### Footer
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Out of the box, Virtuoso:
 - Supports **grouping with sticky group headers** (`GroupedVirtuoso`);
 - Supports **responsive grid layout** (`VirtuosoGrid`);
 - Automatically handles content resizing;
+- Can render header at the top of the list;
 - Can render footer at the end of the list;
 - Can **pin the first `N` items** to the top of the list.
 
@@ -66,6 +67,13 @@ The `VirtuosoGrid` component displays **same sized items** in multiple columns.
 The layout and item sizing is controlled through CSS class properties, which allows you to use media queries, min-width, percentage, etc.
 
 Check the [responsive grid columns](https://virtuoso.dev/grid-responsive-columns) example for a sample implementation.
+
+### Header
+
+The component accepts an optional
+`header` [render property](https://reactjs.org/docs/render-props.html),
+which is rendered before all items.
+The header can be used to host an indicator that the user has reached the top of the list.
 
 ### Footer
 

--- a/src/GroupedVirtuoso.tsx
+++ b/src/GroupedVirtuoso.tsx
@@ -68,9 +68,11 @@ export const GroupedVirtuoso = forwardRef<GroupedVirtuosoMethods, GroupedVirtuos
       contextValue={state}
       style={props.style}
       className={props.className}
+      header={props.header}
       footer={props.footer}
       itemHeight={props.itemHeight}
       ScrollContainer={props.ScrollContainer}
+      HeaderContainer={props.HeaderContainer}
       FooterContainer={props.FooterContainer}
       ListContainer={props.ListContainer}
     />

--- a/src/Virtuoso.tsx
+++ b/src/Virtuoso.tsx
@@ -6,7 +6,14 @@ import { TSubscriber } from './tinyrx'
 import { VirtuosoContext } from './VirtuosoContext'
 import { TRenderProps } from './VirtuosoList'
 import { VirtuosoStore } from './VirtuosoStore'
-import { DefaultListContainer, TFooterContainer, TListContainer, TScrollContainer, VirtuosoView } from './VirtuosoView'
+import {
+  DefaultListContainer,
+  THeaderContainer,
+  TFooterContainer,
+  TListContainer,
+  TScrollContainer,
+  VirtuosoView,
+} from './VirtuosoView'
 
 export type VirtuosoState = ReturnType<typeof VirtuosoStore>
 
@@ -16,6 +23,7 @@ export interface VirtuosoProps {
   totalCount: number
   overscan?: number
   topItems?: number
+  header?: () => ReactElement
   footer?: () => ReactElement
   item: (index: number) => ReactElement
   computeItemKey?: (index: number) => React.Key
@@ -35,6 +43,7 @@ export interface VirtuosoProps {
   initialTopMostItemIndex?: number
   followOutput?: boolean
   ScrollContainer?: TScrollContainer
+  HeaderContainer?: THeaderContainer
   FooterContainer?: TFooterContainer
   ListContainer?: TListContainer
   ItemContainer?: TItemContainer
@@ -44,11 +53,13 @@ export interface VirtuosoProps {
 
 export interface TVirtuosoPresentationProps {
   contextValue: VirtuosoState
+  header?: () => ReactElement
   footer?: () => ReactElement
   style?: CSSProperties
   className?: string
   itemHeight?: number
   ScrollContainer?: TScrollContainer
+  HeaderContainer?: THeaderContainer
   FooterContainer?: TFooterContainer
   ListContainer?: TListContainer
 }
@@ -57,15 +68,28 @@ export { TScrollContainer, TListContainer }
 
 const DEFAULT_STYLE = {}
 export const VirtuosoPresentation: FC<TVirtuosoPresentationProps> = React.memo(
-  ({ contextValue, style, className, footer, itemHeight, ScrollContainer, ListContainer, FooterContainer }) => {
+  ({
+    contextValue,
+    style,
+    className,
+    header,
+    footer,
+    itemHeight,
+    ScrollContainer,
+    ListContainer,
+    HeaderContainer,
+    FooterContainer,
+  }) => {
     return (
       <VirtuosoContext.Provider value={contextValue}>
         <VirtuosoView
           style={style || DEFAULT_STYLE}
           className={className}
+          header={header}
           footer={footer}
           fixedItemHeight={itemHeight !== undefined}
           ScrollContainer={ScrollContainer}
+          HeaderContainer={HeaderContainer}
           FooterContainer={FooterContainer}
           ListContainer={ListContainer || DefaultListContainer}
         />
@@ -142,9 +166,11 @@ export const Virtuoso = forwardRef<VirtuosoMethods, VirtuosoProps>((props, ref) 
       contextValue={state}
       style={props.style}
       className={props.className}
+      header={props.header}
       footer={props.footer}
       itemHeight={props.itemHeight}
       ScrollContainer={props.ScrollContainer}
+      HeaderContainer={props.HeaderContainer}
       FooterContainer={props.FooterContainer}
       ListContainer={props.ListContainer}
     />

--- a/src/VirtuosoStore.tsx
+++ b/src/VirtuosoStore.tsx
@@ -49,6 +49,7 @@ const VirtuosoStore = ({
     itemHeights$,
     offsetList$,
     totalCount$,
+    headerHeight$,
     footerHeight$,
     totalHeight$,
     heightsChanged$,
@@ -86,6 +87,7 @@ const VirtuosoStore = ({
     scrollTop$,
     totalHeight$,
     topListHeight$,
+    headerHeight$,
     footerHeight$,
     minListIndex$,
     totalCount$,
@@ -200,6 +202,7 @@ const VirtuosoStore = ({
   return {
     groupCounts: makeInput(groupCounts$),
     itemHeights: makeInput(itemHeights$),
+    headerHeight: makeInput(headerHeight$),
     footerHeight: makeInput(footerHeight$),
     listHeight: makeInput(listHeight$),
     viewportHeight: makeInput(viewportHeight$),

--- a/src/VirtuosoView.tsx
+++ b/src/VirtuosoView.tsx
@@ -7,6 +7,10 @@ import { VirtuosoFiller } from './VirtuosoFiller'
 import { VirtuosoList } from './VirtuosoList'
 import { TScrollContainer, VirtuosoScroller } from './VirtuosoScroller'
 
+export const DefaultHeaderContainer: React.FC<{ headerRef: CallbackRef }> = ({ children, headerRef }) => (
+  <header ref={headerRef}>{children}</header>
+)
+
 export const DefaultFooterContainer: React.FC<{ footerRef: CallbackRef }> = ({ children, footerRef }) => (
   <footer ref={footerRef}>{children}</footer>
 )
@@ -24,9 +28,18 @@ export const DefaultListContainer: React.FC<{ listRef: CallbackRef; style: CSSPr
 }
 
 export type TListContainer = typeof DefaultListContainer
+export type THeaderContainer = typeof DefaultHeaderContainer
 export type TFooterContainer = typeof DefaultFooterContainer
 
 export { TScrollContainer }
+
+const VirtuosoHeader: FC<{ header: () => ReactElement; HeaderContainer?: THeaderContainer }> = ({
+  header,
+  HeaderContainer = DefaultHeaderContainer,
+}) => {
+  const headerCallbackRef = useHeight(useContext(VirtuosoContext)!.headerHeight)
+  return <HeaderContainer headerRef={headerCallbackRef}>{header()}</HeaderContainer>
+}
 
 const VirtuosoFooter: FC<{ footer: () => ReactElement; FooterContainer?: TFooterContainer }> = ({
   footer,
@@ -94,12 +107,24 @@ const ListWrapper: React.FC<{ fixedItemHeight: boolean; ListContainer: TListCont
 export const VirtuosoView: React.FC<{
   style: CSSProperties
   className?: string
+  header?: () => ReactElement
   footer?: () => ReactElement
   ScrollContainer?: TScrollContainer
   ListContainer: TListContainer
+  HeaderContainer?: THeaderContainer
   FooterContainer?: TFooterContainer
   fixedItemHeight: boolean
-}> = ({ style, footer, fixedItemHeight, ScrollContainer, ListContainer, FooterContainer, className }) => {
+}> = ({
+  style,
+  header,
+  footer,
+  fixedItemHeight,
+  ScrollContainer,
+  ListContainer,
+  HeaderContainer,
+  FooterContainer,
+  className,
+}) => {
   const { scrollTo, scrollTop, totalHeight, viewportHeight } = useContext(VirtuosoContext)!
   const fillerHeight = useOutput<number>(totalHeight, 0)
   const reportScrollTop = (st: number) => {
@@ -118,6 +143,7 @@ export const VirtuosoView: React.FC<{
     >
       <div ref={viewportCallbackRef} style={viewportStyle}>
         <ListWrapper fixedItemHeight={fixedItemHeight} ListContainer={ListContainer}>
+          {header && <VirtuosoHeader header={header} HeaderContainer={HeaderContainer} />}
           <VirtuosoList />
           {footer && <VirtuosoFooter footer={footer} FooterContainer={FooterContainer} />}
         </ListWrapper>

--- a/src/engines/listEngine.ts
+++ b/src/engines/listEngine.ts
@@ -10,6 +10,7 @@ interface ListEngineParams {
   viewportHeight$: TObservable<number>
   scrollTop$: TObservable<number>
   topListHeight$: TObservable<number>
+  headerHeight$: TObservable<number>
   footerHeight$: TObservable<number>
   minListIndex$: TObservable<number>
   totalCount$: TObservable<number>
@@ -25,6 +26,7 @@ export function listEngine({
   viewportHeight$,
   scrollTop$,
   topListHeight$,
+  headerHeight$,
   footerHeight$,
   minListIndex$,
   totalCount$,
@@ -50,6 +52,7 @@ export function listEngine({
     constrainedScrollTop$,
     topListHeight$,
     listHeight$,
+    headerHeight$,
     footerHeight$,
     minListIndex$,
     totalCount$,
@@ -66,6 +69,7 @@ export function listEngine({
             scrollTop,
             topListHeight,
             listHeight,
+            headerHeight,
             footerHeight,
             minIndex,
             totalCount,
@@ -82,7 +86,7 @@ export function listEngine({
 
           const listTop = getListTop(items)
 
-          const listBottom = listTop - scrollTop + listHeight - footerHeight - topListHeight
+          const listBottom = listTop - scrollTop + listHeight - headerHeight - footerHeight - topListHeight
           const maxIndex = Math.max(totalCount - 1, 0)
           const indexOutOfAllowedRange =
             itemLength > 0 && (items[0].index < minIndex || items[itemLength - 1].index > maxIndex)

--- a/src/engines/offsetListEngine.ts
+++ b/src/engines/offsetListEngine.ts
@@ -26,6 +26,7 @@ export function offsetListEngine({
   topList$,
   transposer$,
 }: OffsetListEngineParams) {
+  const headerHeight$ = subject(0)
   const footerHeight$ = subject(0)
   const totalCount$ = subject(totalCount)
   const itemHeights$ = subject<ItemHeight[]>()
@@ -49,8 +50,11 @@ export function offsetListEngine({
   const offsetList$ = subject(initialOffsetList)
   const { stickyItems$ } = stickyItemsEngine({ offsetList$, scrollTop$, topList$, transposer$ })
 
-  const totalHeight$ = combineLatest(offsetList$, totalCount$, footerHeight$).pipe(
-    map(([offsetList, totalCount, footerHeight]) => offsetList.total(totalCount - 1) + footerHeight)
+  const totalHeight$ = combineLatest(offsetList$, totalCount$, headerHeight$, footerHeight$).pipe(
+    map(
+      ([offsetList, totalCount, headerHeight, footerHeight]) =>
+        offsetList.total(totalCount - 1) + headerHeight + footerHeight
+    )
   )
 
   if (!itemHeight) {
@@ -85,6 +89,7 @@ export function offsetListEngine({
     totalCount$,
     offsetList$,
     totalHeight$,
+    headerHeight$,
     footerHeight$,
     initialItemCount$,
     itemHeights$,

--- a/test/VirtuosoStore.test.ts
+++ b/test/VirtuosoStore.test.ts
@@ -19,6 +19,18 @@ describe('Virtuoso Store', () => {
     itemHeights([{ start: 0, end: 0, size: 50 }])
   })
 
+  it('leaves space for the header', done => {
+    const { totalHeight, headerHeight, itemHeights } = VirtuosoStore({ overscan: 0, totalCount: 100 })
+
+    itemHeights([{ start: 0, end: 0, size: 50 }])
+    headerHeight(50)
+
+    totalHeight(val => {
+      expect(val).toBe(5050)
+      done()
+    })
+  })
+
   it('leaves space for the footer', done => {
     const { totalHeight, footerHeight, itemHeights } = VirtuosoStore({ overscan: 0, totalCount: 100 })
 


### PR DESCRIPTION
This PR adds a header prop to Virtuoso, GroupedVirtuoso to help show indicators during pagination when using the list from bottom to top.

I'm creating a chat list like slack. and using scrolling from bottom to top and the indicator should be at the top of the list.
I added the header in the same way as the footer.