### PR TITLE
fix: allow children on custom Table component

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -32,7 +32,7 @@ export type GroupProps = Pick<ComponentPropsWithRef<'div'>, 'style' | 'children'
 }
 
 export type TopItemListProps = Pick<ComponentPropsWithRef<'div'>, 'style' | 'children'>
-export type TableProps = Pick<ComponentPropsWithRef<'table'>, 'style'>
+export type TableProps = Pick<ComponentPropsWithRef<'table'>, 'style' | 'children'>
 
 /**
  * Passed to the Components.TableBody custom component


### PR DESCRIPTION
We have customized the Table component in the following way, where we need to add additional children after the virtualized rows:

```
    Table: ({ context, ...rest }) => {
        const Footer = propComponents?.Footer ?? TableLoadingFooter;
        const totalWidth = context?.columns
          ? getTotalTableMinWidth(context.columns, context?.selectedRows !== undefined)
          : undefined;
        return (
          <table className={styles.table} {...rest} style={{ minWidth: totalWidth, ...rest.style }}>
            {rest.children}
            {loadMoreData !== undefined && <Footer context={context} />}
          </table>
        );
      },
```

Currently, children is not in the props, which causes issues with React 18 and TypeScript. Seems like children is already picked to most other customizable components, so it seems fine to add it to TableProps as well.