### PR TITLE
fix: use default export from react and react-dom, build with classic jsx runtime

### DIFF
--- a/examples/auto-prepend-items.tsx
+++ b/examples/auto-prepend-items.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useState } from 'react'
-import * as React from 'react'
+import React from 'react'
 import { Virtuoso } from '../src'
 import { faker } from '@faker-js/faker'
 
@@ -40,10 +39,10 @@ export function Example() {
   const START_INDEX = 10000
   const INITIAL_ITEM_COUNT = 20
 
-  const [firstItemIndex, setFirstItemIndex] = useState(START_INDEX)
-  const [users, setUsers] = useState(() => generateUsers(INITIAL_ITEM_COUNT, START_INDEX))
+  const [firstItemIndex, setFirstItemIndex] = React.useState(START_INDEX)
+  const [users, setUsers] = React.useState(() => generateUsers(INITIAL_ITEM_COUNT, START_INDEX))
 
-  const prependItems = useCallback(() => {
+  const prependItems = React.useCallback(() => {
     const usersToPrepend = 20
     const nextFirstItemIndex = firstItemIndex - usersToPrepend
 

--- a/ladle.vite.config.ts
+++ b/ladle.vite.config.ts
@@ -1,0 +1,13 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    rollupOptions: {
+      external: ['react', 'react-dom', 'react/jsx-runtime', '@virtuoso.dev/urx', '@virtuoso.dev/react-urx'],
+    },
+  },
+})

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "e2e": "playwright test",
     "lint": "eslint src test e2e --ext .ts,.tsx",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
-    "dev": "ladle serve",
+    "dev": "ladle serve --viteConfig ladle.vite.config.ts",
     "prepare": "pnpm run build && husky install",
     "semantic-release": "semantic-release"
   },

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "homepage": "https://virtuoso.dev/",
   "license": "MIT",
   "source": "src/index.tsx",
-  "main": "dist/index.js",
-  "module": "dist/index.es.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "homepage": "https://virtuoso.dev/",
   "license": "MIT",
   "source": "src/index.tsx",
-  "main": "dist/index.cjs",
-  "module": "dist/index.mjs",
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
   "types": "dist/index.d.ts",
   "keywords": [
     "react",

--- a/src/TableVirtuoso.tsx
+++ b/src/TableVirtuoso.tsx
@@ -1,6 +1,6 @@
 import { systemToComponent } from './react-urx'
 import * as u from './urx'
-import { createElement, FC, PropsWithChildren, ReactElement, Ref, useContext, memo, useState, useEffect } from 'react'
+import React from 'react'
 import useChangedListContentsSizes from './hooks/useChangedChildSizes'
 import { ComputeItemKey, ItemContent, FixedHeaderContent, FixedFooterContent, TableComponents, TableRootProps } from './interfaces'
 import { listSystem } from './listSystem'
@@ -70,7 +70,7 @@ const DefaultFillerRow = ({ height }: { height: number }) => (
   </tr>
 )
 
-const Items = /*#__PURE__*/ memo(function VirtuosoItems() {
+const Items = /*#__PURE__*/ React.memo(function VirtuosoItems() {
   const listState = useEmitterValue('listState')
   const sizeRanges = usePublisher('sizeRanges')
   const useWindowScroll = useEmitterValue('useWindowScroll')
@@ -94,7 +94,7 @@ const Items = /*#__PURE__*/ memo(function VirtuosoItems() {
     customScrollParent
   )
 
-  const [deviation, setDeviation] = useState(0)
+  const [deviation, setDeviation] = React.useState(0)
   useEmitter('deviation', (value) => {
     if (deviation !== value) {
       ref.current!.style.marginTop = `${value}px`
@@ -114,7 +114,7 @@ const Items = /*#__PURE__*/ memo(function VirtuosoItems() {
   const context = useEmitterValue('context')
 
   if (statefulTotalCount === 0 && EmptyPlaceholder) {
-    return createElement(EmptyPlaceholder, contextPropIfNotDomElement(EmptyPlaceholder, context))
+    return React.createElement(EmptyPlaceholder, contextPropIfNotDomElement(EmptyPlaceholder, context))
   }
 
   const paddingTop = listState.offsetTop + paddingTopAddition + deviation
@@ -129,7 +129,7 @@ const Items = /*#__PURE__*/ memo(function VirtuosoItems() {
     const key = computeItemKey(index + firstItemIndex, item.data, context)
 
     if (isSeeking) {
-      return createElement(ScrollSeekPlaceholder, {
+      return React.createElement(ScrollSeekPlaceholder, {
         ...contextPropIfNotDomElement(ScrollSeekPlaceholder, context),
         key,
         index: item.index,
@@ -137,7 +137,7 @@ const Items = /*#__PURE__*/ memo(function VirtuosoItems() {
         type: item.type || 'item',
       })
     }
-    return createElement(
+    return React.createElement(
       TableRowComponent,
       {
         ...contextPropIfNotDomElement(TableRowComponent, context),
@@ -152,20 +152,20 @@ const Items = /*#__PURE__*/ memo(function VirtuosoItems() {
     )
   })
 
-  return createElement(
+  return React.createElement(
     TableBodyComponent,
     { ref: callbackRef, 'data-test-id': 'virtuoso-item-list', ...contextPropIfNotDomElement(TableBodyComponent, context) },
     [paddingTopEl, ...items, paddingBottomEl]
   )
 })
 
-const Viewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
-  const ctx = useContext(VirtuosoMockContext)
+const Viewport: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
+  const ctx = React.useContext(VirtuosoMockContext)
   const viewportHeight = usePublisher('viewportHeight')
   const fixedItemHeight = usePublisher('fixedItemHeight')
   const viewportRef = useSize(u.compose(viewportHeight, (el) => correctItemSize(el, 'height')))
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (ctx) {
       viewportHeight(ctx.viewportHeight)
       fixedItemHeight(ctx.itemHeight)
@@ -179,14 +179,14 @@ const Viewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
   )
 }
 
-const WindowViewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
-  const ctx = useContext(VirtuosoMockContext)
+const WindowViewport: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
+  const ctx = React.useContext(VirtuosoMockContext)
   const windowViewportRect = usePublisher('windowViewportRect')
   const fixedItemHeight = usePublisher('fixedItemHeight')
   const customScrollParent = useEmitterValue('customScrollParent')
   const viewportRef = useWindowViewportRectRef(windowViewportRect, customScrollParent)
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (ctx) {
       fixedItemHeight(ctx.itemHeight)
       windowViewportRect({ offsetTop: 0, visibleHeight: ctx.viewportHeight, visibleWidth: 100 })
@@ -200,7 +200,7 @@ const WindowViewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
   )
 }
 
-const TableRoot: FC<TableRootProps> = /*#__PURE__*/ memo(function TableVirtuosoRoot(props) {
+const TableRoot: React.FC<TableRootProps> = /*#__PURE__*/ React.memo(function TableVirtuosoRoot(props) {
   const useWindowScroll = useEmitterValue('useWindowScroll')
   const customScrollParent = useEmitterValue('customScrollParent')
   const fixedHeaderHeight = usePublisher('fixedHeaderHeight')
@@ -217,7 +217,7 @@ const TableRoot: FC<TableRootProps> = /*#__PURE__*/ memo(function TableVirtuosoR
   const TheTFoot = useEmitterValue('TableFooterComponent')
 
   const theHead = fixedHeaderContent
-    ? createElement(
+    ? React.createElement(
         TheTHead!,
         {
           key: 'TableHead',
@@ -229,7 +229,7 @@ const TableRoot: FC<TableRootProps> = /*#__PURE__*/ memo(function TableVirtuosoR
       )
     : null
   const theFoot = fixedFooterContent
-    ? createElement(
+    ? React.createElement(
         TheTFoot!,
         {
           key: 'TableFoot',
@@ -244,7 +244,7 @@ const TableRoot: FC<TableRootProps> = /*#__PURE__*/ memo(function TableVirtuosoR
   return (
     <TheScroller {...props}>
       <TheViewport>
-        {createElement(TheTable!, { style: { borderSpacing: 0 }, ...contextPropIfNotDomElement(TheTable, context) }, [
+        {React.createElement(TheTable!, { style: { borderSpacing: 0 }, ...contextPropIfNotDomElement(TheTable, context) }, [
           theHead,
           <Items key="TableBody" />,
           theFoot,
@@ -318,5 +318,5 @@ const Scroller = /*#__PURE__*/ buildScroller({ usePublisher, useEmitterValue, us
 const WindowScroller = /*#__PURE__*/ buildWindowScroller({ usePublisher, useEmitterValue, useEmitter })
 
 export const TableVirtuoso = Table as <ItemData = any, Context = any>(
-  props: TableVirtuosoProps<ItemData, Context> & { ref?: Ref<TableVirtuosoHandle> }
-) => ReactElement
+  props: TableVirtuosoProps<ItemData, Context> & { ref?: React.Ref<TableVirtuosoHandle> }
+) => React.ReactElement

--- a/src/Virtuoso.tsx
+++ b/src/Virtuoso.tsx
@@ -1,19 +1,6 @@
 import { systemToComponent } from './react-urx'
 import * as u from './urx'
-import {
-  ComponentType,
-  createElement,
-  CSSProperties,
-  FC,
-  PropsWithChildren,
-  useContext,
-  ReactElement,
-  Ref,
-  memo,
-  useState,
-  useEffect,
-  MutableRefObject,
-} from 'react'
+import React from 'react'
 import useIsomorphicLayoutEffect from './hooks/useIsomorphicLayoutEffect'
 import useChangedListContentsSizes from './hooks/useChangedChildSizes'
 import useScrollTop from './hooks/useScrollTop'
@@ -80,7 +67,7 @@ const DefaultScrollSeekPlaceholder = ({ height }: { height: number }) => <div st
 const GROUP_STYLE = { position: positionStickyCssValue(), zIndex: 1, overflowAnchor: 'none' } as const
 const ITEM_STYLE = { overflowAnchor: 'none' } as const
 
-const Items = /*#__PURE__*/ memo(function VirtuosoItems({ showTopList = false }: { showTopList?: boolean }) {
+const Items = /*#__PURE__*/ React.memo(function VirtuosoItems({ showTopList = false }: { showTopList?: boolean }) {
   const listState = useEmitterValue('listState')
 
   const sizeRanges = usePublisher('sizeRanges')
@@ -108,7 +95,7 @@ const Items = /*#__PURE__*/ memo(function VirtuosoItems({ showTopList = false }:
     customScrollParent
   )
 
-  const [deviation, setDeviation] = useState(0)
+  const [deviation, setDeviation] = React.useState(0)
   useEmitter('deviation', (value) => {
     if (deviation !== value) {
       // ref.current!.style.marginTop = `${value}px`
@@ -126,7 +113,7 @@ const Items = /*#__PURE__*/ memo(function VirtuosoItems({ showTopList = false }:
   const hasGroups = useEmitterValue('groupIndices').length > 0
   const paddingTopAddition = useEmitterValue('paddingTopAddition')
 
-  const containerStyle: CSSProperties = showTopList
+  const containerStyle: React.CSSProperties = showTopList
     ? {}
     : {
         boxSizing: 'border-box',
@@ -136,10 +123,10 @@ const Items = /*#__PURE__*/ memo(function VirtuosoItems({ showTopList = false }:
       }
 
   if (!showTopList && listState.totalCount === 0 && EmptyPlaceholder) {
-    return createElement(EmptyPlaceholder, contextPropIfNotDomElement(EmptyPlaceholder, context))
+    return React.createElement(EmptyPlaceholder, contextPropIfNotDomElement(EmptyPlaceholder, context))
   }
 
-  return createElement(
+  return React.createElement(
     ListComponent,
     {
       ...contextPropIfNotDomElement(ListComponent, context),
@@ -152,7 +139,7 @@ const Items = /*#__PURE__*/ memo(function VirtuosoItems({ showTopList = false }:
       const key = computeItemKey(index + listState.firstItemIndex, item.data, context)
 
       if (isSeeking) {
-        return createElement(ScrollSeekPlaceholder, {
+        return React.createElement(ScrollSeekPlaceholder, {
           ...contextPropIfNotDomElement(ScrollSeekPlaceholder, context),
           key,
           index: item.index,
@@ -163,7 +150,7 @@ const Items = /*#__PURE__*/ memo(function VirtuosoItems({ showTopList = false }:
       }
 
       if (item.type === 'group') {
-        return createElement(
+        return React.createElement(
           GroupComponent,
           {
             ...contextPropIfNotDomElement(GroupComponent, context),
@@ -176,7 +163,7 @@ const Items = /*#__PURE__*/ memo(function VirtuosoItems({ showTopList = false }:
           groupContent(item.index)
         )
       } else {
-        return createElement(
+        return React.createElement(
           ItemComponent,
           {
             ...contextPropIfNotDomElement(ItemComponent, context),
@@ -197,7 +184,7 @@ const Items = /*#__PURE__*/ memo(function VirtuosoItems({ showTopList = false }:
   )
 })
 
-export const scrollerStyle: CSSProperties = {
+export const scrollerStyle: React.CSSProperties = {
   height: '100%',
   outline: 'none',
   overflowY: 'auto',
@@ -205,14 +192,14 @@ export const scrollerStyle: CSSProperties = {
   WebkitOverflowScrolling: 'touch',
 }
 
-export const viewportStyle: CSSProperties = {
+export const viewportStyle: React.CSSProperties = {
   width: '100%',
   height: '100%',
   position: 'absolute',
   top: 0,
 }
 
-const topItemListStyle: CSSProperties = {
+const topItemListStyle: React.CSSProperties = {
   width: '100%',
   position: positionStickyCssValue(),
   top: 0,
@@ -226,22 +213,26 @@ export function contextPropIfNotDomElement(element: unknown, context: unknown) {
   return { context }
 }
 
-const Header: FC = /*#__PURE__*/ memo(function VirtuosoHeader() {
+const Header: React.FC = /*#__PURE__*/ React.memo(function VirtuosoHeader() {
   const Header = useEmitterValue('HeaderComponent')
   const headerHeight = usePublisher('headerHeight')
   const headerFooterTag = useEmitterValue('headerFooterTag')
   const ref = useSize((el) => headerHeight(correctItemSize(el, 'height')))
   const context = useEmitterValue('context')
-  return Header ? createElement(headerFooterTag, { ref }, createElement(Header, contextPropIfNotDomElement(Header, context))) : null
+  return Header
+    ? React.createElement(headerFooterTag, { ref }, React.createElement(Header, contextPropIfNotDomElement(Header, context)))
+    : null
 })
 
-const Footer: FC = /*#__PURE__*/ memo(function VirtuosoFooter() {
+const Footer: React.FC = /*#__PURE__*/ React.memo(function VirtuosoFooter() {
   const Footer = useEmitterValue('FooterComponent')
   const footerHeight = usePublisher('footerHeight')
   const headerFooterTag = useEmitterValue('headerFooterTag')
   const ref = useSize((el) => footerHeight(correctItemSize(el, 'height')))
   const context = useEmitterValue('context')
-  return Footer ? createElement(headerFooterTag, { ref }, createElement(Footer, contextPropIfNotDomElement(Footer, context))) : null
+  return Footer
+    ? React.createElement(headerFooterTag, { ref }, React.createElement(Footer, contextPropIfNotDomElement(Footer, context)))
+    : null
 })
 
 interface Hooks {
@@ -251,7 +242,7 @@ interface Hooks {
 }
 
 export function buildScroller({ usePublisher, useEmitter, useEmitterValue }: Hooks) {
-  const Scroller: ComponentType<ScrollerProps> = memo(function VirtuosoScroller({ style, children, ...props }) {
+  const Scroller: React.ComponentType<ScrollerProps> = React.memo(function VirtuosoScroller({ style, children, ...props }) {
     const scrollContainerStateCallback = usePublisher('scrollContainerState')
     const ScrollerComponent = useEmitterValue('ScrollerComponent')!
     const smoothScrollTargetReached = usePublisher('smoothScrollTargetReached')
@@ -267,10 +258,10 @@ export function buildScroller({ usePublisher, useEmitter, useEmitterValue }: Hoo
 
     useEmitter('scrollTo', scrollToCallback)
     useEmitter('scrollBy', scrollByCallback)
-    return createElement(
+    return React.createElement(
       ScrollerComponent,
       {
-        ref: scrollerRef as MutableRefObject<HTMLDivElement | null>,
+        ref: scrollerRef as React.MutableRefObject<HTMLDivElement | null>,
         style: { ...scrollerStyle, ...style },
         'data-test-id': 'virtuoso-scroller',
         'data-virtuoso-scroller': true,
@@ -285,7 +276,7 @@ export function buildScroller({ usePublisher, useEmitter, useEmitterValue }: Hoo
 }
 
 export function buildWindowScroller({ usePublisher, useEmitter, useEmitterValue }: Hooks) {
-  const Scroller: Components['Scroller'] = memo(function VirtuosoWindowScroller({ style, children, ...props }) {
+  const Scroller: Components['Scroller'] = React.memo(function VirtuosoWindowScroller({ style, children, ...props }) {
     const scrollContainerStateCallback = usePublisher('windowScrollContainerState')
     const ScrollerComponent = useEmitterValue('ScrollerComponent')!
     const smoothScrollTargetReached = usePublisher('smoothScrollTargetReached')
@@ -310,7 +301,7 @@ export function buildWindowScroller({ usePublisher, useEmitter, useEmitterValue 
 
     useEmitter('windowScrollTo', scrollToCallback)
     useEmitter('scrollBy', scrollByCallback)
-    return createElement(
+    return React.createElement(
       ScrollerComponent,
       {
         style: { position: 'relative', ...style, ...(totalListHeight !== 0 ? { height: totalListHeight + deviation } : {}) },
@@ -324,13 +315,13 @@ export function buildWindowScroller({ usePublisher, useEmitter, useEmitterValue 
   return Scroller
 }
 
-const Viewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
-  const ctx = useContext(VirtuosoMockContext)
+const Viewport: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
+  const ctx = React.useContext(VirtuosoMockContext)
   const viewportHeight = usePublisher('viewportHeight')
   const fixedItemHeight = usePublisher('fixedItemHeight')
   const viewportRef = useSize(u.compose(viewportHeight, (el) => correctItemSize(el, 'height')))
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (ctx) {
       viewportHeight(ctx.viewportHeight)
       fixedItemHeight(ctx.itemHeight)
@@ -344,14 +335,14 @@ const Viewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
   )
 }
 
-const WindowViewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
-  const ctx = useContext(VirtuosoMockContext)
+const WindowViewport: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
+  const ctx = React.useContext(VirtuosoMockContext)
   const windowViewportRect = usePublisher('windowViewportRect')
   const fixedItemHeight = usePublisher('fixedItemHeight')
   const customScrollParent = useEmitterValue('customScrollParent')
   const viewportRef = useWindowViewportRectRef(windowViewportRect, customScrollParent)
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (ctx) {
       fixedItemHeight(ctx.itemHeight)
       windowViewportRect({ offsetTop: 0, visibleHeight: ctx.viewportHeight, visibleWidth: 100 })
@@ -365,15 +356,15 @@ const WindowViewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
   )
 }
 
-const TopItemListContainer: FC<PropsWithChildren<unknown>> = ({ children }) => {
+const TopItemListContainer: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   const TopItemList = useEmitterValue('TopItemListComponent')
   const headerHeight = useEmitterValue('headerHeight')
   const style = { ...topItemListStyle, marginTop: `${headerHeight}px` }
   const context = useEmitterValue('context')
-  return createElement(TopItemList || 'div', { style, context }, children)
+  return React.createElement(TopItemList || 'div', { style, context }, children)
 }
 
-const ListRoot: FC<ListRootProps> = /*#__PURE__*/ memo(function VirtuosoRoot(props) {
+const ListRoot: React.FC<ListRootProps> = /*#__PURE__*/ React.memo(function VirtuosoRoot(props) {
   const useWindowScroll = useEmitterValue('useWindowScroll')
   const showTopList = useEmitterValue('topItemsIndexes').length > 0
   const customScrollParent = useEmitterValue('customScrollParent')
@@ -460,9 +451,9 @@ const Scroller = /*#__PURE__*/ buildScroller({ usePublisher, useEmitterValue, us
 const WindowScroller = /*#__PURE__*/ buildWindowScroller({ usePublisher, useEmitterValue, useEmitter })
 
 export const Virtuoso = List as <ItemData = any, Context = any>(
-  props: VirtuosoProps<ItemData, Context> & { ref?: Ref<VirtuosoHandle> }
-) => ReactElement
+  props: VirtuosoProps<ItemData, Context> & { ref?: React.Ref<VirtuosoHandle> }
+) => React.ReactElement
 
 export const GroupedVirtuoso = List as <ItemData = any, Context = any>(
-  props: GroupedVirtuosoProps<ItemData, Context> & { ref?: Ref<GroupedVirtuosoHandle> }
-) => ReactElement
+  props: GroupedVirtuosoProps<ItemData, Context> & { ref?: React.Ref<GroupedVirtuosoHandle> }
+) => React.ReactElement

--- a/src/VirtuosoGrid.tsx
+++ b/src/VirtuosoGrid.tsx
@@ -1,7 +1,7 @@
 import { RefHandle, systemToComponent } from './react-urx'
 
 import * as u from './urx'
-import { memo, createElement, FC, PropsWithChildren, ReactElement, Ref, useContext, useEffect } from 'react'
+import React from 'react'
 import { gridSystem } from './gridSystem'
 import useSize from './hooks/useSize'
 import useWindowViewportRectRef from './hooks/useWindowViewportRect'
@@ -55,7 +55,7 @@ const combinedSystem = /*#__PURE__*/ u.system(([gridSystem, gridComponentPropsSy
   return { ...gridSystem, ...gridComponentPropsSystem }
 }, u.tup(gridSystem, gridComponentPropsSystem))
 
-const GridItems: FC = /*#__PURE__*/ memo(function GridItems() {
+const GridItems: React.FC = /*#__PURE__*/ React.memo(function GridItems() {
   const gridState = useEmitterValue('gridState')
   const listClassName = useEmitterValue('listClassName')
   const itemClassName = useEmitterValue('itemClassName')
@@ -84,7 +84,7 @@ const GridItems: FC = /*#__PURE__*/ memo(function GridItems() {
     })
   })
 
-  return createElement(
+  return React.createElement(
     ListComponent,
     {
       ref: listRef,
@@ -96,14 +96,14 @@ const GridItems: FC = /*#__PURE__*/ memo(function GridItems() {
     gridState.items.map((item) => {
       const key = computeItemKey(item.index, item.data, context)
       return isSeeking
-        ? createElement(ScrollSeekPlaceholder, {
+        ? React.createElement(ScrollSeekPlaceholder, {
             key,
             ...contextPropIfNotDomElement(ScrollSeekPlaceholder, context),
             index: item.index,
             height: gridState.itemHeight,
             width: gridState.itemWidth,
           })
-        : createElement(
+        : React.createElement(
             ItemComponent,
             { ...contextPropIfNotDomElement(ItemComponent, context), className: itemClassName, 'data-index': item.index, key },
             itemContent(item.index, item.data, context)
@@ -112,26 +112,30 @@ const GridItems: FC = /*#__PURE__*/ memo(function GridItems() {
   )
 })
 
-const Header: FC = memo(function VirtuosoHeader() {
+const Header: React.FC = React.memo(function VirtuosoHeader() {
   const Header = useEmitterValue('HeaderComponent')
   const headerHeight = usePublisher('headerHeight')
   const headerFooterTag = useEmitterValue('headerFooterTag')
   const ref = useSize((el) => headerHeight(correctItemSize(el, 'height')))
   const context = useEmitterValue('context')
-  return Header ? createElement(headerFooterTag, { ref }, createElement(Header, contextPropIfNotDomElement(Header, context))) : null
+  return Header
+    ? React.createElement(headerFooterTag, { ref }, React.createElement(Header, contextPropIfNotDomElement(Header, context)))
+    : null
 })
 
-const Footer: FC = memo(function VirtuosoGridFooter() {
+const Footer: React.FC = React.memo(function VirtuosoGridFooter() {
   const Footer = useEmitterValue('FooterComponent')
   const footerHeight = usePublisher('footerHeight')
   const headerFooterTag = useEmitterValue('headerFooterTag')
   const ref = useSize((el) => footerHeight(correctItemSize(el, 'height')))
   const context = useEmitterValue('context')
-  return Footer ? createElement(headerFooterTag, { ref }, createElement(Footer, contextPropIfNotDomElement(Footer, context))) : null
+  return Footer
+    ? React.createElement(headerFooterTag, { ref }, React.createElement(Footer, contextPropIfNotDomElement(Footer, context)))
+    : null
 })
 
-const Viewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
-  const ctx = useContext(VirtuosoGridMockContext)
+const Viewport: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
+  const ctx = React.useContext(VirtuosoGridMockContext)
   const itemDimensions = usePublisher('itemDimensions')
   const viewportDimensions = usePublisher('viewportDimensions')
 
@@ -139,7 +143,7 @@ const Viewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
     viewportDimensions(el.getBoundingClientRect())
   })
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (ctx) {
       viewportDimensions({ height: ctx.viewportHeight, width: ctx.viewportWidth })
       itemDimensions({ height: ctx.itemHeight, width: ctx.itemWidth })
@@ -153,14 +157,14 @@ const Viewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
   )
 }
 
-const WindowViewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
-  const ctx = useContext(VirtuosoGridMockContext)
+const WindowViewport: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
+  const ctx = React.useContext(VirtuosoGridMockContext)
   const windowViewportRect = usePublisher('windowViewportRect')
   const itemDimensions = usePublisher('itemDimensions')
   const customScrollParent = useEmitterValue('customScrollParent')
   const viewportRef = useWindowViewportRectRef(windowViewportRect, customScrollParent)
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (ctx) {
       itemDimensions({ height: ctx.itemHeight, width: ctx.itemWidth })
       windowViewportRect({ offsetTop: 0, visibleHeight: ctx.viewportHeight, visibleWidth: ctx.viewportWidth })
@@ -174,7 +178,7 @@ const WindowViewport: FC<PropsWithChildren<unknown>> = ({ children }) => {
   )
 }
 
-const GridRoot: FC<GridRootProps> = /*#__PURE__*/ memo(function GridRoot({ ...props }) {
+const GridRoot: React.FC<GridRootProps> = /*#__PURE__*/ React.memo(function GridRoot({ ...props }) {
   const useWindowScroll = useEmitterValue('useWindowScroll')
   const customScrollParent = useEmitterValue('customScrollParent')
   const TheScroller = customScrollParent || useWindowScroll ? WindowScroller : Scroller
@@ -249,5 +253,5 @@ function resolveGapValue(property: string, value: string | undefined, log: Log) 
 }
 
 export const VirtuosoGrid = Grid as <ItemData = any, Context = any>(
-  props: VirtuosoGridProps<ItemData, Context> & { ref?: Ref<VirtuosoGridHandle> }
-) => ReactElement
+  props: VirtuosoGridProps<ItemData, Context> & { ref?: React.Ref<VirtuosoGridHandle> }
+) => React.ReactElement

--- a/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,5 +1,5 @@
-import { useEffect, useLayoutEffect } from 'react'
+import React from 'react'
 
-const useIsomorphicLayoutEffect = typeof document !== 'undefined' ? useLayoutEffect : useEffect
+const useIsomorphicLayoutEffect = typeof document !== 'undefined' ? React.useLayoutEffect : React.useEffect
 
 export default useIsomorphicLayoutEffect

--- a/src/hooks/useScrollTop.ts
+++ b/src/hooks/useScrollTop.ts
@@ -1,8 +1,8 @@
-import { useRef, useCallback, useEffect } from 'react'
+import React from 'react'
 import * as u from '../urx'
 import { correctItemSize } from '../utils/correctItemSize'
 import { ScrollContainerState } from '../interfaces'
-import { flushSync } from 'react-dom'
+import ReactDOM from 'react-dom'
 import { approximatelyEqual } from '../utils/approximatelyEqual'
 
 export type ScrollerRef = Window | HTMLElement | null
@@ -14,11 +14,11 @@ export default function useScrollTop(
   scrollerRefCallback: (ref: ScrollerRef) => void = u.noop,
   customScrollParent?: HTMLElement
 ) {
-  const scrollerRef = useRef<HTMLElement | null | Window>(null)
-  const scrollTopTarget = useRef<any>(null)
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const scrollerRef = React.useRef<HTMLElement | null | Window>(null)
+  const scrollTopTarget = React.useRef<any>(null)
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const handler = useCallback(
+  const handler = React.useCallback(
     (ev: Event) => {
       const el = ev.target as HTMLElement
       const windowScroll = (el as any) === window || (el as any) === document
@@ -37,7 +37,7 @@ export default function useScrollTop(
       if ((ev as any).suppressFlushSync) {
         call()
       } else {
-        flushSync(call)
+        ReactDOM.flushSync(call)
       }
 
       if (scrollTopTarget.current !== null) {
@@ -54,7 +54,7 @@ export default function useScrollTop(
     [scrollContainerStateCallback, smoothScrollTargetReached]
   )
 
-  useEffect(() => {
+  React.useEffect(() => {
     const localRef = customScrollParent ? customScrollParent : scrollerRef.current!
 
     scrollerRefCallback(customScrollParent ? customScrollParent : scrollerRef.current)

--- a/src/hooks/useSize.ts
+++ b/src/hooks/useSize.ts
@@ -1,9 +1,9 @@
-import { useRef } from 'react'
+import React from 'react'
 
 export type CallbackRefParam = HTMLElement | null
 
 export function useSizeWithElRef(callback: (e: HTMLElement) => void, enabled = true) {
-  const ref = useRef<CallbackRefParam>(null)
+  const ref = React.useRef<CallbackRefParam>(null)
 
   let callbackRef = (_el: CallbackRefParam) => {
     void 0

--- a/src/hooks/useWindowViewportRect.ts
+++ b/src/hooks/useWindowViewportRect.ts
@@ -1,11 +1,11 @@
-import { useEffect, useRef, useCallback } from 'react'
+import React from 'react'
 import { useSizeWithElRef } from './useSize'
 import { WindowViewportInfo } from '../interfaces'
 
 export default function useWindowViewportRectRef(callback: (info: WindowViewportInfo) => void, customScrollParent?: HTMLElement) {
-  const viewportInfo = useRef<WindowViewportInfo | null>(null)
+  const viewportInfo = React.useRef<WindowViewportInfo | null>(null)
 
-  const calculateInfo = useCallback(
+  const calculateInfo = React.useCallback(
     (element: HTMLElement | null) => {
       if (element === null || !element.offsetParent) {
         return
@@ -38,11 +38,11 @@ export default function useWindowViewportRectRef(callback: (info: WindowViewport
 
   const { callbackRef, ref } = useSizeWithElRef(calculateInfo)
 
-  const scrollAndResizeEventHandler = useCallback(() => {
+  const scrollAndResizeEventHandler = React.useCallback(() => {
     calculateInfo(ref.current)
   }, [calculateInfo, ref])
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (customScrollParent) {
       customScrollParent.addEventListener('scroll', scrollAndResizeEventHandler)
       const observer = new ResizeObserver(scrollAndResizeEventHandler)

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,25 +1,25 @@
-import { ComponentPropsWithRef, ComponentType, Key, ReactNode, HTMLProps } from 'react'
+import React from 'react'
 export interface ListRange {
   startIndex: number
   endIndex: number
 }
 
 export interface ItemContent<D, C> {
-  (index: number, data: D, context: C): ReactNode
+  (index: number, data: D, context: C): React.ReactNode
 }
 
-export type FixedHeaderContent = (() => ReactNode) | null
+export type FixedHeaderContent = (() => React.ReactNode) | null
 
-export type FixedFooterContent = (() => ReactNode) | null
+export type FixedFooterContent = (() => React.ReactNode) | null
 export interface GroupItemContent<D, C> {
-  (index: number, groupIndex: number, data: D, context: C): ReactNode
+  (index: number, groupIndex: number, data: D, context: C): React.ReactNode
 }
 
 export interface GroupContent {
-  (index: number): ReactNode
+  (index: number): React.ReactNode
 }
 
-export type ItemProps<D> = Pick<ComponentPropsWithRef<'div'>, 'style' | 'children'> & {
+export type ItemProps<D> = Pick<React.ComponentPropsWithRef<'div'>, 'style' | 'children'> & {
   'data-index': number
   'data-item-index': number
   'data-item-group-index'?: number
@@ -27,34 +27,38 @@ export type ItemProps<D> = Pick<ComponentPropsWithRef<'div'>, 'style' | 'childre
   item: D
 }
 
-export type GroupProps = Pick<ComponentPropsWithRef<'div'>, 'style' | 'children'> & {
+export type GroupProps = Pick<React.ComponentPropsWithRef<'div'>, 'style' | 'children'> & {
   'data-index': number
   'data-item-index': number
   'data-known-size': number
 }
 
-export type TopItemListProps = Pick<ComponentPropsWithRef<'div'>, 'style' | 'children'>
-export type TableProps = Pick<ComponentPropsWithRef<'table'>, 'style' | 'children'>
+export type TopItemListProps = Pick<React.ComponentPropsWithRef<'div'>, 'style' | 'children'>
+export type TableProps = Pick<React.ComponentPropsWithRef<'table'>, 'style' | 'children'>
 
 /**
  * Passed to the Components.TableBody custom component
  */
-export type TableBodyProps = Pick<ComponentPropsWithRef<'tbody'>, 'style' | 'children' | 'ref' | 'className'> & { 'data-test-id': string }
+export type TableBodyProps = Pick<React.ComponentPropsWithRef<'tbody'>, 'style' | 'children' | 'ref' | 'className'> & {
+  'data-test-id': string
+}
 
 /**
  * Passed to the Components.List custom component
  */
-export type ListProps = Pick<ComponentPropsWithRef<'div'>, 'style' | 'children' | 'ref'> & { 'data-test-id': string }
+export type ListProps = Pick<React.ComponentPropsWithRef<'div'>, 'style' | 'children' | 'ref'> & { 'data-test-id': string }
 
 /**
  * Passed to the Components.List custom component
  */
-export type GridListProps = Pick<ComponentPropsWithRef<'div'>, 'style' | 'children' | 'ref' | 'className'> & { 'data-test-id': string }
+export type GridListProps = Pick<React.ComponentPropsWithRef<'div'>, 'style' | 'children' | 'ref' | 'className'> & {
+  'data-test-id': string
+}
 
 /**
  * Passed to the Components.Scroller custom component
  */
-export type ScrollerProps = Pick<ComponentPropsWithRef<'div'>, 'style' | 'children' | 'tabIndex' | 'ref'> & {
+export type ScrollerProps = Pick<React.ComponentPropsWithRef<'div'>, 'style' | 'children' | 'tabIndex' | 'ref'> & {
   'data-test-id'?: string
   'data-virtuoso-scroller'?: boolean
 }
@@ -93,46 +97,46 @@ export interface Components<Data = unknown, Context = unknown> {
    *
    * The header remains above the top items and does not remain sticky.
    */
-  Header?: ComponentType<{ context?: Context }>
+  Header?: React.ComponentType<{ context?: Context }>
   /**
    * Set to render a component at the bottom of the list.
    */
-  Footer?: ComponentType<{ context?: Context }>
+  Footer?: React.ComponentType<{ context?: Context }>
   /**
    * Set to customize the item wrapping element. Use only if you would like to render list from elements different than a `div`.
    */
-  Item?: ComponentType<ItemProps<Data> & { context?: Context }>
+  Item?: React.ComponentType<ItemProps<Data> & { context?: Context }>
   /**
    * Set to customize the group item wrapping element. Use only if you would like to render list from elements different than a `div`.
    */
-  Group?: ComponentType<GroupProps & { context?: Context }>
+  Group?: React.ComponentType<GroupProps & { context?: Context }>
 
   /**
    * Set to customize the top list item wrapping element. Use if you would like to render list from elements different than a `div`
    * or you want to set a custom z-index for the sticky position.
    */
-  TopItemList?: ComponentType<TopItemListProps & { context?: Context }>
+  TopItemList?: React.ComponentType<TopItemListProps & { context?: Context }>
 
   /**
    * Set to customize the outermost scrollable element. This should not be necessary in general,
    * as the component passes its HTML attribute props to it.
    */
-  Scroller?: ComponentType<ScrollerProps & { context?: Context }>
+  Scroller?: React.ComponentType<ScrollerProps & { context?: Context }>
 
   /**
    * Set to customize the items wrapper. Use only if you would like to render list from elements different than a `div`.
    */
-  List?: ComponentType<ListProps & { context?: Context }>
+  List?: React.ComponentType<ListProps & { context?: Context }>
 
   /**
    * Set to render a custom UI when the list is empty.
    */
-  EmptyPlaceholder?: ComponentType<{ context?: Context }>
+  EmptyPlaceholder?: React.ComponentType<{ context?: Context }>
 
   /**
    * Set to render an item placeholder when the user scrolls fast.  See the `scrollSeek` property for more details.
    */
-  ScrollSeekPlaceholder?: ComponentType<ScrollSeekPlaceholderProps & { context?: Context }>
+  ScrollSeekPlaceholder?: React.ComponentType<ScrollSeekPlaceholderProps & { context?: Context }>
 }
 
 /**
@@ -143,53 +147,53 @@ export interface TableComponents<Data = unknown, Context = unknown> {
    * Set to customize the wrapping `table` element.
    *
    */
-  Table?: ComponentType<TableProps & { context?: Context }>
+  Table?: React.ComponentType<TableProps & { context?: Context }>
 
   /**
    * Set to render a fixed header at the top of the table (`thead`). use [[fixedHeaderHeight]] to set the contents
    *
    */
-  TableHead?: ComponentType<Pick<ComponentPropsWithRef<'thead'>, 'style' | 'ref'> & { context?: Context }>
+  TableHead?: React.ComponentType<Pick<React.ComponentPropsWithRef<'thead'>, 'style' | 'ref'> & { context?: Context }>
 
   /**
    * Set to render a fixed footer at the bottom of the table (`tfoot`). use [[fixedFooterContent]] to set the contents
    */
-  TableFoot?: ComponentType<Pick<ComponentPropsWithRef<'tfoot'>, 'style' | 'ref'> & { context?: Context }>
+  TableFoot?: React.ComponentType<Pick<React.ComponentPropsWithRef<'tfoot'>, 'style' | 'ref'> & { context?: Context }>
 
   /**
    * Set to customize the item wrapping element. Default is `tr`.
    */
-  TableRow?: ComponentType<ItemProps<Data> & { context?: Context }>
+  TableRow?: React.ComponentType<ItemProps<Data> & { context?: Context }>
 
   /**
    * Set to customize the outermost scrollable element. This should not be necessary in general,
    * as the component passes its HTML attribute props to it.
    */
-  Scroller?: ComponentType<ScrollerProps & { context?: Context }>
+  Scroller?: React.ComponentType<ScrollerProps & { context?: Context }>
 
   /**
    * Set to customize the items wrapper. Default is `tbody`.
    */
-  TableBody?: ComponentType<TableBodyProps & { context?: Context }>
+  TableBody?: React.ComponentType<TableBodyProps & { context?: Context }>
 
   /**
    * Set to render a custom UI when the list is empty.
    */
-  EmptyPlaceholder?: ComponentType<{ context?: Context }>
+  EmptyPlaceholder?: React.ComponentType<{ context?: Context }>
 
   /**
    * Set to render an item placeholder when the user scrolls fast.  See the `scrollSeek` property for more details.
    */
-  ScrollSeekPlaceholder?: ComponentType<ScrollSeekPlaceholderProps & { context?: Context }>
+  ScrollSeekPlaceholder?: React.ComponentType<ScrollSeekPlaceholderProps & { context?: Context }>
 
   /**
    * Set to render an empty item placeholder.
    */
-  FillerRow?: ComponentType<FillerRowProps & { context?: Context }>
+  FillerRow?: React.ComponentType<FillerRowProps & { context?: Context }>
 }
 
 export interface ComputeItemKey<D, C> {
-  (index: number, item: D, context: C): Key
+  (index: number, item: D, context: C): React.Key
 }
 
 export interface ScrollSeekToggle {
@@ -266,9 +270,9 @@ export interface GroupIndexLocationWithAlign extends LocationOptions {
 
 export type IndexLocationWithAlign = FlatIndexLocationWithAlign | GroupIndexLocationWithAlign
 
-export type ListRootProps = Omit<HTMLProps<HTMLDivElement>, 'ref' | 'data'>
-export type TableRootProps = Omit<HTMLProps<HTMLTableElement>, 'ref' | 'data'>
-export type GridRootProps = Omit<HTMLProps<HTMLDivElement>, 'ref' | 'data'>
+export type ListRootProps = Omit<React.HTMLProps<HTMLDivElement>, 'ref' | 'data'>
+export type TableRootProps = Omit<React.HTMLProps<HTMLTableElement>, 'ref' | 'data'>
+export type GridRootProps = Omit<React.HTMLProps<HTMLDivElement>, 'ref' | 'data'>
 
 export interface GridItem<D> {
   index: number
@@ -284,44 +288,44 @@ export interface GridComponents<Context = any> {
   /**
    * Set to customize the item wrapping element. Use only if you would like to render list from elements different than a `div`.
    */
-  Item?: ComponentType<GridItemProps & { context?: Context }>
+  Item?: React.ComponentType<GridItemProps & { context?: Context }>
 
   /**
    * Set to customize the outermost scrollable element. This should not be necessary in general,
    * as the component passes its HTML attribute props to it.
    */
-  Scroller?: ComponentType<ScrollerProps & { context?: Context }>
+  Scroller?: React.ComponentType<ScrollerProps & { context?: Context }>
 
   /**
    * Set to customize the items wrapper. Use only if you would like to render list from elements different than a `div`.
    */
-  List?: ComponentType<GridListProps & { context?: Context }>
+  List?: React.ComponentType<GridListProps & { context?: Context }>
 
   /**
    * Set to render a component at the top of the list.
    *
    * The header remains above the top items and does not remain sticky.
    */
-  Header?: ComponentType<{ context?: Context }>
+  Header?: React.ComponentType<{ context?: Context }>
 
   /**
    * Set to render a component at the bottom of the list.
    */
-  Footer?: ComponentType<{ context?: Context }>
+  Footer?: React.ComponentType<{ context?: Context }>
 
   /**
    * Set to render an item placeholder when the user scrolls fast.
    * See the `scrollSeekConfiguration` property for more details.
    */
-  ScrollSeekPlaceholder?: ComponentType<GridScrollSeekPlaceholderProps & { context?: Context }>
+  ScrollSeekPlaceholder?: React.ComponentType<GridScrollSeekPlaceholderProps & { context?: Context }>
 }
 
 export interface GridComputeItemKey<D, C> {
-  (index: number, item: D, context: C): Key
+  (index: number, item: D, context: C): React.Key
 }
 
 export interface GridItemContent<D, C> {
-  (index: number, data: D, context: C): ReactNode
+  (index: number, data: D, context: C): React.ReactNode
 }
 
 export interface WindowViewportInfo {

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,11 +1,11 @@
-import { createContext } from 'react'
+import React from 'react'
 
 export interface VirtuosoMockContextValue {
   viewportHeight: number
   itemHeight: number
 }
 
-export const VirtuosoMockContext = createContext<VirtuosoMockContextValue | undefined>(undefined)
+export const VirtuosoMockContext = React.createContext<VirtuosoMockContextValue | undefined>(undefined)
 
 export interface VirtuosoGridMockContextValue {
   viewportHeight: number
@@ -14,4 +14,4 @@ export interface VirtuosoGridMockContextValue {
   itemWidth: number
 }
 
-export const VirtuosoGridMockContext = createContext<VirtuosoGridMockContextValue | undefined>(undefined)
+export const VirtuosoGridMockContext = React.createContext<VirtuosoGridMockContextValue | undefined>(undefined)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,11 @@ const ext = {
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react({
+      jsxRuntime: 'classic',
+    }),
+  ],
   build: {
     minify: 'terser',
     lib: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,8 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 const ext = {
-  cjs: 'js',
-  es: 'es.js',
+  cjs: 'cjs',
+  es: 'mjs',
 }
 
 // https://vitejs.dev/config/

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,8 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 const ext = {
-  cjs: 'cjs',
-  es: 'mjs',
+  cjs: 'js',
+  es: 'es.js',
 }
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
Relates to https://github.com/petyosi/react-virtuoso/issues/814 and 2103a3354697081af597b43b916eae8bba415271.

The mjs extension specifically is problematic, as some bundlers expect everything from that file down to also be proper ESM. In this lib, the React imports specifically are problematic for webpack, as react is not distributed as ESM, so I get these errors after upgrading:

> ERROR in ./node_modules/react-virtuoso/dist/index.mjs 363:31-44 Can't import the named export 'createContext' from non EcmaScript module (only default export is available)

I'm not sure if changing the extension is the only solution, but it's definitely the easy one, I verified that changing this in node_modules works and requires no major changes on the consumer side (I still have to pass it through babel-loader, but that's a small thing).

I also removed the cjs extension, though that won't likely cause issues, as cjs is a bit better in terms of cross compatibility. I can revert that part, if necessary.

Figured filing a PR is easier than an issue, as the change is so small. Let me know what you think.