### PR TITLE
feat: support `align` property on `scrollIntoView`

### DIFF
--- a/examples/scroll-into-view-align.tsx
+++ b/examples/scroll-into-view-align.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react'
+import { Virtuoso, VirtuosoHandle } from '../src'
+
+export default function App() {
+  const ref = React.useRef<VirtuosoHandle>(null)
+
+  return (
+    <>
+      <Virtuoso
+        ref={ref}
+        totalCount={100}
+        itemContent={(index) => (
+          <div style={{ height: index % 2 ? 30 : 20, background: 'white', color: index === 50 ? 'red' : 'black' }}>Item {index}</div>
+        )}
+        style={{ height: 300 }}
+      />
+      <div>
+        <button id="start" onClick={() => ref.current!.scrollIntoView({ index: 50, align: 'start' })}>
+          Item 50 Start
+        </button>
+        <button id="offset-30" onClick={() => ref.current!.scrollIntoView({ index: 50, align: 'center' })}>
+          Item 50 Center
+        </button>
+        <button id="center-50" onClick={() => ref.current!.scrollIntoView({ index: 50, align: 'end' })}>
+          Item 50 End
+        </button>
+      </div>
+    </>
+  )
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -307,6 +307,7 @@ export interface WindowViewportInfo {
 }
 
 export interface ScrollIntoViewLocationOptions {
+  align?: 'start' | 'center' | 'end'
   behavior?: 'auto' | 'smooth'
   done?: () => void
 }

--- a/src/scrollIntoViewSystem.ts
+++ b/src/scrollIntoViewSystem.ts
@@ -16,18 +16,18 @@ export const scrollIntoViewSystem = u.system(
         scrollIntoView,
         u.withLatestFrom(sizes, viewportHeight, totalCount, headerHeight, scrollTop, gap),
         u.map(([viewLocation, sizes, viewportHeight, totalCount, headerHeight, scrollTop, gap]) => {
-          const { done, behavior, ...rest } = viewLocation
+          const { done, behavior, align, ...rest } = viewLocation
           let location = null
           const actualIndex = originalIndexFromLocation(viewLocation, sizes, totalCount - 1)
 
           const itemTop = offsetOf(actualIndex, sizes.offsetTree, gap) + headerHeight
           if (itemTop < scrollTop) {
-            location = { ...rest, behavior, align: 'start' }
+            location = { ...rest, behavior, align: align ?? 'start' }
           } else {
             const itemBottom = itemTop + findMaxKeyValue(sizes.sizeTree, actualIndex)[1]!
 
             if (itemBottom > scrollTop + viewportHeight) {
-              location = { ...rest, behavior, align: 'end' }
+              location = { ...rest, behavior, align: align ?? 'end' }
             }
           }
 


### PR DESCRIPTION
In my use case I want to render a list of files, where the current file should be centered only it if wasn't visible in the tree when it was selected. This didn't seem possible with the existing `scrollIntoView` API (which always scrolled the item to the bottom/top), so I added an `align` property similar to the one used for the `scrollToIndex` function.