### PR TITLE
feat: expose item data for TableRow & Item

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -258,6 +258,7 @@ export const Items = React.memo(function VirtuosoItems({ showTopList = false }: 
             'data-known-size': item.size,
             'data-item-index': item.index,
             'data-item-group-index': item.groupIndex,
+            item: item.data,
             style: ITEM_STYLE,
           },
           hasGroups

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -145,6 +145,7 @@ export const Items = React.memo(function VirtuosoItems() {
         'data-index': index,
         'data-known-size': item.size,
         'data-item-index': item.index,
+        item: item.data,
         style: { overflowAnchor: 'none' },
       },
       itemContent(item.index, item.data, context)

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -95,7 +95,7 @@ export interface VirtuosoProps<D, C> extends ListRootProps {
   /**
    * Use the `components` property for advanced customization of the elements rendered by the list.
    */
-  components?: Components<C>
+  components?: Components<D, C>
 
   /**
    * Set the callback to specify the contents of the item.
@@ -276,7 +276,7 @@ export interface TableVirtuosoProps<D, C> extends Omit<VirtuosoProps<D, C>, 'com
   /**
    * Use the `components` property for advanced customization of the elements rendered by the table.
    */
-  components?: TableComponents<C>
+  components?: TableComponents<D, C>
   /**
    * Set the contents of the table header.
    */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -19,7 +19,8 @@ export interface GroupContent {
   (index: number): ReactNode
 }
 
-export type ItemProps = Pick<ComponentPropsWithRef<'div'>, 'style' | 'children'> & {
+export type ItemProps<D> = Pick<ComponentPropsWithRef<'div'>, 'style' | 'children'> & {
+  item: D
   'data-index': number
   'data-item-index': number
   'data-item-group-index'?: number
@@ -86,7 +87,7 @@ export interface GridScrollSeekPlaceholderProps {
 /**
  * Customize the Virtuoso rendering by passing a set of custom components.
  */
-export interface Components<Context = unknown> {
+export interface Components<Data = unknown, Context = unknown> {
   /**
    * Set to render a component at the top of the list.
    *
@@ -100,7 +101,7 @@ export interface Components<Context = unknown> {
   /**
    * Set to customize the item wrapping element. Use only if you would like to render list from elements different than a `div`.
    */
-  Item?: ComponentType<ItemProps & { context?: Context }>
+  Item?: ComponentType<ItemProps<Data> & { context?: Context }>
   /**
    * Set to customize the group item wrapping element. Use only if you would like to render list from elements different than a `div`.
    */
@@ -137,7 +138,7 @@ export interface Components<Context = unknown> {
 /**
  * Customize the TableVirtuoso rendering by passing a set of custom components.
  */
-export interface TableComponents<Context = unknown> {
+export interface TableComponents<Data = unknown, Context = unknown> {
   /**
    * Set to customize the wrapping `table` element.
    *
@@ -158,7 +159,7 @@ export interface TableComponents<Context = unknown> {
   /**
    * Set to customize the item wrapping element. Default is `tr`.
    */
-  TableRow?: ComponentType<ItemProps & { context?: Context }>
+  TableRow?: ComponentType<ItemProps<Data> & { context?: Context }>
 
   /**
    * Set to customize the outermost scrollable element. This should not be necessary in general,


### PR DESCRIPTION
We're in multiple places adding `onClick` handlers for the entire table row, for example doing something like this:

```
const components = React.useMemo(
  (): TableComponents<Data> => ({
    Row: (props) => {
      const rowId = props.context?.data[props['data-item-index']]?.id;

      return (
        <TableRow
          onClick={rowId !== undefined && onRowClick !== undefined ? () => onRowClick?.(rowId) : undefined}
          {...props}
        />
      );
    },
  }),
  [onRowClick],
);
```
This means a need for accessing the row data on the TableRow (or Item for regular Virtuoso list) level. Currently we've implemented this so that we're passing the entire data array to context as well, and then accessing it via the index lookup. If the context depends on the data, then it will cause rerenders of basically everything when the data (and context) changes. 

So I looked into whether we could provide the item data to the specific components directly. It seems the data is available in the necessary places - but I'm not entirely sure if there is a good reason why it hasn't been added before. I'm also not sure how much it will help with the rerenders, but it should at least help us clean up our code a bit, as we're only passing the data to various places for this specific need.

Looking for initial feedback on this for now - do you think changing stuff like this would be viable? I expect this needs a couple of changes in other places as well, like Grid for example could benefit from the same thing, but I will add any other necessary changes once we have a general agreement.


