### PR TITLE
fix: adjust the way used to set data-test-id for TableBody

### DIFF
--- a/src/TableVirtuoso.tsx
+++ b/src/TableVirtuoso.tsx
@@ -163,7 +163,7 @@ const Items = /*#__PURE__*/ React.memo(function VirtuosoItems() {
 
   return React.createElement(
     TableBodyComponent,
-    { ref: callbackRef, 'data-test-id': 'virtuoso-item-list', ...contextPropIfNotDomElement(TableBodyComponent, context) },
+    { ref: callbackRef, 'data-testid': 'virtuoso-item-list', ...contextPropIfNotDomElement(TableBodyComponent, context) },
     [paddingTopEl, ...items, paddingBottomEl]
   )
 })

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -40,7 +40,7 @@ export type TableProps = Pick<React.ComponentProps<'table'>, 'style' | 'children
  * Passed to the Components.TableBody custom component
  */
 export type TableBodyProps = Pick<React.ComponentProps<'tbody'>, 'style' | 'children' | 'className'> & {
-  'data-test-id': string
+  'data-testid': string
 } & React.RefAttributes<HTMLTableSectionElement>
 
 /**

--- a/test/__snapshots__/VirtuosoMockContext.test.tsx.snap
+++ b/test/__snapshots__/VirtuosoMockContext.test.tsx.snap
@@ -220,7 +220,7 @@ exports[`VirtuosoMockContext > Table > correctly renders items 1`] = `
         style="border-spacing: 0; overflow-anchor: none;"
       >
         <tbody
-          data-test-id="virtuoso-item-list"
+          data-testid="virtuoso-item-list"
         >
           <tr
             data-index="0"
@@ -281,7 +281,7 @@ exports[`VirtuosoMockContext > Table > correctly renders items with useWindowScr
         style="border-spacing: 0; overflow-anchor: none;"
       >
         <tbody
-          data-test-id="virtuoso-item-list"
+          data-testid="virtuoso-item-list"
         >
           <tr
             data-index="0"


### PR DESCRIPTION
## Overview
I'm trying to integrate `react-virtuoso` with MUI table in my current project, also it is also based on testing-library: `ByTestId`https://testing-library.com/docs/queries/bytestid/, when tried to use `ByTestId` and found it probably might be needed to change

## Changes
- instead of setting table with test id like `data-test-id`, but set table with `data-testid` as its test id

## Check
<img width="892" alt="Screenshot 2024-04-17 at 14 55 41" src="https://github.com/petyosi/react-virtuoso/assets/65659727/418047f4-8b26-4940-96c5-91cb81ca474c">

## Conclusion
If it seems like a good fix, it'd be cool to see it become part of the library. Thanks for your time, and kudos for your fantastic works in open-source 🙇