### PR TITLE
feat: add Header and Footer to VirtuosoGrid

### DIFF
--- a/examples/grid-header-footer.tsx
+++ b/examples/grid-header-footer.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react'
+import { GridComponents, VirtuosoGrid } from '../src'
+import styled from '@emotion/styled'
+
+const ItemContainer = styled.div`
+  box-sizing: border-box;
+  padding: 5px;
+  width: 25%;
+  background: #f5f5f5;
+  display: flex;
+  flex: none;
+  align-content: stretch;
+  /*
+  @media (max-width: 1024px) {
+    width: 33%;
+  }
+
+  @media (max-width: 768px) {
+    width: 50%;
+  }
+
+  @media (max-width: 480px) {
+    width: 100%;
+  }
+  */
+`
+
+const ItemWrapper = styled.div`
+    flex: 1;
+    text-align: center;
+    height: 30px;
+    padding: 20px;
+    background: white;
+  }
+`
+
+const ListContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+` as GridComponents['List']
+
+export default function App() {
+  return (
+    <VirtuosoGrid
+      totalCount={100}
+      components={{
+        Header: () => <div style={{ height: 150 }}>Header</div>,
+        Footer: () => <div style={{ height: 60 }}>Footer</div>,
+        Item: ItemContainer,
+        List: ListContainer,
+        ScrollSeekPlaceholder: () => (
+          <ItemContainer>
+            <ItemWrapper>Placeholder</ItemWrapper>
+          </ItemContainer>
+        ),
+      }}
+      itemContent={(index) => <ItemWrapper>Item {index}</ItemWrapper>}
+      style={{ height: 600 }}
+      overscan={150}
+    />
+  )
+}

--- a/src/Grid.tsx
+++ b/src/Grid.tsx
@@ -9,6 +9,7 @@ import useWindowViewportRectRef from './hooks/useWindowViewportRect'
 import { GridComponents, GridComputeItemKey, GridItemContent, GridRootProps } from './interfaces'
 import { addDeprecatedAlias, buildScroller, buildWindowScroller, contextPropIfNotDomElement, identity, viewportStyle } from './List'
 import { Log, LogLevel } from './loggerSystem'
+import { correctItemSize } from './utils/correctItemSize'
 
 const gridComponentPropsSystem = u.system(() => {
   const itemContent = u.statefulStream<GridItemContent<any, any>>((index) => `Item ${index}`)
@@ -17,6 +18,7 @@ const gridComponentPropsSystem = u.system(() => {
   const itemClassName = u.statefulStream('virtuoso-grid-item')
   const listClassName = u.statefulStream('virtuoso-grid-list')
   const computeItemKey = u.statefulStream<GridComputeItemKey<any, any>>(identity)
+  const headerFooterTag = u.statefulStream('div')
   const scrollerRef = u.statefulStream<(ref: HTMLElement | null) => void>(u.noop)
 
   const distinctProp = <K extends keyof GridComponents>(propName: K, defaultValue: GridComponents[K] | null | 'div' = null) => {
@@ -37,7 +39,10 @@ const gridComponentPropsSystem = u.system(() => {
     computeItemKey,
     itemClassName,
     listClassName,
+    headerFooterTag,
     scrollerRef,
+    FooterComponent: distinctProp('Footer'),
+    HeaderComponent: distinctProp('Header'),
     ListComponent: distinctProp('List', 'div'),
     ItemComponent: distinctProp('Item', 'div'),
     ScrollerComponent: distinctProp('Scroller', 'div'),
@@ -145,6 +150,24 @@ const GridItems: FC = React.memo(function GridItems() {
   )
 })
 
+const Header: FC = React.memo(function VirtuosoHeader() {
+  const Header = useEmitterValue('HeaderComponent')
+  const headerHeight = usePublisher('headerHeight')
+  const headerFooterTag = useEmitterValue('headerFooterTag')
+  const ref = useSize((el) => headerHeight(correctItemSize(el, 'height')))
+  const context = useEmitterValue('context')
+  return Header ? createElement(headerFooterTag, { ref }, createElement(Header, contextPropIfNotDomElement(Header, context))) : null
+})
+
+const Footer: FC = React.memo(function VirtuosoGridFooter() {
+  const Footer = useEmitterValue('FooterComponent')
+  const footerHeight = usePublisher('footerHeight')
+  const headerFooterTag = useEmitterValue('headerFooterTag')
+  const ref = useSize((el) => footerHeight(correctItemSize(el, 'height')))
+  const context = useEmitterValue('context')
+  return Footer ? createElement(headerFooterTag, { ref }, createElement(Footer, contextPropIfNotDomElement(Footer, context))) : null
+})
+
 const Viewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const viewportDimensions = usePublisher('viewportDimensions')
 
@@ -180,7 +203,9 @@ const GridRoot: FC<GridRootProps> = React.memo(function GridRoot({ ...props }) {
   return (
     <TheScroller {...props}>
       <TheViewport>
+        <Header />
         <GridItems />
+        <Footer />
       </TheViewport>
     </TheScroller>
   )
@@ -204,6 +229,7 @@ const {
       data: 'data',
       initialItemCount: 'initialItemCount',
       scrollSeekConfiguration: 'scrollSeekConfiguration',
+      headerFooterTag: 'headerFooterTag',
       listClassName: 'listClassName',
       itemClassName: 'itemClassName',
       useWindowScroll: 'useWindowScroll',

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -523,6 +523,11 @@ export interface VirtuosoGridProps<D, C = unknown> extends GridRootProps {
   computeItemKey?: GridComputeItemKey<D, C>
 
   /**
+   * Set to customize the wrapper tag for the header and footer components (default is `div`).
+   */
+  headerFooterTag?: string
+
+  /**
    * Use to display placeholders if the user scrolls fast through the list.
    *
    * Set `components.ScrollSeekPlaceholder` to change the placeholder content.

--- a/src/gridSystem.ts
+++ b/src/gridSystem.ts
@@ -69,7 +69,7 @@ function gapComparator(prev: Gap, next: Gap) {
 export const gridSystem = u.system(
   ([
     { overscan, visibleRange, listBoundary },
-    { scrollTop, viewportHeight, scrollBy, scrollTo, smoothScrollTargetReached, scrollContainerState },
+    { scrollTop, viewportHeight, scrollBy, scrollTo, smoothScrollTargetReached, scrollContainerState, footerHeight, headerHeight },
     stateFlags,
     scrollSeek,
     { propsReady, didMount },
@@ -287,6 +287,8 @@ export const gridSystem = u.system(
       windowScrollContainerState,
       deviation,
       scrollContainerState,
+      footerHeight,
+      headerHeight,
       initialItemCount,
       gap,
       ...scrollSeek,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -297,6 +297,18 @@ export interface GridComponents<Context = any> {
   List?: ComponentType<GridListProps & { context?: Context }>
 
   /**
+   * Set to render a component at the top of the list.
+   *
+   * The header remains above the top items and does not remain sticky.
+   */
+  Header?: ComponentType<{ context?: Context }>
+
+  /**
+   * Set to render a component at the bottom of the list.
+   */
+  Footer?: ComponentType<{ context?: Context }>
+
+  /**
    * Set to render an item placeholder when the user scrolls fast.
    * See the `scrollSeekConfiguration` property for more details.
    */


### PR DESCRIPTION
Closes #197.

We really only need Footer for showing a loading indicator, like in the issue, but as I wanted to use similar props and examples to List, added Header as well (otherwise the `headerFooterTag` prop would be a bit weird...).

Mostly copied over the implementation from List, not sure if the heights need to be added to some calculations manually as well or will the domIoSystem forward everything automatically? The example I added seemed to work okay.