### PR TITLE
feat(table): preserve tr:nth-child(odd/even)

### DIFF
--- a/examples/table-markup.css
+++ b/examples/table-markup.css
@@ -1,0 +1,3 @@
+.table table tbody tr:nth-child(odd) {
+    background-color: lightgray;
+}

--- a/examples/table-markup.tsx
+++ b/examples/table-markup.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react'
 import { TableVirtuoso, TableVirtuosoHandle } from '../src/'
 
+import './table-markup.css'
+
 export function Example() {
   const ref = React.useRef<TableVirtuosoHandle>(null)
   return (
     <>
       <TableVirtuoso
         ref={ref}
+        className="table"
         totalCount={1000}
         components={{
           EmptyPlaceholder: () => {


### PR DESCRIPTION
In tables CSS styling, you often use the :nth-child(odd/even) to altern background colors for each line. With virtualisation, you can loose this: the colors are switching when an item is "undisplayed"....

With this PR, I add a second FillerRow with zero height when there's already one displayed and the first displayed item original index is even...

(only for TableVirtuoso, I still have to figure out how to do the same thing in Virtuoso - seems a bit more tricky with groups 😅)