### PR TITLE
feat: allow deeply nested groups in GroupedVirtuoso

### DIFF
--- a/examples/grouped.tsx
+++ b/examples/grouped.tsx
@@ -4,7 +4,7 @@ import { GroupedVirtuoso } from '../src'
 export function Example() {
   return (
     <GroupedVirtuoso
-      groupCounts={Array.from({ length: 20 }).fill(3) as number[]}
+      groupCounts={[2, [2, 3], [2, 3, [1, 2]]]}
       itemContent={(index) => <div style={{ height: '20px' }}>Item {index}</div>}
       groupContent={(index) => <div style={{ height: '30px', backgroundColor: 'gray' }}>Group {index}</div>}
       style={{ height: '300px' }}

--- a/src/component-interfaces/Virtuoso.ts
+++ b/src/component-interfaces/Virtuoso.ts
@@ -254,12 +254,13 @@ export interface VirtuosoProps<D, C> extends ListRootProps {
   restoreStateFrom?: StateSnapshot
 }
 
+type NestedArray<T> = Array<T | NestedArray<T>>
 export interface GroupedVirtuosoProps<D, C> extends Omit<VirtuosoProps<D, C>, 'totalCount' | 'itemContent'> {
   /**
    * Specifies the amount of items in each group (and, actually, how many groups are there).
    * For example, passing [20, 30] will display 2 groups with 20 and 30 items each.
    */
-  groupCounts?: number[]
+  groupCounts?: NestedArray<number>
 
   /**
    * Specifies how each each group header gets rendered. The callback receives the zero-based index of the group.


### PR DESCRIPTION
This is a draft to see if it's something you would accept. I have components that need deeply nested groups (up to 4 levels deep at this time). I'm currently accomplishing this with a custom usage of Virtuoso by indenting my items based on their level in the hierarchy. It works, but it doesn't benefit from the sticky group headers. It seemed like things were mostly setup to accommodate more than one level of groups in GroupedVirtuoso, so I thought I'd try it out.

This implementation seems to work - all tests pass, and the updated grouped example renders the groups as I would expect (though they're not indented). The only missing piece in my mind is to somehow communicate to the consumer the hierarchy of groups and items. I was thinking about tracking the `level` of groups and items and passing that to the `itemContent` and `groupContent` renderers. But I wanted to get this out here to get feedback before going any further.

The way this works, is it treats an array in `groupCounts` as another group, starting a new level. So with the following values passed to `groupCounts`: `[2, [2, 3], [2, 3, [1, 2]]]`, the levels of the first few would look like this:

![image](https://github.com/petyosi/react-virtuoso/assets/66479/ec30381e-0d33-46da-a698-9a6ae635165e)


First group has 2 items then a group that has two groups with 2 and 3 items respectively, and so on.