### PR TITLE
feat: mock context for grid

### DIFF
--- a/site/docs/mocking-in-tests.md
+++ b/site/docs/mocking-in-tests.md
@@ -5,7 +5,7 @@ sidebar_label: Mocking in tests
 slug: /mocking-in-tests/
 ---
 
-If you try to use Virtuoso in a testing environment, you're likely going to discover that it does not render any items. This is due to rendering being controlled by measuring the height of its DOM elements (the list container and the items themselves). 
+If you try to use Virtuoso in a testing environment, you're likely going to discover that it does not render any items. This is due to rendering being controlled by measuring the height of its DOM elements (the list container and the items themselves).
 This information is not available in the simulated JSDOM environment.
 To work around this, Virtuoso exposes a `VirtuosoMockContext` context API, which can be used to mock DOM measurements in tests, so list items or table rows would be rendered and could be tested with snapshots or other assertions.
 
@@ -28,6 +28,35 @@ describe('Virtuoso', () => {
     const { container } = render(<Virtuoso data={data} />, {
       wrapper: ({ children }) => (
         <VirtuosoMockContext.Provider value={{ viewportHeight: 300, itemHeight: 100 }}>{children}</VirtuosoMockContext.Provider>
+      ),
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+})
+```
+
+To mock VirtuosoGrid rendering, use `VirtuosoGridMockContext` instead, which accepts additional `viewportWidth` and `itemWidth` props.
+
+```jsx
+import { render } from '@testing-library/react'
+import * as React from 'react'
+import { VirtuosoGrid, VirtuosoGridMockContext } from 'react-virtuoso'
+
+describe('Virtuoso', () => {
+  type Item = { id: string, value: string }
+  const data: Item[] = [
+    { id: '1', value: 'foo' },
+    { id: '2', value: 'bar' },
+    { id: '3', value: 'baz' },
+  ]
+
+  it('correctly renders items', () => {
+    const { container } = render(<VirtuosoGrid data={data} />, {
+      wrapper: ({ children }) => (
+        <VirtuosoGridMockContext.Provider value={{ viewportHeight: 300, viewportWidth: 300, itemHeight: 100, itemWidth: 100 }}>
+          {children}
+        </VirtuosoGridMockContext.Provider>
       ),
     })
 

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -6,3 +6,12 @@ export interface VirtuosoMockContextValue {
 }
 
 export const VirtuosoMockContext = React.createContext<VirtuosoMockContextValue | undefined>(undefined)
+
+export interface VirtuosoGridMockContextValue {
+  viewportHeight: number
+  viewportWidth: number
+  itemHeight: number
+  itemWidth: number
+}
+
+export const VirtuosoGridMockContext = React.createContext<VirtuosoGridMockContextValue | undefined>(undefined)

--- a/test/VirtuosoMockContext.test.tsx
+++ b/test/VirtuosoMockContext.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react'
 import * as React from 'react'
-import { Virtuoso, VirtuosoMockContext, TableVirtuoso } from '../src'
+import { Virtuoso, VirtuosoMockContext, TableVirtuoso, VirtuosoGrid, VirtuosoGridMockContext } from '../src'
 
 describe('VirtuosoMockContext', () => {
   type Item = { id: string; value: string }
@@ -9,6 +9,10 @@ describe('VirtuosoMockContext', () => {
     { id: '2', value: 'bar' },
     { id: '3', value: 'baz' },
     { id: '4', value: 'ban' },
+    { id: '5', value: 'bam' },
+    { id: '6', value: 'baw' },
+    { id: '7', value: 'bae' },
+    { id: '8', value: 'bat' },
   ]
 
   describe('List', () => {
@@ -48,6 +52,32 @@ describe('VirtuosoMockContext', () => {
       const { container } = render(<TableVirtuoso data={data} useWindowScroll />, {
         wrapper: ({ children }) => (
           <VirtuosoMockContext.Provider value={{ viewportHeight: 300, itemHeight: 100 }}>{children}</VirtuosoMockContext.Provider>
+        ),
+      })
+
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  describe('Grid', () => {
+    it('correctly renders items', () => {
+      const { container } = render(<VirtuosoGrid data={data} />, {
+        wrapper: ({ children }) => (
+          <VirtuosoGridMockContext.Provider value={{ viewportHeight: 200, viewportWidth: 300, itemHeight: 100, itemWidth: 100 }}>
+            {children}
+          </VirtuosoGridMockContext.Provider>
+        ),
+      })
+
+      expect(container).toMatchSnapshot()
+    })
+
+    it('correctly renders items with useWindowScroll', () => {
+      const { container } = render(<VirtuosoGrid data={data} useWindowScroll />, {
+        wrapper: ({ children }) => (
+          <VirtuosoGridMockContext.Provider value={{ viewportHeight: 200, viewportWidth: 300, itemHeight: 100, itemWidth: 100 }}>
+            {children}
+          </VirtuosoGridMockContext.Provider>
         ),
       })
 

--- a/test/__snapshots__/VirtuosoMockContext.test.tsx.snap
+++ b/test/__snapshots__/VirtuosoMockContext.test.tsx.snap
@@ -1,5 +1,117 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`VirtuosoMockContext Grid correctly renders items 1`] = `
+<div>
+  <div
+    data-test-id="virtuoso-scroller"
+    data-virtuoso-scroller="true"
+    style="height: 100%; outline: none; overflow-y: auto; position: relative;"
+    tabindex="0"
+  >
+    <div
+      style="width: 100%; height: 100%; position: absolute; top: 0px;"
+    >
+      <div
+        class="virtuoso-grid-list"
+        style="padding-top: 0px; padding-bottom: 100px;"
+      >
+        <div
+          class="virtuoso-grid-item"
+          data-index="0"
+        >
+          Item 0
+        </div>
+        <div
+          class="virtuoso-grid-item"
+          data-index="1"
+        >
+          Item 1
+        </div>
+        <div
+          class="virtuoso-grid-item"
+          data-index="2"
+        >
+          Item 2
+        </div>
+        <div
+          class="virtuoso-grid-item"
+          data-index="3"
+        >
+          Item 3
+        </div>
+        <div
+          class="virtuoso-grid-item"
+          data-index="4"
+        >
+          Item 4
+        </div>
+        <div
+          class="virtuoso-grid-item"
+          data-index="5"
+        >
+          Item 5
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`VirtuosoMockContext Grid correctly renders items with useWindowScroll 1`] = `
+<div>
+  <div
+    data-virtuoso-scroller="true"
+    style="position: relative; height: 300px;"
+  >
+    <div
+      style="width: 100%; height: 100%; position: absolute; top: 0px;"
+    >
+      <div
+        class="virtuoso-grid-list"
+        style="padding-top: 0px; padding-bottom: 100px;"
+      >
+        <div
+          class="virtuoso-grid-item"
+          data-index="0"
+        >
+          Item 0
+        </div>
+        <div
+          class="virtuoso-grid-item"
+          data-index="1"
+        >
+          Item 1
+        </div>
+        <div
+          class="virtuoso-grid-item"
+          data-index="2"
+        >
+          Item 2
+        </div>
+        <div
+          class="virtuoso-grid-item"
+          data-index="3"
+        >
+          Item 3
+        </div>
+        <div
+          class="virtuoso-grid-item"
+          data-index="4"
+        >
+          Item 4
+        </div>
+        <div
+          class="virtuoso-grid-item"
+          data-index="5"
+        >
+          Item 5
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`VirtuosoMockContext List correctly renders items 1`] = `
 <div>
   <div


### PR DESCRIPTION
~~Note: this is stacked on top of #766, will rebase once that one gets merged, but you can look at the latest commit in this branch for all the mocking related changes. Could not figure out how to stack PRs from a fork properly~~ 🙃

This adds a separate mock context for VirtuosoGrid, as it needs more data than List/Table.