### PR TITLE
fix: stop "Zero-sized element, this should not happen" error from showing up when it should not

### DIFF
--- a/src/hooks/useSize.ts
+++ b/src/hooks/useSize.ts
@@ -12,12 +12,12 @@ export function useSizeWithElRef(callback: (e: HTMLElement) => void, enabled = t
   if (typeof ResizeObserver !== 'undefined') {
     const observer = React.useMemo(() => {
       return new ResizeObserver((entries: ResizeObserverEntry[]) => {
-        const element = entries[0].target as HTMLElement
-        if (element.offsetParent !== null) {
-          requestAnimationFrame(() => {
-            callback(element)
-          })
-        }
+        requestAnimationFrame(() => {
+          const element = entries[0].target as HTMLElement
+            if (element.offsetParent !== null) {
+              callback(element)
+            }
+        })
       })
     }, [callback])
 

--- a/src/hooks/useSize.ts
+++ b/src/hooks/useSize.ts
@@ -14,9 +14,9 @@ export function useSizeWithElRef(callback: (e: HTMLElement) => void, enabled = t
       return new ResizeObserver((entries: ResizeObserverEntry[]) => {
         requestAnimationFrame(() => {
           const element = entries[0].target as HTMLElement
-            if (element.offsetParent !== null) {
-              callback(element)
-            }
+          if (element.offsetParent !== null) {
+            callback(element)
+          }
         })
       })
     }, [callback])


### PR DESCRIPTION
this should fix #1060 

Very ugly and extreme example where it happens: https://codesandbox.io/p/sandbox/red-glitter-hcqz3d?file=%2FApp.js%3A62%2C1 
After fix: https://codesandbox.io/p/sandbox/hungry-roentgen-3ff9yp