### PR TITLE
fix: provide context to filler row

### DIFF
--- a/src/TableVirtuoso.tsx
+++ b/src/TableVirtuoso.tsx
@@ -120,9 +120,9 @@ const Items = /*#__PURE__*/ memo(function VirtuosoItems() {
   const paddingTop = listState.offsetTop + paddingTopAddition + deviation
   const paddingBottom = listState.offsetBottom
 
-  const paddingTopEl = paddingTop > 0 ? <FillerRow height={paddingTop} key="padding-top" /> : null
+  const paddingTopEl = paddingTop > 0 ? <FillerRow height={paddingTop} key="padding-top" context={context} /> : null
 
-  const paddingBottomEl = paddingBottom > 0 ? <FillerRow height={paddingBottom} key="padding-bottom" /> : null
+  const paddingBottomEl = paddingBottom > 0 ? <FillerRow height={paddingBottom} key="padding-bottom" context={context} /> : null
 
   const items = listState.items.map((item) => {
     const index = item.originalIndex!


### PR DESCRIPTION
Passes context to FillerRow, which [the props interface says the component should already receive](https://github.com/petyosi/react-virtuoso/blob/master/src/interfaces.ts#L188).

We want to use it to work around https://github.com/petyosi/react-virtuoso/issues/609, as we know the column count via the passed context.