### PR TITLE
fix: probe item data in VirtuosoGrid

### DIFF
--- a/src/gridSystem.ts
+++ b/src/gridSystem.ts
@@ -57,6 +57,13 @@ const PROBE_GRID_STATE: GridState = {
 
 const { round, ceil, floor, min, max } = Math
 
+function buildProbeGridState<D = unknown>(items: GridItem<D>[]): GridState {
+  return {
+    ...PROBE_GRID_STATE,
+    items: items,
+  }
+}
+
 function buildItems<D>(startIndex: number, endIndex: number, data: D[] | undefined) {
   return Array.from({ length: endIndex - startIndex + 1 }).map(
     (_, i) => ({ index: i + startIndex, data: data?.[i + startIndex] } as GridItem<D>)
@@ -126,7 +133,7 @@ export const gridSystem = u.system(
           }
 
           if (itemWidth === 0) {
-            return PROBE_GRID_STATE
+            return buildProbeGridState(buildItems(0, 0, data))
           }
 
           const perRow = itemsPerRow(viewportWidth, itemWidth, columnGap)

--- a/test/Grid.test.tsx
+++ b/test/Grid.test.tsx
@@ -1,0 +1,131 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import * as React from 'react'
+import ReactDOM from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import { Grid } from '../src/Grid'
+jest.mock('../src/hooks/useSize')
+jest.mock('../src/hooks/useScrollTop')
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('Grid', () => {
+  let container: HTMLDivElement
+  beforeEach(() => {
+    // setup a DOM element as a render target
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    // cleanup on exiting
+    document.body.removeChild(container)
+  })
+
+  it('renders a probe item initially', () => {
+    act(() => {
+      ReactDOM.createRoot(container).render(<Grid totalCount={20000} />)
+    })
+
+    const scroller = container.firstElementChild as any
+    const viewport = scroller.firstElementChild
+    const listParent = viewport.firstElementChild
+
+    act(() => {
+      scroller.triggerScroll({ scrollTop: 0, scrollHeight: 700, viewportHeight: 200 })
+      viewport.triggerResize({ getBoundingClientRect: () => ({ height: 700 }) })
+    })
+
+    expect(listParent.children).toHaveLength(1)
+    expect(listParent.textContent).toBe('Item 0')
+  })
+
+  describe('data list', () => {
+    let scroller: any
+    let viewport: any
+    let listParent: any
+    const data: any = Array.from({ length: 1000 }).map((_, i) => `Item ${i}`)
+
+    beforeEach(() => {
+      act(() => {
+        ReactDOM.createRoot(container).render(<Grid data={data} itemContent={(_: number, data: string) => data} />)
+      })
+
+      scroller = container.firstElementChild
+      viewport = scroller.firstElementChild
+      listParent = viewport.firstElementChild
+
+      act(() => {
+        scroller.triggerScroll({ scrollTop: 0, scrollHeight: 700, viewportHeight: 200 })
+        viewport.triggerResize({ getBoundingClientRect: () => ({ height: 700 }) })
+      })
+    })
+
+    it('renders the list with the data item', () => {
+      expect(listParent.firstElementChild.textContent).toBe('Item 0')
+    })
+  })
+
+  it('updates when data is propagated', () => {
+    const Case = () => {
+      const [data, setData] = React.useState([] as any[])
+
+      return (
+        <>
+          <Grid data={data} itemContent={(_: number, item: { name: string }) => item.name} />
+          <button onClick={() => setData([{ name: 'Item 0' }])}>Set Data</button>
+        </>
+      )
+    }
+
+    act(() => {
+      ReactDOM.createRoot(container).render(<Case />)
+    })
+
+    const scroller = container.firstElementChild as any
+    const viewport = scroller.firstElementChild
+    const listParent = viewport.firstElementChild
+
+    act(() => {
+      scroller.triggerScroll({ scrollTop: 0, scrollHeight: 700, viewportHeight: 200 })
+      viewport.triggerResize({ getBoundingClientRect: () => ({ height: 100 }) })
+      container.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(listParent.firstElementChild.textContent).toBe('Item 0')
+  })
+
+  it('updates when data is propagated (same length)', () => {
+    const Case = () => {
+      const [data, setData] = React.useState([{ name: 'Item 0' }] as any[])
+
+      return (
+        <>
+          <Grid
+            data={data}
+            itemContent={(_: number, item: { name: string }) => {
+              return item.name
+            }}
+          />
+          <button onClick={() => setData([{ name: 'Item 1' }])}>Set Data</button>
+        </>
+      )
+    }
+
+    act(() => {
+      ReactDOM.createRoot(container).render(<Case />)
+    })
+
+    const scroller = container.firstElementChild as any
+    const viewport = scroller.firstElementChild
+    const listParent = viewport.firstElementChild
+
+    act(() => {
+      scroller.triggerScroll({ scrollTop: 0, scrollHeight: 700, viewportHeight: 200 })
+      viewport.triggerResize({ getBoundingClientRect: () => ({ height: 100 }) })
+      container.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(listParent.firstElementChild.textContent).toBe('Item 1')
+  })
+})


### PR DESCRIPTION
Another bugfix. The item data was not defined for the probe item. causing errors when the component called `computeItemKey` or `itemContent` fn props that expected data to always be there.

I also duplicated some parts of the existing `List.test.tsx` for Grid to somewhat test this behavior - without the changes, it would also fail.

Sorry about all the bugs :) 