### PR TITLE
feat: add fixed footer content to TableVirtuoso

### DIFF
--- a/examples/react-table-flexlayout.tsx
+++ b/examples/react-table-flexlayout.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react'
-import {
-  Column, TableBodyProps,
-  useFlexLayout,
-  useTable,
-} from 'react-table'
+import { Column, TableBodyProps, useFlexLayout, useTable } from 'react-table'
 import { FillerRowProps, TableVirtuoso } from '../src/'
 import { ItemProps, ScrollSeekPlaceholderProps } from '../dist'
 
@@ -28,103 +24,94 @@ const generateData = (length: number, startIndex = 0) => {
 }
 
 export default function App() {
-
   const [data, columns] = React.useMemo(() => {
-    const columns: readonly Column<{ id: number; content: string; }>[] = [
-        {
-          Header: 'Id',
-          accessor: 'id'
-        },
-        {
-          Header: 'Table item',
-          accessor: 'content'
-        }
-      ];
-    return [generateData(500), columns];
+    const columns: readonly Column<{ id: number; content: string }>[] = [
+      {
+        Header: 'Id',
+        accessor: 'id',
+      },
+      {
+        Header: 'Table item',
+        accessor: 'content',
+        Footer: 'Footer element',
+      },
+    ]
+    return [generateData(500), columns]
+  }, [])
 
-  }, []);
-
-  const {
-    getTableBodyProps,
-    getTableProps,
-    prepareRow,
-    headerGroups,
-    rows,
-  } = useTable({
-    data,
-    columns
-  }, useFlexLayout);
+  const { getTableBodyProps, getTableProps, prepareRow, headerGroups, footerGroups, rows } = useTable(
+    {
+      data,
+      columns,
+    },
+    useFlexLayout
+  )
 
   const TableRow = (props: ItemProps): React.ReactElement => {
-    const index: number = props["data-index"];
-    const row = rows[index];
-    return (
-      <div
-        {...props}
-        {...row.getRowProps()}
-      />
-    );
-  };
-  const TableBody = React.forwardRef<HTMLTableSectionElement, TableBodyProps>(
-    (props, ref) => <div {...getTableBodyProps()} {...props} ref={ref} />
-  );
-  TableBody.displayName = "TableBody";
+    const index: number = props['data-index']
+    const row = rows[index]
+    return <div {...props} {...row.getRowProps()} />
+  }
+  const TableBody = React.forwardRef<HTMLTableSectionElement, TableBodyProps>((props, ref) => (
+    <div {...getTableBodyProps()} {...props} ref={ref} />
+  ))
+  TableBody.displayName = 'TableBody'
 
