### PR TITLE
fix: VirtuosoGrid and TableVirtuoso type definiton

### DIFF
--- a/src/VirtuosoGrid.tsx
+++ b/src/VirtuosoGrid.tsx
@@ -248,4 +248,6 @@ function resolveGapValue(property: string, value: string | undefined, log: Log) 
   return parseInt(value ?? '0', 10)
 }
 
-export const VirtuosoGrid = Grid as <Context = any>(props: VirtuosoGridProps<Context> & { ref?: Ref<VirtuosoGridHandle> }) => ReactElement
+export const VirtuosoGrid = Grid as <ItemData = any, Context = any>(
+  props: VirtuosoGridProps<ItemData, Context> & { ref?: Ref<VirtuosoGridHandle> }
+) => ReactElement

--- a/src/component-interfaces/TableVirtuoso.ts
+++ b/src/component-interfaces/TableVirtuoso.ts
@@ -1,6 +1,7 @@
 import type {
   ComputeItemKey,
   FixedHeaderContent,
+  FixedFooterContent,
   FlatIndexLocationWithAlign,
   FlatScrollIntoViewLocation,
   FollowOutput,
@@ -18,10 +19,16 @@ export interface TableVirtuosoProps<D, C> extends Omit<VirtuosoProps<D, C>, 'com
    * Use the `components` property for advanced customization of the elements rendered by the table.
    */
   components?: TableComponents<D, C>
+
   /**
    * Set the contents of the table header.
    */
   fixedHeaderContent?: FixedHeaderContent
+
+  /**
+   * Set the contents of the table footer.
+   */
+  fixedFooterContent?: FixedFooterContent
 
   /**
    * The total amount of items to be rendered.

--- a/src/component-interfaces/VirtuosoGrid.ts
+++ b/src/component-interfaces/VirtuosoGrid.ts
@@ -20,6 +20,11 @@ export interface VirtuosoGridProps<D, C = unknown> extends GridRootProps {
   data?: readonly D[]
 
   /**
+   * Additional context available in the custom components and content callbacks
+   */
+  context?: C
+
+  /**
    * Use for server-side rendering - if set, the list will render the specified amount of items
    * regardless of the container / item size.
    */


### PR DESCRIPTION
Fixes multiple regressions from 397cf169c0b0447cbee875752694b89f9d235711. 

1. As `VirtuosoGridProps` accepts two generic parameters, so should the component.
2. Also, context prop was removed from `VirtuosoGridProps` the props for some reason, which I added back.
3. Also, `fixedFooterContent` prop on TableVirtuoso seems to have gone missing from the props interface, even though the implementation remained. Added this back as well, we use it.