### PR TITLE
Add initialItemCount property to VirtuosoGrid component

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -473,6 +473,12 @@ export interface VirtuosoGridProps<C extends unknown = unknown> extends GridRoot
    */
   totalCount: number
 
+   /**
+   * Use for server-side rendering - if set, the list will render the specified amount of items
+   * regardless of the container / item size.
+   */
+    initialItemCount?: number
+    
   /**
    * Set the callback to specify the contents of the item.
    */


### PR DESCRIPTION
Hello, I was going to create an issue but this should solve it.

---

**Reproduction**
I was using the `initialItemCount` property to SSR some elements, works fine but TS can't find the property on a VirtuosoGrid component!
https://codesandbox.io/s/sandpack-project-forked-67ks79?file=/App.tsx

**To Reproduce**
Steps to reproduce the behavior:
1. Go to https://codesandbox.io/s/sandpack-project-forked-67ks79?file=/App.tsx
2. Scroll down to line 38
4. See error `Property 'initialItemCount' does not exist on type 'IntrinsicAttributes & VirtuosoGridProps<any> & { ref?: Ref<VirtuosoGridHandle>; }'`

**Expected behavior**
The property works but TS does not recognize it

---

I could not test the docs locally but from what I saw in the Readme, and the code, they are created from this file .
Let me know If I'm missing something 👍