### PR TITLE
feat: offset the `initialItemCount` with the `initialTopMostItem`

### DIFF
--- a/test/ssr.test.tsx
+++ b/test/ssr.test.tsx
@@ -13,6 +13,7 @@ describe('SSR List', () => {
     const html = ReactDOMServer.renderToString(<Virtuoso id="root" totalCount={20000} initialItemCount={30} />)
     const { document } = new JSDOM(html).window
 
+    expect(document.querySelector('#root > div > div')!.getAttribute('style')).not.toMatch('visibility:hidden')
     expect(document.querySelector('#root > div > div')!.childElementCount).toEqual(30)
   })
 
@@ -20,6 +21,28 @@ describe('SSR List', () => {
     const html = ReactDOMServer.renderToString(<VirtuosoGrid id="root" totalCount={20000} initialItemCount={30} />)
     const { document } = new JSDOM(html).window
     expect(document.querySelector('#root > div > div')!.childElementCount).toEqual(30)
+    expect(document.querySelector('#root > div > div > div')?.innerHTML).toEqual('Item 0')
+  })
+
+  it('renders 30 grid items with offset', () => {
+    const html = ReactDOMServer.renderToString(
+      <Virtuoso
+        id="root"
+        data={[
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34,
+          35, 36, 37, 38, 39, 40,
+        ]}
+        totalCount={20000}
+        initialItemCount={30}
+        initialTopMostItemIndex={10}
+        itemContent={(_: number, item: any) => `Item ${item}`}
+      />
+    )
+    const { document } = new JSDOM(html).window
+
+    expect(document.querySelector('#root > div > div')!.getAttribute('style')).not.toMatch('visibility:hidden')
+    expect(document.querySelector('#root > div > div')!.childElementCount).toEqual(30)
+    expect(document.querySelector('#root > div > div > div')?.innerHTML).toEqual('Item 10')
   })
 
   it('renders 3 groups and their children', () => {


### PR DESCRIPTION
Currently, when using `initialItemCount`, it would always render the first `N`
items (starting at 0). With this change, it will still render N items, but start at the offset provided by `initialTopMostItem`.

This PR contains the work performed by @TrueCarry for issue #361 plus some changes based on the feedback provided there. 

There is one issue however: due to the filter for `scrolledToInitialItem`, the rendered items will always have a `visibility: hidden` (unless the offset is 0, thus recreating the old behaviour). This would mean that, while the correct section will be rendered, it will be hidden.
https://github.com/petyosi/react-virtuoso/blob/16b418b8fae443b59ad379850b9b7d2be2c69e61/src/initialTopMostItemIndexSystem.ts#L22-L30

I have added a test case to test this, but I am not quite sure how to resolve this without breaking some of the other tests (this is my first time looking at the source code for Virtuoso). As such, some feedback would be greatly appreciated. 