### PR TITLE
perf(deps): don't include resize-observer-polyfill in bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ If you need to support reordering, [check the React Sortable HOC example](//virt
 
 For in-depth documentation and live examples of the supported features and live demos, check the [documentation website](//virtuoso.dev).
 
+## Browser support
+
+To support [legacy browsers](https://caniuse.com/resizeobserver), you might have to load a [ResizeObserver Polyfill](https://www.npmjs.com/package/resize-observer-polyfill) before using `react-virtuoso`:
+
+```
+import ResizeObserver from 'resize-observer-polyfill'
+
+if (!window.ResizeObserver)
+  window.ResizeObserver = ResizeObserver
+```
+
 ## Author
 
 Petyo Ivanov [@petyosi](//twitter.com/petyosi).

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
   },
   "dependencies": {
     "@virtuoso.dev/react-urx": "^0.2.5",
-    "@virtuoso.dev/urx": "^0.2.5",
-    "resize-observer-polyfill": "^1.5.1"
+    "@virtuoso.dev/urx": "^0.2.5"
   },
   "peerDependencies": {
     "react": ">=16"
@@ -91,6 +90,7 @@
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
     "react-test-renderer": "^16.13.1",
+    "resize-observer-polyfill": "^1.5.1",
     "semantic-release": "^17.3.0",
     "ts-jest": "^26.5.1",
     "tslib": "^2.0.0",

--- a/src/hooks/useSize.ts
+++ b/src/hooks/useSize.ts
@@ -1,5 +1,7 @@
 import { useRef } from 'react'
-import ResizeObserver from 'resize-observer-polyfill'
+
+// TypeScript 4.1 does not yet include typings for ResizeObserver (4.2 does)
+declare const ResizeObserver: typeof import('resize-observer-polyfill').default
 
 export type CallbackRefParam = HTMLElement | null
 

--- a/test/ssr.test.tsx
+++ b/test/ssr.test.tsx
@@ -5,11 +5,26 @@
 import ReactDOMServer from 'react-dom/server'
 import { JSDOM } from 'jsdom'
 import * as React from 'react'
+import ResizeObserver from 'resize-observer-polyfill'
 // import { create } from 'react-test-renderer' // ES6
 import { List } from '../src/List'
 import { Grid } from '../src/Grid'
 
+// TypeScript 4.1 does not yet include typings for ResizeObserver (4.2 does)
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace -- NodeJS.Global is typed using a namespace
+  namespace NodeJS {
+    interface Global {
+      ResizeObserver: typeof import('resize-observer-polyfill').default
+    }
+  }
+}
+
 describe('SSR List', () => {
+  beforeAll(() => {
+    global.ResizeObserver = ResizeObserver
+  })
+
   it('renders 30 items', () => {
     const html = ReactDOMServer.renderToString(<List id="root" totalCount={20000} initialItemCount={30} />)
     const { document } = new JSDOM(html).window


### PR DESCRIPTION
Fixes https://github.com/petyosi/react-virtuoso/issues/343.

This removes `resize-observer-polyfill` from the production dependencies and moves it to `devDependencies`. This is required because the tests still need the `resize-observer-polyfill`.

Since this is a **semver-major breaking change**, I also added a new section to the `README.md`.

Unfortunately, TypeScript 4.1 doesn't include the `ResizeObserver` typings, so I included two declarations for it that can be removed when updating the TypeScript version (I tried but gave up when the e2e tests did no longer compile because of `rootDir` issues).