### PR TITLE
fix scrolledToBottom calculation

### DIFF
--- a/playground/followBottom.html
+++ b/playground/followBottom.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta httpEquiv="X-UA-Compatible" content="ie=edge" />
+    <title>Issue 163</title>
+    <style>
+      html, body {
+        margin: 0;
+        height: 100%;
+      }
+
+      .App {
+        width: 100vw;
+        display: flex;
+        align-items: center;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script src="./followBottom.tsx"></script>
+  </body>
+</html>

--- a/playground/followBottom.tsx
+++ b/playground/followBottom.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+import { useState, createRef, useEffect, useRef } from 'react'
+import * as ReactDOM from 'react-dom'
+
+import { Virtuoso } from '../src'
+
+export default function App() {
+  const [total, setTotal] = useState(100)
+  const [appending, setAppending] = useState(true);
+  const appendInterval = useRef(null)
+
+  useEffect(() => {
+    if (!appending) return () => {};
+    function append() {
+      console.log('appending items')
+      setTotal(old => old + 1)
+    }
+    const interval = setInterval(append, 50)
+    return () => clearInterval(interval)
+  }, [appending])
+
+  return (
+    <div className="App">
+      <div>
+        <Virtuoso
+          totalCount={total}
+          item={index => <div>Item {index}</div>}
+          style={{ height: '100vh', width: '350px' }}
+          followOutput
+        />
+      </div>
+      <button onClick={() => setAppending(!appending)}>feed {appending ? "on" : "off"}</button>
+    </div>
+  )
+}
+
+ReactDOM.render(<App />, document.getElementById('root'))

--- a/src/engines/scrolledToBottomEngine.ts
+++ b/src/engines/scrolledToBottomEngine.ts
@@ -15,7 +15,7 @@ export function scrolledToBottomEngine({ totalHeight$, viewportHeight$, scrollTo
     .pipe(
       map(([scrollTop, viewportHeight, totalHeight]) => {
         if (viewportHeight === 0) return false
-        return scrollTop === totalHeight - viewportHeight || totalHeight <= viewportHeight
+        return totalHeight - viewportHeight - scrollTop <= 1 || totalHeight <= viewportHeight
       })
     )
     .subscribe(value => {


### PR DESCRIPTION
This fixes the `scrolledToBottom` calculation so that it also works when window is zoomed in/out. Zooming introduces rounding issues, which this PR fixes. This is related to https://github.com/petyosi/react-virtuoso/issues/184.

Note that the original issue can easily be reproduced by going to https://virtuoso.dev/stick-to-bottom/ and changing the zoom level of the browser. 

This is an alternative fix to https://github.com/petyosi/react-virtuoso/pull/185, which was causing this function to return `true` even when not scrolled to the bottom for me.

I also added the playground files I used to test this change locally. Let me know if they should be removed for this PR to be merged. You can verify locally what this PR does by simply removing the change in `scrolledToBottomEngine.ts`; this should break the behaviour in the playground example.

