### PR TITLE
fix: upward scroll after scrollTo glitch in iOS Chrome / Webview

### DIFF
--- a/src/upwardScrollFixSystem.ts
+++ b/src/upwardScrollFixSystem.ts
@@ -9,7 +9,7 @@ import { simpleMemoize } from './utils/simpleMemoize'
 import { recalcSystem } from './recalcSystem'
 
 const isMobileSafari = simpleMemoize(() => {
-  return /iP(ad|hone|od).+Version\/[\d.]+.*Safari/i.test(navigator.userAgent)
+  return /iP(ad|od|hone)/i.test(navigator.userAgent) && /WebKit/i.test(navigator.userAgent)
 })
 
 type UpwardFixState = [number, ListItem<any>[], number, number]


### PR DESCRIPTION
closes #788 

I have run the tests and made sure they pass.