### PR TITLE
perf: Optimize useSize performance when apply fixedItemHeight

### DIFF
--- a/src/hooks/useSize.ts
+++ b/src/hooks/useSize.ts
@@ -5,11 +5,16 @@ export type CallbackRefParam = HTMLElement | null
 export function useSizeWithElRef(callback: (e: HTMLElement) => void, enabled = true) {
   const ref = React.useRef<CallbackRefParam>(null)
 
-  let callbackRef = (_el: CallbackRefParam) => {
-    void 0
+  let callbackRef = (elRef: CallbackRefParam) => {
+    if (elRef) {
+      callback(elRef)
+      ref.current = elRef
+    } else {
+      ref.current = null
+    }
   }
 
-  if (typeof ResizeObserver !== 'undefined') {
+  if (typeof ResizeObserver !== 'undefined' && enabled) {
     const observer = new ResizeObserver((entries: ResizeObserverEntry[]) => {
       const element = entries[0].target as HTMLElement
       if (element.offsetParent !== null) {
@@ -18,7 +23,7 @@ export function useSizeWithElRef(callback: (e: HTMLElement) => void, enabled = t
     })
 
     callbackRef = (elRef: CallbackRefParam) => {
-      if (elRef && enabled) {
+      if (elRef) {
         observer.observe(elRef)
         ref.current = elRef
       } else {


### PR DESCRIPTION
When apply `fixedItemHeight`, there is no need to new ResizeObserver.

It cost 2ms each item in `new ResizeObserver`.

There is almost cost 300ms in TableVirtuoso with 170 items.
![image](https://user-images.githubusercontent.com/5857931/228468210-b35b9445-a066-46dd-89fc-8191643b8a05.png)
