### PR TITLE
fix: fix value type and add optional chaining (IE11)

### DIFF
--- a/src/hooks/useChangedChildSizes.ts
+++ b/src/hooks/useChangedChildSizes.ts
@@ -93,12 +93,12 @@ function getChangedChildSizes(children: HTMLCollection, itemSize: SizeFunction, 
   return results
 }
 
-function resolveGapValue(property: string, value: string, log: Log) {
-  if (value !== 'normal' && !value.endsWith('px')) {
+function resolveGapValue(property: string, value: string | undefined, log: Log) {
+  if (value !== 'normal' && !value?.endsWith('px')) {
     log(`${property} was not resolved to pixel value correctly`, value, LogLevel.WARN)
   }
   if (value === 'normal') {
     return 0
   }
-  return parseInt(value, 10)
+  return parseInt(value ?? '0', 10)
 }


### PR DESCRIPTION
Fix issue https://github.com/petyosi/react-virtuoso/issues/710 for IE11