### PR TITLE
docs: `atTopThreshold` and `atBottomThreshold` accepts pixel values

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -233,11 +233,15 @@ export interface VirtuosoProps<D, C> extends ListRootProps {
   scrollerRef?: (ref: HTMLElement | Window | null) => any
 
   /**
+   * *The property accepts pixel values.*
+   *
    * By default `0`. Redefine to change how much away from the top the scroller can be before the list is not considered not at top.
    */
   atTopThreshold?: number
 
   /**
+   * *The property accepts pixel values.*
+   *
    * By default `4`. Redefine to change how much away from the bottom the scroller can be before the list is not considered not at bottom.
    */
   atBottomThreshold?: number


### PR DESCRIPTION
From what I understand from the list behaviour, the attributes accept pixel values. I had initially confused it with the number of items/elements from the top. It would have saved me a lot of time if I knew it was pixels instead.