### PR TITLE
Fix TS definition for itemSize prop

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -121,7 +121,7 @@ export interface VirtuosoProps<D, C> extends ListRootProps {
    *
    * The default implementation reads `el.getBoundingClientRect().height` and `el.getBoundingClientRect().width`.
    */
-  itemSize?: (el: HTMLElement, field: 'offsetHeight' | 'offsetWidth') => number
+  itemSize?: (el: HTMLElement, dimension: 'height' | 'width') => number
 
   /**
    * Can be used to improve performance if the rendered items are of known size.


### PR DESCRIPTION
The itemSize TypeScript definition seems wrong. It wants offsetHeight/offsetWidth instead of height/width

Related: #687 