### PR TITLE
Fix incorrect property name

### DIFF
--- a/site/docs/hello.md
+++ b/site/docs/hello.md
@@ -31,7 +31,7 @@ It is up to you to build and return the respective content for it.
 />
 ```
 
-## List with `itemCount`
+## List with `itemContent`
 
 ```jsx live
 () => {


### PR DESCRIPTION
Looks like the property name 'itemCount' was added mistakenly and the information in the doc actually refers to 'itemContent'.