### PR TITLE
fix: move stable item style to outside scope

### DIFF
--- a/src/TableVirtuoso.tsx
+++ b/src/TableVirtuoso.tsx
@@ -70,6 +70,8 @@ const DefaultFillerRow = ({ height }: { height: number }) => (
   </tr>
 )
 
+const ITEM_STYLE = { overflowAnchor: 'none' } as const
+
 const Items = /*#__PURE__*/ React.memo(function VirtuosoItems() {
   const listState = useEmitterValue('listState')
   const sizeRanges = usePublisher('sizeRanges')
@@ -146,7 +148,7 @@ const Items = /*#__PURE__*/ React.memo(function VirtuosoItems() {
         'data-known-size': item.size,
         'data-item-index': item.index,
         item: item.data,
-        style: { overflowAnchor: 'none' },
+        style: ITEM_STYLE,
       },
       itemContent(item.index, item.data, context)
     )


### PR DESCRIPTION
I've been using your library recently and stumbled across an issue. When scrolling, the style of TableRow is changing between rerenders, which stops it from being properly memoized.

I traced this back to inline styles changing the referential equality between renders. So, I made a small tweak: I moved the stable style to an outside scope. Now, the TableRow is memoizing like a champ.

I saw something similar being done in the Virtuoso component (https://github.com/petyosi/react-virtuoso/blob/cb156cc3009cc544ca31eb30041ef35c4a278f8d/src/Virtuoso.tsx#L68), so I guess it's in line with your usual patterns.

To help illustrate the impact of this change, I've taken before-and-after snapshots from React's profiler tab (modified example from https://virtuoso.dev/table-fixed-headers/). 
before: 
<img width="1591" alt="Screenshot 2023-07-17 at 23 37 17" src="https://github.com/petyosi/react-virtuoso/assets/7099901/9f154d6b-1d2a-4a6c-8164-e4c725ed022a">
after:
<img width="1589" alt="Screenshot 2023-07-17 at 23 36 15" src="https://github.com/petyosi/react-virtuoso/assets/7099901/cf39f00b-928c-446d-aef2-bb5a72abe8ca">


Would love to hear what you think about this. If it seems like a good fix, it'd be cool to see it become part of the library.

Thanks for your time, and kudos for your fantastic work in open-source 🙇 .