### PR TITLE
VirtuosoGrid | Offsets fix

### DIFF
--- a/playground/grid.tsx
+++ b/playground/grid.tsx
@@ -3,12 +3,12 @@ import { useRef, useEffect, useCallback, useState } from 'react'
 import * as ReactDOM from 'react-dom'
 
 import { VirtuosoGrid } from '../src/VirtuosoGrid'
-import { getUser } from '../../site/src/examples/FakeData'
-import { UserItem } from '../../site/src/examples/ExampleComponents'
+import { getUser } from './fakeData'
+// import { UserItem } from '../../site/src/examples/ExampleComponents'
 import './grid.css'
 
 const GenerateItem = (index: number) => {
-  return <UserItem user={getUser(index)} index={index} />
+  return <div style={{ height: 500 }}>{getUser(index).name}</div>
 }
 
 const App = () => {
@@ -47,13 +47,7 @@ const App = () => {
       <button onClick={() => setTotal(0)}>Set to Zero</button>
       <button onClick={() => setTotal(2)}>Set to 2</button>
       <button onClick={() => setTotal(1000)}>Restore</button>
-      <VirtuosoGrid
-        style={{ width: '100%', height: '500px' }}
-        overscan={200}
-        totalCount={total}
-        item={GenerateItem}
-        endReached={() => loadMore()}
-      />
+      <VirtuosoGrid style={{ width: '100%', height: '500px' }} overscan={200} totalCount={25} item={GenerateItem} />
     </div>
   )
 }

--- a/playground/grid.tsx
+++ b/playground/grid.tsx
@@ -40,14 +40,12 @@ const App = () => {
     loadMore()
   }, [])
 
-  console.log(total)
-
   return (
-    <div>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
       <button onClick={() => setTotal(0)}>Set to Zero</button>
       <button onClick={() => setTotal(2)}>Set to 2</button>
       <button onClick={() => setTotal(1000)}>Restore</button>
-      <VirtuosoGrid style={{ width: '100%', height: '500px' }} overscan={200} totalCount={25} item={GenerateItem} />
+      <VirtuosoGrid style={{ width: '100%', flex: 'auto' }} overscan={200} totalCount={75} item={GenerateItem} />
     </div>
   )
 }

--- a/src/VirtuosoGrid.tsx
+++ b/src/VirtuosoGrid.tsx
@@ -65,13 +65,12 @@ const VirtuosoGridFC: React.FC<VirtuosoGridFCProps> = ({
   style = { height: '100%' },
   computeItemKey = key => key,
 }) => {
-  const { listOffset, remainingHeight, gridDimensions, scrollTo, scrollTop, itemsRender } = engine
+  const { listOffsets, gridDimensions, scrollTo, scrollTop, itemsRender } = engine
 
-  const fillerHeight = useOutput<number>(remainingHeight, 0)
-  const translate = useOutput<number>(listOffset, 0)
-  const listStyle = { paddingTop: `${translate}px`, paddingBottom: `${fillerHeight}px` }
-
+  const { top, bottom } = useOutput(listOffsets, { top: 0, bottom: 0 })
   const render = useOutput(itemsRender, false)
+
+  const listStyle = { paddingTop: `${top}px`, paddingBottom: `${bottom}px` }
 
   const viewportCallbackRef = useSize(({ element, width, height }) => {
     const firstItem = element.firstChild!.firstChild as HTMLElement


### PR DESCRIPTION
* merge top and bottom padding values to one object-value at grid engine

Since listOffset$ and remainingHeight$ were updated separately, it caused two rerenders, which was making your scroll position have a "shaking" effect. With this commit, they are updating synchronously, and it fixes the "shaking" problem.
PS: you can check that shaking effect by changing the item height at playground/grid.tsx to 500px in the current master-branch.