-  const TableHead = React.forwardRef<HTMLTableSectionElement>((props, ref) => (
-    <div {...props} ref={ref} />
-  )) as any; // typings from lib component not working properly
-  TableHead.displayName = "TableHead";
+  const TableHead = React.forwardRef<HTMLTableSectionElement>((props, ref) => <div {...props} ref={ref} />) as any // typings from lib component not working properly
+  TableHead.displayName = 'TableHead'
+
+  const TableFoot = React.forwardRef<HTMLTableSectionElement>((props, ref) => <div {...props} ref={ref} />)
+  TableFoot.displayName = 'TableFoot'
 
   const TableItem = React.useCallback(
     (index: number, style: object) => {
-      const row = rows[index];
-      prepareRow(row);
-      return row.cells.map(cell => (
-        <div
-          {...cell.getCellProps({ style })}
-          key={cell.getCellProps().key}
-        >
-          {cell.render("Cell")}
+      const row = rows[index]
+      prepareRow(row)
+      return row.cells.map((cell) => (
+        <div {...cell.getCellProps({ style })} key={cell.getCellProps().key}>
+          {cell.render('Cell')}
         </div>
-      ));
+      ))
     },
     [rows]
-  );
+  )
 
   return (
     <>
       <TableVirtuoso
         totalCount={500}
         components={{
-          Table: ({ style, ...props }) => (
-            <div {...getTableProps({ style })} {...props} />
-          ),
+          Table: ({ style, ...props }) => <div {...getTableProps({ style })} {...props} />,
           TableHead,
+          TableFoot,
           TableBody,
           TableRow,
           ScrollSeekPlaceholder: ({ height }: ScrollSeekPlaceholderProps) => <div style={{ height, padding: 0, border: 0 }} />,
-          FillerRow: ({ height}: FillerRowProps) => <div style={{height}} />,
+          FillerRow: ({ height }: FillerRowProps) => <div style={{ height }} />,
           EmptyPlaceholder: () => <div>Empty</div>,
         }}
         style={{ height: 700 }}
         fixedHeaderContent={() => {
-          return (
-            headerGroups.map(headerGroup => (
-              <div
-                {...headerGroup.getHeaderGroupProps()}
-                key={headerGroup.getHeaderGroupProps().key}
-              >
-                {headerGroup.headers.map(column => (
-                  <div
-                    {...column.getHeaderProps()}
-                    key={column.getHeaderProps().key}
-                  >
-                    {column.render("Header")}
-                  </div>
-                ))}
-              </div>
-            ))
-          )
+          return headerGroups.map((headerGroup) => (
+            <div {...headerGroup.getHeaderGroupProps()} key={headerGroup.getHeaderGroupProps().key}>
+              {headerGroup.headers.map((column) => (
+                <div {...column.getHeaderProps()} key={column.getHeaderProps().key}>
+                  {column.render('Header')}
+                </div>
+              ))}
+            </div>
+          ))
+        }}
+        fixedFooterContent={() => {
+          return footerGroups.map((footerGroup) => (
+            <div {...footerGroup.getFooterGroupProps()} key={footerGroup.getFooterGroupProps().key}>
+              {footerGroup.headers.map((column) => (
+                <div {...column.getFooterProps()} key={column.getFooterProps().key}>
+                  {column.render('Footer')}
+                </div>
+              ))}
+            </div>
+          ))
         }}
         itemContent={TableItem}
       />

--- a/examples/table-markup.tsx
+++ b/examples/table-markup.tsx
@@ -32,6 +32,18 @@ export default function App() {
             </tr>
           )
         }}
