### PR TITLE
feat(): support custom TopItemListComponent

### DIFF
--- a/e2e/grid-optimize-rendering.tsx
+++ b/e2e/grid-optimize-rendering.tsx
@@ -35,10 +35,10 @@ const ItemWrapper = styled.div`
   }
 `
 
-const ListContainer: GridComponents['List'] = styled.div`
+const ListContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
-`
+` as GridComponents['List']
 
 const Item = React.memo<any>(({ item }: { item: { index: number; selected: boolean } }) => {
   console.log(`rendering Item ${item.index}`)

--- a/e2e/grid.tsx
+++ b/e2e/grid.tsx
@@ -35,10 +35,10 @@ const ItemWrapper = styled.div`
   }
 `
 
-const ListContainer: GridComponents['List'] = styled.div`
+const ListContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
-`
+` as GridComponents['List']
 
 export default function App() {
   const ref = React.createRef<VirtuosoGridHandle>()

--- a/e2e/window-grid.tsx
+++ b/e2e/window-grid.tsx
@@ -33,10 +33,10 @@ const ItemWrapper = styled.div`
   }
 `
 
-const ListContainer: GridComponents['List'] = styled.div`
+const ListContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
-`
+` as GridComponents['List']
 
 export default function App() {
   const ref = React.createRef<VirtuosoGridHandle>()

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -61,6 +61,7 @@ const listComponentPropsSystem = system(() => {
     scrollerRef,
     FooterComponent: distinctProp('Footer'),
     HeaderComponent: distinctProp('Header'),
+    TopItemListComponent: distinctProp('TopItemList'),
     ListComponent: distinctProp('List', 'div'),
     ItemComponent: distinctProp('Item', 'div'),
     GroupComponent: distinctProp('Group', 'div'),
@@ -370,9 +371,10 @@ const WindowViewport: FC = ({ children }) => {
 }
 
 const TopItemListContainer: FC = ({ children }) => {
+  const TopItemList = useEmitterValue('TopItemListComponent')
   const headerHeight = useEmitterValue('headerHeight')
-
-  return <div style={{ ...topItemListStyle, marginTop: `${headerHeight}px` }}>{children}</div>
+  const style = { ...topItemListStyle, marginTop: `${headerHeight}px` }
+  return createElement(TopItemList || 'div', { style }, children)
 }
 
 const ListRoot: FC<ListRootProps> = React.memo(function VirtuosoRoot(props) {

--- a/src/hooks/useSize.ts
+++ b/src/hooks/useSize.ts
@@ -5,7 +5,7 @@ export type CallbackRefParam = HTMLElement | null
 
 export function useSizeWithElRef(callback: (e: HTMLElement) => void, enabled = true) {
   const ref = useRef<CallbackRefParam>(null)
-  const observer = new ResizeObserver((entries) => {
+  const observer = new ResizeObserver((entries: ResizeObserverEntry[]) => {
     const element = entries[0].target as HTMLElement
     // Revert the RAF below - it causes a blink in the upward scrolling fix
     // See e2e/chat example

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -29,6 +29,8 @@ export interface GroupProps {
   'data-known-size': number
 }
 
+export type TopItemListProps = Pick<ComponentPropsWithRef<'div'>, 'style' | 'children'>
+
 /**
  * Passed to the Components.List custom component
  */
@@ -74,6 +76,12 @@ export interface Components {
    * Set to customize the group item wrapping element. Use only if you would like to render list from elements different than a `div`.
    */
   Group?: ComponentType<GroupProps>
+
+  /**
+   * Set to customize the top list item wrapping element. Use if you would like to render list from elements different than a `div`
+   * or you want to set a custom z-index for the sticky position.
+   */
+  TopItemList?: ComponentType<TopItemListProps>
 
   /**
    * Set to customize the outermost scrollable element. This should not be necessary in general,


### PR DESCRIPTION
This PR introduces a small new feature that allows the definition of a custom component for `TopItemListContainer`, this is useful to set a custom z-index or a different strategy for sticky position.

I had to do the following additional changes due to problems with setup:

Node: v12.18.3
NPM: 6.14.6
ProductName:    Mac OS X
ProductVersion: 10.15.7
BuildVersion:   19H2

#### 1)
I had to change this
```
const ListContainer: GridComponents['List'] = styled.div`
  display: flex;
  flex-wrap: wrap;
`
```
to 
```
const ListContainer = styled.div`
  display: flex;
  flex-wrap: wrap;
` as GridComponents['List']
```
because I was getting that `Types of property 'propTypes' are incompatible.` between `StyledComponent` and `GridProps`

#### 2)
I've also had to change this
```
 const observer = new ResizeObserver((entries) => {
    const element = entries[0].target as HTMLElement
```

to 

```
 const observer = new ResizeObserver((entries: ResizeObserverEntry[]) => {
    const element = entries[0].target as HTMLElement
```

explicitly assigning a type to `entries` as this was preventing me to do an initial `npm install`. As I was getting:
```
(rpt2 plugin) Error: src/hooks/useSize.ts(8,40): semantic error TS7006: Parameter 'entries' implicitly has an 'any' type.
```
