### PR TITLE
refactor: prefer constant for Item.style

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -167,6 +167,7 @@ const combinedSystem = system(([listSystem, propsSystem]) => {
 const DefaultScrollSeekPlaceholder = ({ height }: { height: number }) => <div style={{ height }}></div>
 
 const GROUP_STYLE = { position: positionStickyCssValue(), zIndex: 1, overflowAnchor: 'none' }
+const ITEM_STYLE = { overflowAnchor: 'none' }
 
 export const Items = React.memo(function VirtuosoItems({ showTopList = false }: { showTopList?: boolean }) {
   const listState = useEmitterValue('listState')
@@ -264,7 +265,7 @@ export const Items = React.memo(function VirtuosoItems({ showTopList = false }: 
             'data-known-size': item.size,
             'data-item-index': item.index,
             'data-item-group-index': item.groupIndex,
-            style: { overflowAnchor: 'none' },
+            style: ITEM_STYLE,
           } as any,
           hasGroups
             ? (itemContent as GroupItemContent<any, any>)(item.index, item.groupIndex!, item.data, context)

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -18,14 +18,14 @@ export interface GroupContent {
   (index: number): ReactNode
 }
 
-export interface ItemProps {
+export type ItemProps = Pick<ComponentPropsWithRef<'div'>, 'style' | 'children'> & {
   'data-index': number
   'data-item-index': number
   'data-item-group-index'?: number
   'data-known-size': number
 }
 
-export interface GroupProps {
+export type GroupProps = Pick<ComponentPropsWithRef<'div'>, 'style' | 'children'> & {
   'data-index': number
   'data-item-index': number
   'data-known-size': number


### PR DESCRIPTION
Fixes #635 

Also improved the typing of ItemProps and GroupProps to reflect that they are getting these additional props sent to them (children and style).