### PR TITLE
Fix type issue arising from React import

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardRefExoticComponent, ReactElement, Ref } from 'react'
+import { ForwardRefExoticComponent, ReactElement, Ref } from 'react'
 import { Grid, GridHandle } from './Grid'
 
 import {
@@ -14,7 +14,7 @@ import {
   ScrollSeekConfiguration,
 } from './interfaces'
 import { List, ListHandle } from './List'
-type CompProps<T> = T extends React.ForwardRefExoticComponent<infer R> ? R : never
+type CompProps<T> = T extends ForwardRefExoticComponent<infer R> ? R : never
 type ListProps = CompProps<typeof List>
 type GridProps = CompProps<typeof Grid>
 


### PR DESCRIPTION
Right now, the typings of this package can throw the following error when `allowSyntheticDefaultImports` is disabled. This can easily be avoided.

```
[error] TypeScript error node_modules/.pnpm/react-virtuoso@1.10.4_react@16.14.0/node_modules/react-virtuoso/dist/components.d.ts:1:8 - error TS1259: Module '"/home/.../node_modules/.pnpm/@types/react@16.14.11/node_modules/@types/react/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flag

import React, { ForwardRefExoticComponent, ReactElement, Ref } from 'react';
```

I believe you don't actually need to default import React here, correct?