### PR TITLE
feat: allow grouped table

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "workbench.colorCustomizations": {}
+}

--- a/examples/group-table.tsx
+++ b/examples/group-table.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react'
+import { TableVirtuoso, TableVirtuosoHandle } from '../src/'
+
+export default function App() {
+  const ref = React.useRef<TableVirtuosoHandle>(null)
+  return (
+    <>
+      <TableVirtuoso
+        ref={ref}
+        totalCount={1000}
+        components={{
+          EmptyPlaceholder: () => {
+            return (
+              <tbody>
+                <tr>
+                  <td>Empty</td>
+                </tr>
+              </tbody>
+            )
+          },
+        }}
+        groupCounts={Array.from({ length: 100 }).fill(10) as number[]}
+        style={{ height: 700 }}
+        fixedHeaderContent={() => {
+          return (
+            <tr style={{ background: 'white' }}>
+              <th key={1} style={{ height: 150, border: '1px solid black', background: 'white' }}>
+                TH 1
+              </th>
+              <th key={2} style={{ height: 150, border: '1px solid black', background: 'white' }}>
+                TH meh
+              </th>
+            </tr>
+          )
+        }}
+        fixedFooterContent={() => {
+          return (
+            <tr style={{ background: 'white' }}>
+              <th key={1} style={{ height: 150, border: '1px solid black', background: 'white' }}>
+                Footer TH 1
+              </th>
+              <th key={2} style={{ height: 150, border: '1px solid black', background: 'white' }}>
+                Footer TH meh
+              </th>
+            </tr>
+          )
+        }}
+        itemContent={(index) => {
+          return (
+            <>
+              <td style={{ height: 21 }}>{index}Cell 1</td>
+              <td style={{ height: 21 }}>Cell 2</td>
+            </>
+          )
+        }}
+        groupContent={(index) => {
+          return (
+            <>
+              <td style={{ height: 21 }}>Group {index}</td>
+              <td style={{ height: 21 }}>Meh</td>
+            </>
+          )
+        }}
+      />
+      <button
+        onClick={() =>
+          ref.current.scrollToIndex({
+            index: 900,
+            align: 'start',
+          })
+        }
+      >
+        scroll 900 start
+      </button>
+      <button
+        onClick={() =>
+          ref.current.scrollToIndex({
+            index: 900,
+            align: 'end',
+          })
+        }
+      >
+        scroll 900 end
+      </button>
+
+      <button
+        onClick={() =>
+          ref.current.scrollToIndex({
+            index: 900,
+            align: 'center',
+          })
+        }
+      >
+        scroll 900 center
+      </button>
+      <button
+        onClick={() =>
+          ref.current.scrollIntoView({
+            index: 50,
+          })
+        }
+      >
+        scroll 50 into view
+      </button>
+      <p>Buttons should align 900 correctly </p>
+    </>
+  )
+}