+        fixedFooterContent={() => {
+          return (
+            <tr style={{ background: 'white' }}>
+              <th key={1} style={{ height: 150, border: '1px solid black', background: 'white' }}>
+                Footer TH 1
+              </th>
+              <th key={2} style={{ height: 150, border: '1px solid black', background: 'white' }}>
+                Footer TH meh
+              </th>
+            </tr>
+          )
+        }}
         itemContent={(index) => {
           return (
             <>

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -22,6 +22,7 @@ import {
   FlatIndexLocationWithAlign,
   FlatScrollIntoViewLocation,
   SizeFunction,
+  FixedFooterContent,
 } from './interfaces'
 import { List } from './List'
 import { Grid } from './Grid'
@@ -280,6 +281,11 @@ export interface TableVirtuosoProps<D, C> extends Omit<VirtuosoProps<D, C>, 'com
    * Set the contents of the table header.
    */
   fixedHeaderContent?: FixedHeaderContent
+
+  /**
+   * Set the contents of the table footer.
+   */
+  fixedFooterContent?: FixedFooterContent
 
   /**
    * The total amount of items to be rendered.

--- a/src/domIOSystem.ts
+++ b/src/domIOSystem.ts
@@ -12,6 +12,7 @@ export const domIOSystem = u.system(
     const scrollHeight = u.stream<number>()
     const headerHeight = u.statefulStream(0)
     const fixedHeaderHeight = u.statefulStream(0)
+    const fixedFooterHeight = u.statefulStream(0)
     const footerHeight = u.statefulStream(0)
     const scrollTo = u.stream<ScrollToOptions>()
     const scrollBy = u.stream<ScrollToOptions>()
@@ -44,6 +45,7 @@ export const domIOSystem = u.system(
       viewportHeight,
       headerHeight,
       fixedHeaderHeight,
+      fixedFooterHeight,
       footerHeight,
       scrollHeight,
       smoothScrollTargetReached,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { ComponentPropsWithRef, ComponentType, Key, ReactNode } from 'react'
+import React, { ComponentPropsWithRef, ComponentType, Key, ReactNode } from 'react'
 export interface ListRange {
   startIndex: number
   endIndex: number
@@ -10,6 +10,7 @@ export interface ItemContent<D, C> {
 
 export type FixedHeaderContent = (() => React.ReactNode) | null
 
+export type FixedFooterContent = (() => React.ReactNode) | null
 export interface GroupItemContent<D, C> {
   (index: number, groupIndex: number, data: D, context: C): ReactNode
 }
@@ -148,6 +149,11 @@ export interface TableComponents<Context = unknown> {
    *
    */
   TableHead?: ComponentType<Pick<ComponentPropsWithRef<'thead'>, 'style' | 'ref'> & { context?: Context }>
+
+  /**
+   * Set to render a fixed footer at the bottom of the table (`tfoot`). use [[fixedFooterContent]] to set the contents
+   */
+  TableFoot?: ComponentType<Pick<ComponentPropsWithRef<'tfoot'>, 'style' | 'ref'> & { context?: Context }>
 
   /**
    * Set to customize the item wrapping element. Default is `tr`.

--- a/src/scrollToIndexSystem.ts
+++ b/src/scrollToIndexSystem.ts
@@ -29,7 +29,16 @@ export function normalizeIndexLocation(location: IndexLocation) {
 export const scrollToIndexSystem = u.system(
   ([
     { sizes, totalCount, listRefresh, gap },
-    { scrollingInProgress, viewportHeight, scrollTo, smoothScrollTargetReached, headerHeight, footerHeight, fixedHeaderHeight },
+    {
+      scrollingInProgress,
+      viewportHeight,
+      scrollTo,
+      smoothScrollTargetReached,
+      headerHeight,
+      footerHeight,
+      fixedHeaderHeight,
+      fixedFooterHeight,
+    },
     { log },
   ]) => {
     const scrollToIndex = u.stream<IndexLocation>()
@@ -61,65 +70,72 @@ export const scrollToIndexSystem = u.system(
       u.pipe(
         scrollToIndex,
         u.withLatestFrom(sizes, viewportHeight, totalCount, topListHeight, headerHeight, footerHeight, log),
-        u.withLatestFrom(gap, fixedHeaderHeight),
-        u.map(([[location, sizes, viewportHeight, totalCount, topListHeight, headerHeight, footerHeight, log], gap, fixedHeaderHeight]) => {
-          const normalLocation = normalizeIndexLocation(location)
-          const { align, behavior, offset } = normalLocation
-          const lastIndex = totalCount - 1
+        u.withLatestFrom(gap, fixedHeaderHeight, fixedFooterHeight),
+        u.map(
+          ([
+            [location, sizes, viewportHeight, totalCount, topListHeight, headerHeight, footerHeight, log],
+            gap,
+            fixedHeaderHeight,
+            fixedFooterHeight,
+          ]) => {
+            const normalLocation = normalizeIndexLocation(location)
+            const { align, behavior, offset } = normalLocation
+            const lastIndex = totalCount - 1
 
-          const index = originalIndexFromLocation(normalLocation, sizes, lastIndex)
+            const index = originalIndexFromLocation(normalLocation, sizes, lastIndex)
 
-          let top = offsetOf(index, sizes.offsetTree, gap) + headerHeight
-          if (align === 'end') {
-            top += fixedHeaderHeight + findMaxKeyValue(sizes.sizeTree, index)[1]! - viewportHeight
-            if (index === lastIndex) {
-              top += footerHeight
-            }
-          } else if (align === 'center') {
-            top += (fixedHeaderHeight + findMaxKeyValue(sizes.sizeTree, index)[1]! - viewportHeight) / 2
-          } else {
-            top -= topListHeight
-          }
-
-          if (offset) {
-            top += offset
-          }
-
-          const retry = (listChanged: boolean) => {
-            cleanup()
-            if (listChanged) {
-              log('retrying to scroll to', { location }, LogLevel.DEBUG)
-              u.publish(scrollToIndex, location)
+            let top = offsetOf(index, sizes.offsetTree, gap) + headerHeight
+            if (align === 'end') {
+              top += fixedHeaderHeight + findMaxKeyValue(sizes.sizeTree, index)[1]! - viewportHeight + fixedFooterHeight
+              if (index === lastIndex) {
+                top += footerHeight
+              }
+            } else if (align === 'center') {
+              top += (fixedHeaderHeight + findMaxKeyValue(sizes.sizeTree, index)[1]! - viewportHeight + fixedFooterHeight) / 2
             } else {
-              log('list did not change, scroll successful', {}, LogLevel.DEBUG)
+              top -= topListHeight
             }
-          }
 
-          cleanup()
+            if (offset) {
+              top += offset
+            }
 
-          if (behavior === 'smooth') {
-            let listChanged = false
-            unsubscribeListRefresh = u.subscribe(listRefresh, (changed) => {
-              listChanged = listChanged || changed
-            })
+            const retry = (listChanged: boolean) => {
+              cleanup()
+              if (listChanged) {
+                log('retrying to scroll to', { location }, LogLevel.DEBUG)
+                u.publish(scrollToIndex, location)
+              } else {
+                log('list did not change, scroll successful', {}, LogLevel.DEBUG)
+              }
+            }
 
-            unsubscribeNextListRefresh = u.handleNext(smoothScrollTargetReached, () => {
-              retry(listChanged)
-            })
-          } else {
-            unsubscribeNextListRefresh = u.handleNext(u.pipe(listRefresh, watchChangesFor(150)), retry)
-          }
-
-          // if the scroll jump is too small, the list won't get rerendered.
-          // clean this listener
-          cleartTimeoutRef = setTimeout(() => {
             cleanup()
-          }, 1200)
 
-          u.publish(scrollingInProgress, true)
-          log('scrolling from index to', { index, top, behavior }, LogLevel.DEBUG)
-          return { top, behavior }
-        })
+            if (behavior === 'smooth') {
+              let listChanged = false
+              unsubscribeListRefresh = u.subscribe(listRefresh, (changed) => {
+                listChanged = listChanged || changed
+              })
+
+              unsubscribeNextListRefresh = u.handleNext(smoothScrollTargetReached, () => {
+                retry(listChanged)
+              })
+            } else {
+              unsubscribeNextListRefresh = u.handleNext(u.pipe(listRefresh, watchChangesFor(150)), retry)
+            }
+
+            // if the scroll jump is too small, the list won't get rerendered.
+            // clean this listener
+            cleartTimeoutRef = setTimeout(() => {
+              cleanup()
+            }, 1200)
+
+            u.publish(scrollingInProgress, true)
+            log('scrolling from index to', { index, top, behavior }, LogLevel.DEBUG)
+            return { top, behavior }
+          }
+        )
       ),
       scrollTo
     )

--- a/src/totalListHeightSystem.ts
+++ b/src/totalListHeightSystem.ts
@@ -3,13 +3,13 @@ import { listStateSystem } from './listStateSystem'
 import { domIOSystem } from './domIOSystem'
 
 export const totalListHeightSystem = u.system(
-  ([{ footerHeight, headerHeight, fixedHeaderHeight }, { listState }]) => {
+  ([{ footerHeight, headerHeight, fixedHeaderHeight, fixedFooterHeight }, { listState }]) => {
     const totalListHeightChanged = u.stream<number>()
     const totalListHeight = u.statefulStreamFromEmitter(
       u.pipe(
-        u.combineLatest(footerHeight, headerHeight, fixedHeaderHeight, listState),
-        u.map(([footerHeight, headerHeight, fixedHeaderHeight, listState]) => {
-          return footerHeight + headerHeight + fixedHeaderHeight + listState.offsetBottom + listState.bottom
+        u.combineLatest(footerHeight, fixedFooterHeight, headerHeight, fixedHeaderHeight, listState),
+        u.map(([footerHeight, fixedFooterHeight, headerHeight, fixedHeaderHeight, listState]) => {
+          return footerHeight + fixedFooterHeight + headerHeight + fixedHeaderHeight + listState.offsetBottom + listState.bottom
         })
       ),
       0


### PR DESCRIPTION
Closes #570 

This PR adds the `fixedFooterContent` prop to the `TableVirtuoso`. It works almost identically to `fixedHeaderContent`, except it renders a `tfoot` instead of a `thead`.

I wasn't exactly sure if there were tests I needed to add. I mostly mimicked what I saw being done with `fixedHeaderContent`. I'm pretty new to the urx framework, so forgive me if I made mistakes.