### PR TITLE
feat: add VirtuosoMockContext for mocking state

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@emotion/styled": "^10.0.27",
     "@microsoft/api-extractor": "^7.25.0",
     "@playwright/test": "^1.22.2",
+    "@testing-library/react": "^13.4.0",
     "@types/faker": "^5.1.4",
     "@types/jest": "^26.0.20",
     "@types/jsdom": "^16.2.3",

--- a/site/docs/mocking-in-tests.md
+++ b/site/docs/mocking-in-tests.md
@@ -1,0 +1,35 @@
+---
+id: mocking-in-tests
+title: Mocking in tests
+sidebar_label: Mocking in tests
+slug: /mocking-in-tests/
+---
+
+Virtuoso exposes a `VirtuosoMockContext` context API, which can be used to mock DOM measurements in tests, so list items or table rows would be rendered and could be tested with snapshots or other assertions.
+
+It allows specifying `viewportHeight` and `itemHeight`.
+
+```jsx
+import { render } from '@testing-library/react'
+import * as React from 'react'
+import { Virtuoso, VirtuosoMockContext } from 'react-virtuoso'
+
+describe('Virtuoso', () => {
+  type Item = { id: string, value: string }
+  const data: Item[] = [
+    { id: '1', value: 'foo' },
+    { id: '2', value: 'bar' },
+    { id: '3', value: 'baz' },
+  ]
+
+  it('correctly renders items', async () => {
+    const { container } = render(<Virtuoso data={data} />, {
+      wrapper: ({ children }) => (
+        <VirtuosoMockContext.Provider value={{ viewportHeight: 300, itemHeight: 100 }}>{children}</VirtuosoMockContext.Provider>
+      ),
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+})
+```

