### PR TITLE
fix: from visible range calculation

### DIFF
--- a/e2e/header-footer.tsx
+++ b/e2e/header-footer.tsx
@@ -5,12 +5,11 @@ export default function App() {
   return (
     <Virtuoso
       totalCount={100}
-      topItemCount={1}
       components={{
-        Header: () => <div style={{ height: 150 }}>Header</div>,
+        Header: () => <div style={{ height: 250 }}>Header</div>,
         Footer: () => <div style={{ height: 60 }}>Footer</div>,
       }}
-      itemContent={(index) => <div style={{ height: 100, padding: '100px 0px', background: 'gray' }}>Item {index}</div>}
+      itemContent={(index) => <div style={{ height: 20, padding: '30px 0px', background: 'gray' }}>Item {index}</div>}
       style={{ height: 600 }}
       overscan={150}
     />

--- a/e2e/header-footer.tsx
+++ b/e2e/header-footer.tsx
@@ -5,11 +5,12 @@ export default function App() {
   return (
     <Virtuoso
       totalCount={100}
+      topItemCount={1}
       components={{
-        Header: () => <div style={{ height: 250 }}>Header</div>,
+        Header: () => <div style={{ height: 150 }}>Header</div>,
         Footer: () => <div style={{ height: 60 }}>Footer</div>,
       }}
-      itemContent={(index) => <div style={{ height: 20, padding: '30px 0px', background: 'gray' }}>Item {index}</div>}
+      itemContent={(index) => <div style={{ height: 100, padding: '100px 0px', background: 'gray' }}>Item {index}</div>}
       style={{ height: 600 }}
       overscan={150}
     />

--- a/src/sizeRangeSystem.ts
+++ b/src/sizeRangeSystem.ts
@@ -59,7 +59,7 @@ export const sizeRangeSystem = u.system(
 
           if (direction !== NONE) {
             return [
-              Math.max(top - headerVisible - getOverscan(overscan, TOP, direction), 0),
+              Math.max(top - headerHeight - getOverscan(overscan, TOP, direction), 0),
               top - headerVisible + viewportHeight + getOverscan(overscan, BOTTOM, direction),
             ] as NumberTuple
           }


### PR DESCRIPTION
I have missed an edge case in #417

When header height is greater than item height from visible range is wrongly calculated.