### PR TITLE
fix(itemSize): fix itemSize callback parameter value not as expected

### DIFF
--- a/src/hooks/useChangedChildSizes.ts
+++ b/src/hooks/useChangedChildSizes.ts
@@ -12,7 +12,7 @@ export default function useChangedListContentsSizes(
   customScrollParent?: HTMLElement
 ) {
   return useSizeWithElRef((el: HTMLElement) => {
-    const ranges = getChangedChildSizes(el.children, itemSize, 'offsetHeight', log)
+    const ranges = getChangedChildSizes(el.children, itemSize, 'height', log)
     let scrollableElement = el.parentElement!
 
     while (!scrollableElement.dataset['virtuosoScroller']) {
@@ -54,7 +54,7 @@ export default function useChangedListContentsSizes(
   }, enabled)
 }
 
-function getChangedChildSizes(children: HTMLCollection, itemSize: SizeFunction, field: 'offsetHeight' | 'offsetWidth', log: Log) {
+function getChangedChildSizes(children: HTMLCollection, itemSize: SizeFunction, field: 'height' | 'width', log: Log) {
   const length = children.length
 
   if (length === 0) {

--- a/src/sizeSystem.ts
+++ b/src/sizeSystem.ts
@@ -268,13 +268,8 @@ export function hasGroups(sizes: SizeState) {
 
 type OptionalNumber = number | undefined
 
-const SIZE_MAP = {
-  offsetHeight: 'height',
-  offsetWidth: 'width',
-} as const
-
 /** Calculates the height of `el`, which will be the `Item` element in the DOM. */
-export type SizeFunction = (el: HTMLElement, field: 'offsetHeight' | 'offsetWidth') => number
+export type SizeFunction = (el: HTMLElement, field: 'height' | 'width') => number
 
 export const sizeSystem = u.system(
   ([{ log }, { recalcInProgress }]) => {
@@ -287,7 +282,7 @@ export const sizeSystem = u.system(
     const groupIndices = u.statefulStream([] as number[])
     const fixedItemSize = u.statefulStream<OptionalNumber>(undefined)
     const defaultItemSize = u.statefulStream<OptionalNumber>(undefined)
-    const itemSize = u.statefulStream<SizeFunction>((el, field) => correctItemSize(el, SIZE_MAP[field]))
+    const itemSize = u.statefulStream<SizeFunction>((el, field) => correctItemSize(el, field))
     const data = u.statefulStream<Data>(undefined)
     const gap = u.statefulStream(0)
     const initial = initialSizeState()


### PR DESCRIPTION
```tsx
<Virtuoso
  itemSize={(el: HTMLElement, dimension: 'height' | 'width') => {
    // Should output `height` , but `offsetHeight`
    console.log(dimension);
  }}
/>;
```

Related:  https://github.com/petyosi/react-virtuoso/pull/688