--- a/site/docs/mocking-in-tests.md
+++ b/site/docs/mocking-in-tests.md
@@ -22,7 +22,7 @@ describe('Virtuoso', () => {
     { id: '3', value: 'baz' },
   ]
 
-  it('correctly renders items', async () => {
+  it('correctly renders items', () => {
     const { container } = render(<Virtuoso data={data} />, {
       wrapper: ({ children }) => (
         <VirtuosoMockContext.Provider value={{ viewportHeight: 300, itemHeight: 100 }}>{children}</VirtuosoMockContext.Provider>

--- a/site/docs/mocking-in-tests.md
+++ b/site/docs/mocking-in-tests.md
@@ -5,7 +5,9 @@ sidebar_label: Mocking in tests
 slug: /mocking-in-tests/
 ---
 
-Virtuoso exposes a `VirtuosoMockContext` context API, which can be used to mock DOM measurements in tests, so list items or table rows would be rendered and could be tested with snapshots or other assertions.
+If you try to use Virtuoso in a testing environment, you're likely going to discover that it does not render any items. This is due to rendering being controlled by measuring the height of its DOM elements (the list container and the items themselves). 
+This information is not available in the simulated JSDOM environment.
+To work around this, Virtuoso exposes a `VirtuosoMockContext` context API, which can be used to mock DOM measurements in tests, so list items or table rows would be rendered and could be tested with snapshots or other assertions.
 
 It allows specifying `viewportHeight` and `itemHeight`.
 

--- a/site/sidebars.js
+++ b/site/sidebars.js
@@ -26,6 +26,7 @@ module.exports = {
       'window-scrolling',
       'keyboard-navigation',
       'react-beautiful-dnd-window-scroller',
+      'mocking-in-tests',
     ],
     'Customize Markup': ['custom-scroll-container', 'customize-structure'],
     'API Reference': ['virtuoso-api-reference', 'virtuoso-grid-api-reference', 'table-virtuoso-api-reference'],

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -11,6 +11,7 @@ import { listSystem } from './listSystem'
 import { positionStickyCssValue } from './utils/positionStickyCssValue'
 import useWindowViewportRectRef from './hooks/useWindowViewportRect'
 import { correctItemSize } from './utils/correctItemSize'
+import { VirtuosoContext } from './utils/context'
 import { ScrollerProps } from '.'
 
 export function identity<T>(value: T) {
@@ -153,7 +154,8 @@ const GROUP_STYLE = { position: positionStickyCssValue(), zIndex: 1, overflowAnc
 const ITEM_STYLE = { overflowAnchor: 'none' } as const
 
 export const Items = React.memo(function VirtuosoItems({ showTopList = false }: { showTopList?: boolean }) {
-  const listState = useEmitterValue('listState')
+  const ctx = React.useContext(VirtuosoContext)
+  const computedListState = useEmitterValue('listState')
 
   const sizeRanges = usePublisher('sizeRanges')
   const useWindowScroll = useEmitterValue('useWindowScroll')
@@ -169,6 +171,13 @@ export const Items = React.memo(function VirtuosoItems({ showTopList = false }: 
   const itemSize = useEmitterValue('itemSize')
   const log = useEmitterValue('log')
   const listGap = usePublisher('gap')
+
+  const listState = ctx
+    ? {
+        ...computedListState,
+        ...ctx.listState,
+      }
+    : computedListState
 
   const { callbackRef } = useChangedListContentsSizes(
     sizeRanges,

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -416,9 +416,18 @@ const Viewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
 }
 
 const WindowViewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
+  const ctx = useContext(VirtuosoMockContext)
   const windowViewportRect = usePublisher('windowViewportRect')
+  const fixedItemHeight = usePublisher('fixedItemHeight')
   const customScrollParent = useEmitterValue('customScrollParent')
   const viewportRef = useWindowViewportRectRef(windowViewportRect, customScrollParent)
+
+  React.useEffect(() => {
+    if (ctx) {
+      fixedItemHeight(ctx.itemHeight)
+      windowViewportRect({ offsetTop: 0, visibleHeight: ctx.viewportHeight, visibleWidth: 100 })
+    }
+  }, [ctx, windowViewportRect, fixedItemHeight])
 
   return (
     <div ref={viewportRef} style={viewportStyle} data-viewport-type="window">

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -1,7 +1,7 @@
 import { systemToComponent } from '@virtuoso.dev/react-urx'
 import * as u from '@virtuoso.dev/urx'
 import * as React from 'react'
-import { createElement, FC, PropsWithChildren } from 'react'
+import { createElement, FC, PropsWithChildren, useContext } from 'react'
 import useChangedListContentsSizes from './hooks/useChangedChildSizes'
 import { ComputeItemKey, ItemContent, FixedHeaderContent, TableComponents, TableRootProps } from './interfaces'
 import { listSystem } from './listSystem'
@@ -9,6 +9,7 @@ import { identity, buildScroller, buildWindowScroller, viewportStyle, contextPro
 import useSize from './hooks/useSize'
 import { correctItemSize } from './utils/correctItemSize'
 import useWindowViewportRectRef from './hooks/useWindowViewportRect'
+import { VirtuosoMockContext } from './utils/context'
 
 const tableComponentPropsSystem = u.system(() => {
   const itemContent = u.statefulStream<ItemContent<any, unknown>>((index: number) => <td>Item ${index}</td>)
@@ -161,8 +162,17 @@ export interface Hooks {
 }
 
 const Viewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
+  const ctx = useContext(VirtuosoMockContext)
   const viewportHeight = usePublisher('viewportHeight')
+  const fixedItemHeight = usePublisher('fixedItemHeight')
   const viewportRef = useSize(u.compose(viewportHeight, (el) => correctItemSize(el, 'height')))
+
+  React.useEffect(() => {
+    if (ctx) {
+      viewportHeight(ctx.viewportHeight)
+      fixedItemHeight(ctx.itemHeight)
+    }
+  }, [ctx, viewportHeight, fixedItemHeight])
 
   return (
     <div style={viewportStyle} ref={viewportRef} data-viewport-type="element">

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -182,9 +182,18 @@ const Viewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
 }
 
 const WindowViewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
+  const ctx = useContext(VirtuosoMockContext)
   const windowViewportRect = usePublisher('windowViewportRect')
+  const fixedItemHeight = usePublisher('fixedItemHeight')
   const customScrollParent = useEmitterValue('customScrollParent')
   const viewportRef = useWindowViewportRectRef(windowViewportRect, customScrollParent)
+
+  React.useEffect(() => {
+    if (ctx) {
+      fixedItemHeight(ctx.itemHeight)
+      windowViewportRect({ offsetTop: 0, visibleHeight: ctx.viewportHeight, visibleWidth: 100 })
+    }
+  }, [ctx, windowViewportRect, fixedItemHeight])
 
   return (
     <div ref={viewportRef} style={viewportStyle} data-viewport-type="window">

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
 export * from './components'
 export * from './interfaces'
 export { LogLevel } from './loggerSystem'
-export { VirtuosoMockContext } from './utils/context'
+export * from './utils/context'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
 export * from './components'
 export * from './interfaces'
 export { LogLevel } from './loggerSystem'
+export { VirtuosoContext } from './utils/context'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
 export * from './components'
 export * from './interfaces'
 export { LogLevel } from './loggerSystem'
-export { VirtuosoContext } from './utils/context'
+export { VirtuosoMockContext } from './utils/context'

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,4 +1,8 @@
 import * as React from 'react'
-import { ListState } from '../listStateSystem'
 
-export const VirtuosoContext = React.createContext<{ listState: Partial<ListState> } | undefined>(undefined)
+interface Context {
+  viewportHeight: number
+  itemHeight: number
+}
+
+export const VirtuosoMockContext = React.createContext<Context | undefined>(undefined)

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,0 +1,4 @@
+import * as React from 'react'
+import { ListState } from '../listStateSystem'
+
+export const VirtuosoContext = React.createContext<{ listState: Partial<ListState> } | undefined>(undefined)

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,8 +1,8 @@
 import * as React from 'react'
 
-interface Context {
+export interface VirtuosoMockContextValue {
   viewportHeight: number
   itemHeight: number
 }
 
-export const VirtuosoMockContext = React.createContext<Context | undefined>(undefined)
+export const VirtuosoMockContext = React.createContext<VirtuosoMockContextValue | undefined>(undefined)

--- a/test/VirtuosoMockContext.test.tsx
+++ b/test/VirtuosoMockContext.test.tsx
@@ -1,0 +1,57 @@
+import { render } from '@testing-library/react'
+import * as React from 'react'
+import { Virtuoso, VirtuosoMockContext, TableVirtuoso } from '../src'
+
+describe('VirtuosoMockContext', () => {
+  type Item = { id: string; value: string }
+  const data: Item[] = [
+    { id: '1', value: 'foo' },
+    { id: '2', value: 'bar' },
+    { id: '3', value: 'baz' },
+    { id: '4', value: 'ban' },
+  ]
+
+  describe('List', () => {
+    it('correctly renders items', () => {
+      const { container } = render(<Virtuoso data={data} />, {
+        wrapper: ({ children }) => (
+          <VirtuosoMockContext.Provider value={{ viewportHeight: 300, itemHeight: 100 }}>{children}</VirtuosoMockContext.Provider>
+        ),
+      })
+
+      expect(container).toMatchSnapshot()
+    })
+
+    it('correctly renders items with useWindowScroll', () => {
+      const { container } = render(<Virtuoso data={data} useWindowScroll />, {
+        wrapper: ({ children }) => (
+          <VirtuosoMockContext.Provider value={{ viewportHeight: 300, itemHeight: 100 }}>{children}</VirtuosoMockContext.Provider>
+        ),
+      })
+
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  describe('Table', () => {
+    it('correctly renders items', () => {
+      const { container } = render(<TableVirtuoso data={data} />, {
+        wrapper: ({ children }) => (
+          <VirtuosoMockContext.Provider value={{ viewportHeight: 300, itemHeight: 100 }}>{children}</VirtuosoMockContext.Provider>
+        ),
+      })
+
+      expect(container).toMatchSnapshot()
+    })
+
+    it('correctly renders items with useWindowScroll', () => {
+      const { container } = render(<TableVirtuoso data={data} useWindowScroll />, {
+        wrapper: ({ children }) => (
+          <VirtuosoMockContext.Provider value={{ viewportHeight: 300, itemHeight: 100 }}>{children}</VirtuosoMockContext.Provider>
+        ),
+      })
+
+      expect(container).toMatchSnapshot()
+    })
+  })
+})

--- a/test/__snapshots__/VirtuosoMockContext.test.tsx.snap
+++ b/test/__snapshots__/VirtuosoMockContext.test.tsx.snap
@@ -1,0 +1,203 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VirtuosoMockContext List correctly renders items 1`] = `
+<div>
+  <div
+    data-test-id="virtuoso-scroller"
+    data-virtuoso-scroller="true"
+    style="height: 100%; outline: none; overflow-y: auto; position: relative;"
+    tabindex="0"
+  >
+    <div
+      data-viewport-type="element"
+      style="width: 100%; height: 100%; position: absolute; top: 0px;"
+    >
+      <div
+        data-test-id="virtuoso-item-list"
+        style="box-sizing: border-box; padding-top: 0px; padding-bottom: 100px; margin-top: 0px;"
+      >
+        <div
+          data-index="0"
+          data-item-index="0"
+          data-known-size="100"
+        >
+          Item 0
+        </div>
+        <div
+          data-index="1"
+          data-item-index="1"
+          data-known-size="100"
+        >
+          Item 1
+        </div>
+        <div
+          data-index="2"
+          data-item-index="2"
+          data-known-size="100"
+        >
+          Item 2
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`VirtuosoMockContext List correctly renders items with useWindowScroll 1`] = `
+<div>
+  <div
+    data-virtuoso-scroller="true"
+    style="position: relative; height: 400px;"
+  >
+    <div
+      data-viewport-type="window"
+      style="width: 100%; height: 100%; position: absolute; top: 0px;"
+    >
+      <div
+        data-test-id="virtuoso-item-list"
+        style="box-sizing: border-box; padding-top: 0px; padding-bottom: 100px; margin-top: 0px;"
+      >
+        <div
+          data-index="0"
+          data-item-index="0"
+          data-known-size="100"
+        >
+          Item 0
+        </div>
+        <div
+          data-index="1"
+          data-item-index="1"
+          data-known-size="100"
+        >
+          Item 1
+        </div>
+        <div
+          data-index="2"
+          data-item-index="2"
+          data-known-size="100"
+        >
+          Item 2
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`VirtuosoMockContext Table correctly renders items 1`] = `
+<div>
+  <div
+    data-test-id="virtuoso-scroller"
+    data-virtuoso-scroller="true"
+    style="height: 100%; outline: none; overflow-y: auto; position: relative;"
+    tabindex="0"
+  >
+    <div
+      data-viewport-type="element"
+      style="width: 100%; height: 100%; position: absolute; top: 0px;"
+    >
+      <table
+        style="border-spacing: 0;"
+      >
+        <tbody
+          data-test-id="virtuoso-item-list"
+        >
+          <tr
+            data-index="0"
+            data-item-index="0"
+            data-known-size="100"
+          >
+            <td>
+              Item $
+              0
+            </td>
+          </tr>
+          <tr
+            data-index="1"
+            data-item-index="1"
+            data-known-size="100"
+          >
+            <td>
+              Item $
+              1
+            </td>
+          </tr>
+          <tr
+            data-index="2"
+            data-item-index="2"
+            data-known-size="100"
+          >
+            <td>
+              Item $
+              2
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="height: 100px; padding: 0px; border: 0px;"
+            />
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`VirtuosoMockContext Table correctly renders items with useWindowScroll 1`] = `
+<div>
+  <div
+    data-virtuoso-scroller="true"
+    style="position: relative; height: 400px;"
+  >
+    <div
+      data-viewport-type="window"
+      style="width: 100%; height: 100%; position: absolute; top: 0px;"
+    >
+      <table
+        style="border-spacing: 0;"
+      >
+        <tbody
+          data-test-id="virtuoso-item-list"
+        >
+          <tr
+            data-index="0"
+            data-item-index="0"
+            data-known-size="100"
+          >
+            <td>
+              Item $
+              0
+            </td>
+          </tr>
+          <tr
+            data-index="1"
+            data-item-index="1"
+            data-known-size="100"
+          >
+            <td>
+              Item $
+              1
+            </td>
+          </tr>
+          <tr
+            data-index="2"
+            data-item-index="2"
+            data-known-size="100"
+          >
+            <td>
+              Item $
+              2
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="height: 100px; padding: 0px; border: 0px;"
+            />
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2065,6 +2065,29 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@testing-library/dom@^8.5.0":
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.17.1.tgz#2d7af4ff6dad8d837630fecd08835aee08320ad7"
+  integrity sha512-KnH2MnJUzmFNPW6RIKfd+zf2Wue8mEKX0M3cpX6aKl5ZXrJM1/c/Pc8c2xDNYQCnJO48Sm5ITbMXgqTr3h4jxQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
+"@testing-library/react@^13.4.0":
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.4.0.tgz#6a31e3bf5951615593ad984e96b9e5e2d9380966"
+  integrity sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^8.5.0"
+    "@types/react-dom" "^18.0.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -2079,6 +2102,11 @@
   version "1.0.38"
   resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.38.tgz#a81fd8606d481f873a3800c6ebae4f1d768a56a9"
   integrity sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
+  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.18"
@@ -2274,6 +2302,13 @@
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/@types/react-beautiful-dnd/-/react-beautiful-dnd-13.1.2.tgz#510405abb09f493afdfd898bf83995dc6385c130"
   integrity sha512-+OvPkB8CdE/bGdXKyIhc/Lm2U7UAYCCJgsqmopFmh9gbAudmslkI8eOrPDjg4JhwSE6wytz4a3/wRjKtovHVJg==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-dom@^18.0.0":
+  version "18.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
+  integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
   dependencies:
     "@types/react" "*"
 
@@ -2633,6 +2668,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0, ansi-styles@^4.3.0:
   dependencies:
     color-convert "^2.0.1"
 
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
 ansi-to-html@^0.6.4:
   version "0.6.15"
   resolved "https://registry.yarnpkg.com/ansi-to-html/-/ansi-to-html-0.6.15.tgz#ac6ad4798a00f6aa045535d7f6a9cb9294eebea7"
@@ -2716,6 +2756,11 @@ aria-query@^4.2.2:
   dependencies:
     "@babel/runtime" "^7.10.2"
     "@babel/runtime-corejs3" "^7.10.2"
+
+aria-query@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.2.tgz#0b8a744295271861e1d933f8feca13f9b70cfdc1"
+  integrity sha512-eigU3vhqSO+Z8BKDnVLN/ompjhf3pYzecKXz8+whRy+9gZu8n1TCGfwzQUUPnqdHl9ax1Hr9031orZ+UOEYr7Q==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -4544,6 +4589,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
+  integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
 
 dom-serializer@0:
   version "0.2.2"
@@ -7742,6 +7792,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
+
 magic-string@^0.22.4:
   version "0.22.5"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.5.tgz#8e9cf5afddf44385c1da5bc2a6a0dbd10b03657e"
@@ -9958,6 +10013,15 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     "@jest/types" "^26.6.2"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
 proc-log@^1.0.0:


### PR DESCRIPTION
Initial idea on how this could be implemented.

To use it, one would then have to mock the listState object in tests:

```tsx
<VirtuosoContext.Provider
  value={{
    listState: {
      items: data.map((i, idx) => ({
        data: i,
        index: idx,
        offset: 0,
        size: 0,
        originalIndex: idx,
      })),
    },
  }}
>
  <Virtuoso data={data} />
</VirtuosoContext.Provider>
```

However, this is not quite developer-friendly:
- it expects that you always have the mock data available in tests. In reality, the data can come from elsewhere, e.g. some mocked query result or something like that.
- having to map the data to pass forward all the different internal variables is quite cumbersome.

Ideally, I would only want to tell the context provider how many items I want to render (n or "all"). But the data is not currently available in `Items`, and not sure how to provide it there.