### PR TITLE
Add `startReached` prop

### DIFF
--- a/src/GroupedVirtuoso.tsx
+++ b/src/GroupedVirtuoso.tsx
@@ -28,6 +28,7 @@ export const GroupedVirtuoso = forwardRef<GroupedVirtuosoMethods, GroupedVirtuos
   )
 
   useEffect(() => {
+    state.startReached(props.startReached)
     state.endReached(props.endReached)
     state.rangeChanged(props.rangeChanged)
     state.atBottomStateChange(props.atBottomStateChange)
@@ -48,6 +49,7 @@ export const GroupedVirtuoso = forwardRef<GroupedVirtuosoMethods, GroupedVirtuos
     }
   }, [
     state,
+    props.startReached,
     props.endReached,
     props.rangeChanged,
     props.atBottomStateChange,

--- a/src/Virtuoso.tsx
+++ b/src/Virtuoso.tsx
@@ -30,6 +30,7 @@ export interface VirtuosoProps {
   prependItemCount?: number
   itemHeight?: number
   defaultItemHeight?: number
+  startReached?: () => void
   endReached?: (index: number) => void
   scrollingStateChange?: TSubscriber<boolean>
   atBottomStateChange?: TSubscriber<boolean>
@@ -122,6 +123,7 @@ export const Virtuoso = forwardRef<VirtuosoMethods, VirtuosoProps>((props, ref) 
   useEffect(() => {
     state.isScrolling(props.scrollingStateChange)
     state.atBottomStateChange(props.atBottomStateChange)
+    state.startReached(props.startReached)
     state.endReached(props.endReached)
     state.topItemCount(props.topItems || 0)
     state.totalCount(props.totalCount)
@@ -145,6 +147,7 @@ export const Virtuoso = forwardRef<VirtuosoMethods, VirtuosoProps>((props, ref) 
     state,
     props.scrollingStateChange,
     props.atBottomStateChange,
+    props.startReached,
     props.endReached,
     props.topItems,
     props.totalCount,

--- a/src/VirtuosoStore.tsx
+++ b/src/VirtuosoStore.tsx
@@ -80,7 +80,7 @@ const VirtuosoStore = ({
     heightsChanged$,
   })
 
-  const { listHeight$, list$, listOffset$, endReached$ } = listEngine({
+  const { listHeight$, list$, listOffset$, startReached$, endReached$ } = listEngine({
     overscan,
     defaultItemHeight,
     viewportHeight$,
@@ -232,6 +232,7 @@ const VirtuosoStore = ({
     topList: makeOutput(topList$),
     listOffset: makeOutput(domListOffset$),
     totalHeight: makeOutput(domTotalHeight$),
+    startReached: makeOutput(startReached$),
     endReached: makeOutput(endReached$),
     atBottomStateChange: makeOutput(scrolledToBottom$),
     totalListHeightChanged: makeOutput(totalHeight$),

--- a/src/engines/listEngine.ts
+++ b/src/engines/listEngine.ts
@@ -36,6 +36,7 @@ export function listEngine({
   totalHeight$,
 }: ListEngineParams) {
   const listHeight$ = subject(0)
+  const startReached$ = coldSubject<number>()
   const endReached$ = coldSubject<number>()
   const list$ = subject<ListItem[]>([])
 
@@ -120,6 +121,12 @@ export function listEngine({
 
   const listOffset$ = combineLatest(list$, scrollTop$, topListHeight$).pipe(map(([items]) => getListTop(items)))
 
+  constrainedScrollTop$.subscribe(scrollTop => {
+    if (scrollTop === 0) {
+      startReached$.next(scrollTop)
+    }
+  })
+
   let currentEndIndex = 0
 
   list$
@@ -138,5 +145,5 @@ export function listEngine({
       }
     })
 
-  return { list$, listOffset$, listHeight$, endReached$ }
+  return { list$, listOffset$, listHeight$, startReached$, endReached$ }
 }


### PR DESCRIPTION
Thank you for merged header prop.

This PR adds a startReached prop to Virtuoso, GroupedVirtuoso to help bottom-up scrolling.
I was implementing it using ScrollContainer but I want to use it like endReached.