### PR TITLE
fix: Window Scrolling

### DIFF
--- a/src/hooks/useScrollTop.ts
+++ b/src/hooks/useScrollTop.ts
@@ -16,7 +16,12 @@ export default function useScrollTop(
   const handler = useCallback(
     (ev: Event) => {
       const el = ev.target as HTMLElement
-      const scrollTop = (el as any) === window || (el as any) === document ? document.documentElement.scrollTop : el.scrollTop
+      const scrollTop =
+        (el as any) === window || (el as any) === document
+          ? window.scrollY ||
+            window.pageYOffset ||
+            document.body.scrollTop + ((document.documentElement && document.documentElement.scrollTop) || 0)
+          : el.scrollTop
       scrollTopCallback(Math.max(scrollTop, 0))
 
       if (scrollTopTarget.current !== null) {


### PR DESCRIPTION
Digging around to solve #295 I found that `document.documentElement.scrollTop` stayed 0 when I scrolled. So taking advice form [this][1] I included other alternatives to get the scroll value which seems to make it work! 

Fixes #295

[1]: https://stackoverflow.com/questions/20514596/document-documentelement-scrolltop-return-value-differs-in-chrome/33462363#33462363
