### PR TITLE
Clarify `data` does not work for VirtuosoGrid

### DIFF
--- a/site/docs/hello.md
+++ b/site/docs/hello.md
@@ -12,6 +12,8 @@ The `itemContent` render callback accepts `index`, and `item` parameter (if `dat
 which specifies the absolute index of the item rendered;
 It is up to you to build and return the respective content for it.
 
+**Note:** VirtuosoGrid does not support `data`.
+
 ## List with `data`
 
 ```jsx live include-data


### PR DESCRIPTION
[As stated in issue 523](https://github.com/petyosi/react-virtuoso/issues/523#issuecomment-992457927):

> data is not supported for the grid component.