### PR TITLE
fix: skip recalc if data changes before totalCount

### DIFF
--- a/examples/remove-items.tsx
+++ b/examples/remove-items.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+import { useState } from 'react'
+import { Virtuoso } from '../src'
+
+interface User {
+  name: string
+}
+
+const users: User[] = [
+  {
+    name: 'Sheila Robel',
+  },
+  {
+    name: 'Brian Bernier',
+  },
+  {
+    name: 'Destiny Hegmann',
+  },
+  {
+    name: 'Demetrius Schaden',
+  },
+  {
+    name: 'Tara Smitham',
+  },
+]
+
+export function Example() {
+  const [list, setList] = useState(users)
+
+  const remove = (user: User) => {
+    setList((prevList) => prevList.filter((u) => u.name !== user.name))
+  }
+
+  return (
+    <Virtuoso
+      style={{ height: 1000 }}
+      data={list}
+      // eslint-disable-next-line no-console
+      itemsRendered={(props) => console.log('items rendered', props)}
+      fixedItemHeight={80}
+      itemContent={(index, user) => (
+        <div>
+          <h4>
+            {user.name}
+            <button onClick={() => remove(user)}>Close</button>
+          </h4>
+        </div>
+      )}
+    />
+  )
+}

--- a/src/listStateSystem.ts
+++ b/src/listStateSystem.ts
@@ -173,8 +173,8 @@ export const listStateSystem = u.system(
         u.filter(([mount, recalcInProgress, , totalCount, , , , , , , data]) => {
           // When data length changes, it is synced to totalCount, both of which trigger a recalc separately.
           // Recalc should be skipped then, as the calculation expects both data and totalCount to be in sync.
-          const isTotalCountInSync = data ? totalCount === data.length : true
-          return mount && !recalcInProgress && isTotalCountInSync
+          const dataChangeInProgress = data && data.length !== totalCount
+          return mount && !recalcInProgress && !dataChangeInProgress
         }),
         u.map(
           ([

--- a/src/listStateSystem.ts
+++ b/src/listStateSystem.ts
@@ -170,8 +170,11 @@ export const listStateSystem = u.system(
           u.duc(gap),
           data
         ),
-        u.filter(([mount, recalcInProgress]) => {
-          return mount && !recalcInProgress
+        u.filter(([mount, recalcInProgress, , totalCount, , , , , , , data]) => {
+          // When data length changes, it is synced to totalCount, both of which trigger a recalc separately.
+          // Recalc should be skipped then, as the calculation expects both data and totalCount to be in sync.
+          const isTotalCountInSync = data ? totalCount === data.length : true
+          return mount && !recalcInProgress && isTotalCountInSync
         }),
         u.map(
           ([

--- a/test/Virtuoso.test.tsx
+++ b/test/Virtuoso.test.tsx
@@ -176,4 +176,93 @@ describe('Virtuoso', () => {
 
     expect(listParent.firstElementChild.textContent).toBe('Item 1')
   })
+
+  it('updates when data is propagated (reduced length)', () => {
+    const itemsRendered = vi.fn()
+    const Case = () => {
+      const [data, setData] = React.useState([{ name: 'Item 0' }, { name: 'Item 1' }] as any[])
+
+      return (
+        <>
+          <Virtuoso
+            data={data}
+            itemContent={(_: number, item: { name: string }) => {
+              return item.name
+            }}
+            itemsRendered={itemsRendered}
+          />
+          <button onClick={() => setData([{ name: 'Item 1' }])}>Set Data</button>
+        </>
+      )
+    }
+
+    act(() => {
+      ReactDOM.createRoot(container).render(<Case />)
+    })
+
+    itemsRendered.mockClear()
+
+    const scroller = container.firstElementChild as any
+    const viewport = scroller.firstElementChild
+    const listParent = viewport.firstElementChild
+
+    act(() => {
+      scroller.triggerScroll({ scrollTop: 0, scrollHeight: 700, viewportHeight: 200 })
+      viewport.triggerResize({ getBoundingClientRect: () => ({ height: 100 }) })
+      listParent.triggerChangedChildSizes([{ startIndex: 0, endIndex: 0, size: 10 }])
+    })
+
+    expect(itemsRendered).toHaveBeenCalledTimes(2)
+    expect(itemsRendered).toHaveBeenNthCalledWith(1, [
+      {
+        data: {
+          name: 'Item 0',
+        },
+        index: 0,
+        offset: 0,
+        originalIndex: 0,
+        size: 0,
+      },
+    ])
+    expect(itemsRendered).toHaveBeenNthCalledWith(2, [
+      {
+        data: {
+          name: 'Item 0',
+        },
+        index: 0,
+        offset: 0,
+        originalIndex: 0,
+        size: 10,
+      },
+      {
+        data: {
+          name: 'Item 1',
+        },
+        index: 1,
+        offset: 10,
+        originalIndex: 1,
+        size: 10,
+      },
+    ])
+    itemsRendered.mockClear()
+
+    act(() => {
+      container.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(itemsRendered).toHaveBeenCalledTimes(1)
+    expect(itemsRendered).toHaveBeenCalledWith([
+      {
+        data: {
+          name: 'Item 1',
+        },
+        index: 0,
+        offset: 0,
+        originalIndex: 0,
+        size: 10,
+      },
+    ])
+
+    expect(listParent.firstElementChild.textContent).toBe('Item 1')
+  })
 })


### PR DESCRIPTION
Fixes #809. Skipping the recalc if totalCount is not in sync with data.length seems to fix the issue, but I'm not entirely sure if there is maybe some better way of ensuring that the updates would be batched?