### PR TITLE
fix(grouped list): #769 Move sticky container above list items contai…

### DIFF
--- a/e2e/grouped-topmost-item.test.ts
+++ b/e2e/grouped-topmost-item.test.ts
@@ -10,10 +10,26 @@ test.describe('jagged grouped list', () => {
   test('puts the specified item below the group', async ({ page }) => {
     // we pick the second item, the first should remain under the group header
     const stickyItemIndex = await page.evaluate(() => {
-      const stickyItem = document.querySelector('#test-root > div > div:first-child > div > div:nth-child(2)') as HTMLDivElement
+      const stickyItem = document.querySelector('#test-root > div > div:last-child > div > div:nth-child(2)') as HTMLDivElement
       return stickyItem.dataset['itemIndex']
     })
 
+    const { topListItemContainerZIndex, listItemContainerZIndex } = await page.evaluate(() => {
+      const topListItemContainerZIndex = Number.parseInt(
+        getComputedStyle(document.querySelector('#test-root > div > div') as HTMLDivElement).zIndex
+      )
+
+      const listItemContainerZIndex = Number.parseInt(
+        getComputedStyle(document.querySelector('#test-root > div > div:last-child') as HTMLDivElement).zIndex
+      )
+
+      return {
+        topListItemContainerZIndex: Number.isNaN(topListItemContainerZIndex) ? 0 : topListItemContainerZIndex,
+        listItemContainerZIndex: Number.isNaN(listItemContainerZIndex) ? 0 : listItemContainerZIndex,
+      }
+    })
+
     expect(stickyItemIndex).toBe('10')
+    expect(topListItemContainerZIndex).toBeGreaterThan(listItemContainerZIndex)
   })
 })

--- a/e2e/grouped.test.ts
+++ b/e2e/grouped.test.ts
@@ -9,7 +9,7 @@ test.describe('jagged grouped list', () => {
 
   test('renders correct sizing', async ({ page }) => {
     const [paddingTop, paddingBottom] = await page.evaluate(() => {
-      const listContainer = document.querySelector('#test-root > div > div > div:first-child') as HTMLElement
+      const listContainer = document.querySelector('#test-root > div > div:last-child > div:first-child') as HTMLElement
       return [listContainer.style.paddingTop, listContainer.style.paddingBottom]
     })
 
@@ -26,7 +26,7 @@ test.describe('jagged grouped list', () => {
     await page.waitForTimeout(100)
 
     const stickyItemIndex = await page.evaluate(() => {
-      const stickyItem = document.querySelector('#test-root > div > div:last-child > div > div') as HTMLElement
+      const stickyItem = document.querySelector('#test-root > div > div > div > div') as HTMLElement
       return stickyItem.dataset['index']
     })
 

--- a/e2e/top-items.test.ts
+++ b/e2e/top-items.test.ts
@@ -16,7 +16,7 @@ test.describe('jagged list with 2 top items', () => {
     expect(scrollTop).toBe(0)
 
     const paddingTop = await page.evaluate(() => {
-      const listContainer = document.querySelector('#test-root > div > div > div') as HTMLElement
+      const listContainer = document.querySelector('#test-root > div > div:last-child > div') as HTMLElement
       return listContainer.style.paddingTop
     })
 
@@ -25,7 +25,7 @@ test.describe('jagged list with 2 top items', () => {
 
   test('renders correct amount of items', async ({ page }) => {
     const childElementCount = await page.evaluate(() => {
-      const listContainer = document.querySelectorAll('#test-root > div > div > div')[0]
+      const listContainer = document.querySelectorAll('#test-root > div > div:last-child > div')[0]
       return listContainer.childElementCount
     })
     expect(childElementCount).toBe(9)
@@ -40,7 +40,7 @@ test.describe('jagged list with 2 top items', () => {
     await page.waitForTimeout(100)
 
     const firstChildIndex: string = await page.evaluate(() => {
-      const firstChild = document.querySelector('#test-root > div > div > div > div') as HTMLElement
+      const firstChild = document.querySelector('#test-root > div > div:last-child > div > div') as HTMLElement
       return firstChild.dataset['index']!
     })
 

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -288,6 +288,7 @@ const topItemListStyle: CSSProperties = {
   width: '100%',
   position: positionStickyCssValue(),
   top: 0,
+  zIndex: 1,
 }
 
 export function contextPropIfNotDomElement(element: unknown, context: unknown) {
@@ -452,16 +453,16 @@ const ListRoot: FC<ListRootProps> = React.memo(function VirtuosoRoot(props) {
   const TheViewport = customScrollParent || useWindowScroll ? WindowViewport : Viewport
   return (
     <TheScroller {...props}>
-      <TheViewport>
-        <Header />
-        <Items />
-        <Footer />
-      </TheViewport>
       {showTopList && (
         <TopItemListContainer>
           <Items showTopList={true} />
         </TopItemListContainer>
       )}
+      <TheViewport>
+        <Header />
+        <Items />
+        <Footer />
+      </TheViewport>
     </TheScroller>
   )
 })


### PR DESCRIPTION
- Addresses #769 to correct natural tab ordering for accessibility
- Adds zIndex of 1 to group container
- Adjust related tests to point to the correct group element now that the DOM nodes are essentially swapped within the scroller