--- a/examples/group-table.tsx
+++ b/examples/group-table.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react'
-import { TableVirtuoso, TableVirtuosoHandle } from '../src/'
+import { GroupedTableVirtuoso, GroupedTableVirtuosoHandle } from '../src/'
 
 export default function App() {
-  const ref = React.useRef<TableVirtuosoHandle>(null)
+  const ref = React.useRef<GroupedTableVirtuosoHandle>(null)
   return (
     <>
-      <TableVirtuoso
+      <GroupedTableVirtuoso
         ref={ref}
-        totalCount={1000}
         components={{
           EmptyPlaceholder: () => {
             return (

--- a/site/docs/grouped-table.md
+++ b/site/docs/grouped-table.md
@@ -1,15 +1,27 @@
-import React, { useMemo } from 'react'
-import { GroupedTableVirtuoso } from '../src/'
+---
+id: grouped-table
+title: Grouped Table
+sidebar_label: Grouped Table
+slug: /grouped-table/
+---
+
+The example below shows a simple table grouping mode.
+
+```jsx live
+import { GroupedTableVirtuoso } from 'react-virtuoso'
+import { useMemo, useRef } from 'react'
 
 export default function App() {
+  const ref = useRef()
+
   const groupCounts = useMemo(() => {
-    return Array(1000).fill(10) as number[]
+    return Array(1000).fill(10)
   }, [])
 
   return (
     <GroupedTableVirtuoso
       groupCounts={groupCounts}
-      style={{ height: 700 }}
+      style={{ height: 400 }}
       fixedHeaderContent={() => {
         return (
           <tr style={{ background: 'white', textAlign: 'left' }}>
@@ -41,3 +53,4 @@ export default function App() {
     />
   )
 }
+```

--- a/site/docs/table-virtuoso-api-reference.md
+++ b/site/docs/table-virtuoso-api-reference.md
@@ -1,15 +1,16 @@
 ---
 id: table-virtuoso-api-reference
 title: Table Virtuoso API Reference
-sidebar_label: Table Virtuoso 
+sidebar_label: Table Virtuoso
 slug: /table-virtuoso-api-reference/
 ---
 
 import Props from './api/interfaces/_component_interfaces_tablevirtuoso_.tablevirtuosoprops.md'
+import GroupProps from './api/interfaces/_component_interfaces_tablevirtuoso_.groupedtablevirtuosoprops.md'
 import VirtuosoProps from './api/interfaces/_component_interfaces_virtuoso_.virtuosoprops.md'
 import Methods from './api/interfaces/_component_interfaces_virtuoso_.virtuosohandle.md'
 
-All properties are optional - by default, the component will render empty. 
+All properties are optional - by default, the component will render empty.
 
 If you are using TypeScript and want to use correctly typed component `ref`, you can use the `VirtuosoHandle`.
 
@@ -21,10 +22,16 @@ const ref = useRef<VirtuosoHandle>(null)
 <TableVirtuoso ref={ref} /*...*/ />
 ```
 
-## Table Virtuoso Properties
+## TableVirtuoso Properties
 
 <div className="generated-api">
 <Props />
+</div>
+
+## GroupedTableVirtuoso Properties
+
+<div className="generated-api">
+<GroupProps />
 </div>
 
 ## Methods

--- a/site/sidebars.js
+++ b/site/sidebars.js
@@ -11,7 +11,7 @@ module.exports = {
       'initial-index',
       'range-change-callback',
     ],
-    'Grouped Mode': ['grouped-numbers', 'grouped-by-first-letter', 'grouped-with-load-on-demand', 'scroll-to-group'],
+    'Grouped Mode': ['grouped-numbers', 'grouped-by-first-letter', 'grouped-with-load-on-demand', 'scroll-to-group', 'grouped-table'],
     Table: ['hello-table', 'table-fixed-headers', 'mui-table-virtual-scroll', 'table-fixed-columns', 'react-table-integration'],
     Grid: ['grid-responsive-columns'],
     Scenarios: [

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -2308,6 +2308,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.3.tgz#e7b5aebbac150f8b5fdd4a46e7f0bd8e65e19109"
   integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
 
+"@types/prop-types@*":
+  version "15.7.5"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
+  integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
+
 "@types/prop-types@^15.7.4":
   version "15.7.4"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
@@ -2340,10 +2345,20 @@
     "@types/react" "*"
 
 "@types/react@*":
-  version "0.0.0"
+  version "18.0.5"
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
 
 "@types/react@link:../node_modules/@types/react":
   version "0.0.0"
+  uid ""
+
+"@types/scheduler@*":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
+  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@types/source-list-map@*":
   version "0.1.2"

--- a/src/component-interfaces/TableVirtuoso.ts
+++ b/src/component-interfaces/TableVirtuoso.ts
@@ -11,19 +11,11 @@ import type {
   ScrollSeekConfiguration,
   SizeFunction,
   TableComponents,
+  GroupItemContent,
 } from '../interfaces'
 import type { VirtuosoProps } from './Virtuoso'
 
 export interface TableVirtuosoProps<D, C> extends Omit<VirtuosoProps<D, C>, 'components' | 'headerFooterTag' | 'topItemCount'> {
-  /**
-   * Specifies the amount of items in each group (and, actually, how many groups are there).
-   * For example, passing [20, 30] will display 2 groups with 20 and 30 items each.
-   */
-  groupCounts?: number[]
-  /**
-   * Specifies how each each group header gets rendered. The callback receives the zero-based index of the group.
-   */
-  groupContent?: GroupContent
   /**
    * Use the `components` property for advanced customization of the elements rendered by the table.
    */
@@ -217,6 +209,24 @@ export interface TableVirtuosoProps<D, C> extends Omit<VirtuosoProps<D, C>, 'com
    * By default `4`. Redefine to change how much away from the bottom the scroller can be before the list is not considered not at bottom.
    */
   atBottomThreshold?: number
+}
+
+export interface GroupedTableVirtuosoProps<D, C> extends Omit<TableVirtuosoProps<D, C>, 'totalCount' | 'itemContent'> {
+  /**
+   * Specifies the amount of items in each group (and, actually, how many groups are there).
+   * For example, passing [20, 30] will display 2 groups with 20 and 30 items each.
+   */
+  groupCounts?: number[]
+
+  /**
+   * Specifies how each each group header gets rendered. The callback receives the zero-based index of the group.
+   */
+  groupContent?: GroupContent
+
+  /**
+   * Specifies how each each item gets rendered.
+   */
+  itemContent?: GroupItemContent<D, C>
 }
 
 export interface TableVirtuosoHandle {

--- a/src/component-interfaces/TableVirtuoso.ts
+++ b/src/component-interfaces/TableVirtuoso.ts
@@ -5,6 +5,7 @@ import type {
   FlatScrollIntoViewLocation,
   FollowOutput,
   ItemContent,
+  GroupContent,
   ListItem,
   ListRange,
   ScrollSeekConfiguration,
@@ -14,6 +15,15 @@ import type {
 import type { VirtuosoProps } from './Virtuoso'
 
 export interface TableVirtuosoProps<D, C> extends Omit<VirtuosoProps<D, C>, 'components' | 'headerFooterTag' | 'topItemCount'> {
+  /**
+   * Specifies the amount of items in each group (and, actually, how many groups are there).
+   * For example, passing [20, 30] will display 2 groups with 20 and 30 items each.
+   */
+  groupCounts?: number[]
+  /**
+   * Specifies how each each group header gets rendered. The callback receives the zero-based index of the group.
+   */
+  groupContent?: GroupContent
   /**
    * Use the `components` property for advanced customization of the elements rendered by the table.
    */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -173,6 +173,11 @@ export interface TableComponents<Data = unknown, Context = unknown> {
   TableBody?: ComponentType<TableBodyProps & { context?: Context }>
 
   /**
+   * Set to customize the group item wrapping element. Use only if you would like to render list from elements different than a `div`.
+   */
+  Group?: ComponentType<GroupProps & { context?: Context }>
+
+  /**
    * Set to render a custom UI when the list is empty.
    */
   EmptyPlaceholder?: ComponentType<{ context?: Context }>


### PR DESCRIPTION
Hi this is probably more of a WIP but I wanted to get your pulse on that. We needed to have sticky group headers in our table and I saw that not much was missing from the table implementation for it to work.

I added an example (group-table.tx)