### PR TITLE
fix: prevent adding context as an attribute of the TopItemList's DOM element

### DIFF
--- a/src/Virtuoso.tsx
+++ b/src/Virtuoso.tsx
@@ -363,11 +363,11 @@ const WindowViewport: React.FC<React.PropsWithChildren<unknown>> = ({ children }
 }
 
 const TopItemListContainer: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
-  const TopItemList = useEmitterValue('TopItemListComponent')
+  const TopItemList = useEmitterValue('TopItemListComponent') || 'div'
   const headerHeight = useEmitterValue('headerHeight')
   const style = { ...topItemListStyle, marginTop: `${headerHeight}px` }
   const context = useEmitterValue('context')
-  return React.createElement(TopItemList || 'div', { style, context }, children)
+  return React.createElement(TopItemList, { style, ...contextPropIfNotDomElement(TopItemList, context) }, children)
 }
 
 const ListRoot: React.FC<ListRootProps> = /*#__PURE__*/ React.memo(function VirtuosoRoot(props) {


### PR DESCRIPTION
I just found a small mistake. Context appears as an attribute of the DOM element.

<img width="508" alt="image" src="https://github.com/petyosi/react-virtuoso/assets/4821962/e7473e26-cdf1-4331-8970-386bc5c7f971">