### PR TITLE
fix: atBottomStateChange fires multiple times(#497)

### DIFF
--- a/src/stateFlagsSystem.ts
+++ b/src/stateFlagsSystem.ts
@@ -183,17 +183,12 @@ export const stateFlagsSystem = u.system(([{ scrollContainerState, scrollTop, vi
     isAtBottom
   )
 
+  // Just subscribe isAtBottom once, no need to subscribe multiple times here
   u.subscribe(isAtBottom, (value) => {
     setTimeout(() => u.publish(atBottomStateChange, value))
   })
 
   const scrollDirection = u.statefulStream<ScrollDirection>(DOWN)
-
-  u.subscribe(isAtBottom, (value) => {
-    setTimeout(() => {
-      u.publish(atBottomStateChange, value)
-    })
-  })
 
   u.connect(
     u.pipe(
@@ -218,8 +213,6 @@ export const stateFlagsSystem = u.system(([{ scrollContainerState, scrollTop, vi
   )
 
   u.connect(u.pipe(scrollContainerState, u.throttleTime(50), u.mapTo(NONE)), scrollDirection)
-
-  u.connect(isAtBottom, atBottomStateChange)
 
   const scrollVelocity = u.statefulStream(0)
 


### PR DESCRIPTION
Fix for [bug](https://github.com/petyosi/react-virtuoso/issues/497).

Avoid an initial false/true/false flick of atBottomStateChange.

Now it only fires once(with initial state false) on mount.

_Note: The main changes are lines 192~210_