### PR TITLE
refactor(endless-scrolling.md): remove unecessary useMemo and useRef

### DIFF
--- a/docs/scenarios/endless-scrolling.md
+++ b/docs/scenarios/endless-scrolling.md
@@ -16,7 +16,7 @@ Scroll fast to the bottom of the list to load additional items.
 ```jsx live include-data
 import { Virtuoso } from 'react-virtuoso'
 import { generateUsers } from './data'
-import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 
 export default function App() {
   const [users, setUsers] = useState(() => [])


### PR DESCRIPTION
Remove unnecessary useMemo and useRef from the code snippet present on page https://virtuoso.dev/endless-scrolling/