### PR TITLE
fix: globalThis fallback

### DIFF
--- a/src/loggerSystem.ts
+++ b/src/loggerSystem.ts
@@ -5,6 +5,11 @@ declare namespace globalThis {
   let VIRTUOSO_LOG_LEVEL: LogLevel | undefined
 }
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
+declare namespace window {
+  let VIRTUOSO_LOG_LEVEL: LogLevel | undefined
+}
+
 export enum LogLevel {
   DEBUG,
   INFO,
@@ -26,11 +31,13 @@ const CONSOLE_METHOD_MAP = {
   [LogLevel.ERROR]: 'error',
 } as const
 
+const getGlobalThis = () => (typeof globalThis === 'undefined' ? window : globalThis)
+
 export const loggerSystem = u.system(
   () => {
     const logLevel = u.statefulStream<LogLevel>(LogLevel.ERROR)
     const log = u.statefulStream<Log>((label: string, message: any, level: LogLevel = LogLevel.INFO) => {
-      const currentLevel = (globalThis || window)['VIRTUOSO_LOG_LEVEL'] ?? u.getValue(logLevel)
+      const currentLevel = getGlobalThis()['VIRTUOSO_LOG_LEVEL'] ?? u.getValue(logLevel)
       if (level >= currentLevel) {
         console[CONSOLE_METHOD_MAP[level]]('%creact-virtuoso: %c%s %o', 'color: #0253b3; font-weight: bold', 'color: black', label, message)
       }


### PR DESCRIPTION
Hello!

Even after https://github.com/petyosi/react-virtuoso/commit/922a4681f9a34253eb1f61b6137e23fc4576db5d , I still had the same problem reported in https://github.com/petyosi/react-virtuoso/issues/473 in old browsers:
![image](https://user-images.githubusercontent.com/732422/142449787-76bc65c8-63d1-43b5-aaa1-be1df8479b82.png)

I was able to simulate locally by running `delete globalThis` in the console and going to a screen that uses `react-virtuoso`, then the application crashed, as reported by Sentry. This happens because the browser throws a `ReferenceError` if you try to evaluate a non-defined variable:
![image](https://user-images.githubusercontent.com/732422/142450063-eec56ccb-8f00-4f57-9fad-d736722d4299.png)

Therefore `globalThis || window` threw an error in older browsers.

I tried locally the same scenario with this fix I'm submitting and my application is not breaking anymore with it.