### PR TITLE
docs: update the default code copy button color

### DIFF
--- a/site/docusaurus-sandpack/src/theme/CodeBlock/style.css
+++ b/site/docusaurus-sandpack/src/theme/CodeBlock/style.css
@@ -21,7 +21,7 @@
   top: 1.5em;
 
   z-index: 99;
-  color: #fff;
+  color: #393A34;
 
   opacity: 0;
 


### PR DESCRIPTION
The copy button is not displayed well on the current code block background, so fix it.

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/3297859/227554759-d041e7c8-ddbf-42fc-919a-c6891a1f34e0.png">
