### PR TITLE
fix: fix TableBody type

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -35,6 +35,11 @@ export type TopItemListProps = Pick<ComponentPropsWithRef<'div'>, 'style' | 'chi
 export type TableProps = Pick<ComponentPropsWithRef<'table'>, 'style'>
 
 /**
+ * Passed to the Components.TableBody custom component
+ */
+export type TableBodyProps = Pick<ComponentPropsWithRef<'tbody'>, 'style' | 'children' | 'ref' | 'className'> & { 'data-test-id': string }
+
+/**
  * Passed to the Components.List custom component
  */
 export type ListProps = Pick<ComponentPropsWithRef<'div'>, 'style' | 'children' | 'ref'> & { 'data-test-id': string }
@@ -152,7 +157,7 @@ export interface TableComponents<Context = unknown> {
   /**
    * Set to customize the items wrapper. Default is `tbody`.
    */
-  TableBody?: ComponentType<ListProps & { context?: Context }>
+  TableBody?: ComponentType<TableBodyProps & { context?: Context }>
 
   /**
    * Set to render a custom UI when the list is empty.


### PR DESCRIPTION
I get an type error when trying to run [MUI Table example](https://virtuoso.dev/mui-table-virtual-scroll/) as a TypeScript project.

<details>
<summary>error message</summary>

```
No overload matches this call.
  Overload 1 of 2, '(props: { component: ElementType<any>; } & { children?: ReactNode; classes?: Partial<TableBodyClasses> | undefined; sx?: SxProps<Theme> | undefined; } & CommonProps & Omit<...>): Element', gave the following error.
    Property 'component' is missing in type '{ ref: ForwardedRef<HTMLDivElement>; style?: CSSProperties | undefined; children?: ReactNode; 'data-test-id': string; context?: any; }' but required in type '{ component: ElementType<any>; }'.
  Overload 2 of 2, '(props: DefaultComponentProps<TableBodyTypeMap<{}, "tbody">>): Element', gave the following error.
    Type 'ForwardedRef<HTMLDivElement>' is not assignable to type '((instance: HTMLTableSectionElement | null) => void) | RefObject<HTMLTableSectionElement> | null | undefined'.
      Type 'MutableRefObject<HTMLDivElement | null>' is not assignable to type '((instance: HTMLTableSectionElement | null) => void) | RefObject<HTMLTableSectionElement> | null | undefined'.
        Type 'MutableRefObject<HTMLDivElement | null>' is not assignable to type 'RefObject<HTMLTableSectionElement>'.
          Types of property 'current' are incompatible.
            Type 'HTMLDivElement | null' is not assignable to type 'HTMLTableSectionElement | null'.
              Type 'HTMLDivElement' is missing the following properties from type 'HTMLTableSectionElement': ch, chOff, rows, vAlign, and 2 more.ts(2769)
```

</details>

Please see [codesandbox](https://codesandbox.io/s/quizzical-noyce-3fxuws?file=/src/App.tsx)