### PR TITLE
fix: adjust the way used to set data test Scroller, List, GridList

### DIFF
--- a/src/Virtuoso.tsx
+++ b/src/Virtuoso.tsx
@@ -134,7 +134,7 @@ const Items = /*#__PURE__*/ React.memo(function VirtuosoItems({ showTopList = fa
       ...contextPropIfNotDomElement(ListComponent, context),
       ref: callbackRef,
       style: containerStyle,
-      'data-test-id': showTopList ? 'virtuoso-top-item-list' : 'virtuoso-item-list',
+      'data-testid': showTopList ? 'virtuoso-top-item-list' : 'virtuoso-item-list',
     },
     (showTopList ? listState.topItems : listState.items).map((item) => {
       const index = item.originalIndex!

--- a/src/Virtuoso.tsx
+++ b/src/Virtuoso.tsx
@@ -270,7 +270,7 @@ export function buildScroller({ usePublisher, useEmitter, useEmitterValue }: Hoo
       {
         ref: scrollerRef as React.MutableRefObject<HTMLDivElement | null>,
         style: { ...scrollerStyle, ...style },
-        'data-test-id': 'virtuoso-scroller',
+        'data-testid': 'virtuoso-scroller',
         'data-virtuoso-scroller': true,
         tabIndex: 0,
         ...props,

--- a/src/VirtuosoGrid.tsx
+++ b/src/VirtuosoGrid.tsx
@@ -99,7 +99,7 @@ const GridItems: React.FC = /*#__PURE__*/ React.memo(function GridItems() {
       className: listClassName,
       ...contextPropIfNotDomElement(ListComponent, context),
       style: { paddingTop: gridState.offsetTop, paddingBottom: gridState.offsetBottom },
-      'data-test-id': 'virtuoso-item-list',
+      'data-testid': 'virtuoso-item-list',
     },
     gridState.items.map((item) => {
       const key = computeItemKey(item.index, item.data, context)

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -47,7 +47,7 @@ export type TableBodyProps = Pick<React.ComponentProps<'tbody'>, 'style' | 'chil
  * Passed to the Components.List custom component
  */
 export type ListProps = Pick<React.ComponentProps<'div'>, 'style' | 'children'> & {
-  'data-test-id': string
+  'data-testid': string
 } & React.RefAttributes<HTMLDivElement>
 
 /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -68,7 +68,7 @@ export type GridItemProps = Pick<React.ComponentProps<'div'>, 'style' | 'childre
  * Passed to the Components.Scroller custom component
  */
 export type ScrollerProps = Pick<React.ComponentProps<'div'>, 'style' | 'children' | 'tabIndex'> & {
-  'data-test-id'?: string
+  'data-testid'?: string
   'data-virtuoso-scroller'?: boolean
 } & React.RefAttributes<HTMLDivElement>
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -54,7 +54,7 @@ export type ListProps = Pick<React.ComponentProps<'div'>, 'style' | 'children'> 
  * Passed to the Components.List custom component
  */
 export type GridListProps = Pick<React.ComponentProps<'div'>, 'style' | 'children' | 'className'> & {
-  'data-test-id': string
+  'data-testid': string
 } & React.RefAttributes<HTMLDivElement>
 
 /**

--- a/test/__snapshots__/VirtuosoMockContext.test.tsx.snap
+++ b/test/__snapshots__/VirtuosoMockContext.test.tsx.snap
@@ -127,7 +127,7 @@ exports[`VirtuosoMockContext > List > correctly renders items 1`] = `
       style="width: 100%; height: 100%; position: absolute; top: 0px;"
     >
       <div
-        data-test-id="virtuoso-item-list"
+        data-testid="virtuoso-item-list"
         style="box-sizing: border-box; padding-top: 0px; padding-bottom: 500px; margin-top: 0px;"
       >
         <div
@@ -171,7 +171,7 @@ exports[`VirtuosoMockContext > List > correctly renders items with useWindowScro
       style="width: 100%; height: 100%; position: absolute; top: 0px;"
     >
       <div
-        data-test-id="virtuoso-item-list"
+        data-testid="virtuoso-item-list"
         style="box-sizing: border-box; padding-top: 0px; padding-bottom: 500px; margin-top: 0px;"
       >
         <div

--- a/test/__snapshots__/VirtuosoMockContext.test.tsx.snap
+++ b/test/__snapshots__/VirtuosoMockContext.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`VirtuosoMockContext > Grid > correctly renders items 1`] = `
 <div>
   <div
-    data-test-id="virtuoso-scroller"
+    data-testid="virtuoso-scroller"
     data-virtuoso-scroller="true"
     style="height: 100%; outline: none; overflow-y: auto; position: relative;"
     tabindex="0"
@@ -117,7 +117,7 @@ exports[`VirtuosoMockContext > Grid > correctly renders items with useWindowScro
 exports[`VirtuosoMockContext > List > correctly renders items 1`] = `
 <div>
   <div
-    data-test-id="virtuoso-scroller"
+    data-testid="virtuoso-scroller"
     data-virtuoso-scroller="true"
     style="height: 100%; outline: none; overflow-y: auto; position: relative;"
     tabindex="0"
@@ -207,7 +207,7 @@ exports[`VirtuosoMockContext > List > correctly renders items with useWindowScro
 exports[`VirtuosoMockContext > Table > correctly renders items 1`] = `
 <div>
   <div
-    data-test-id="virtuoso-scroller"
+    data-testid="virtuoso-scroller"
     data-virtuoso-scroller="true"
     style="height: 100%; outline: none; overflow-y: auto; position: relative;"
     tabindex="0"

--- a/test/__snapshots__/VirtuosoMockContext.test.tsx.snap
+++ b/test/__snapshots__/VirtuosoMockContext.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`VirtuosoMockContext > Grid > correctly renders items 1`] = `
     >
       <div
         class="virtuoso-grid-list"
-        data-test-id="virtuoso-item-list"
+        data-testid="virtuoso-item-list"
         style="padding-top: 0px; padding-bottom: 100px;"
       >
         <div
@@ -69,7 +69,7 @@ exports[`VirtuosoMockContext > Grid > correctly renders items with useWindowScro
     >
       <div
         class="virtuoso-grid-list"
-        data-test-id="virtuoso-item-list"
+        data-testid="virtuoso-item-list"
         style="padding-top: 0px; padding-bottom: 100px;"
       >
         <div


### PR DESCRIPTION
## Overview
Adjust the way used to set data test `Scroller`, `List`, `GridList`

## Changes
- Instead of setting `Scroller`, `List`, `GridList` with test id like `data-test-id`, but set them with `data-testid` as its test id

## Check
<img width="902" alt="Screenshot 2024-04-18 at 13 23 08" src="https://github.com/petyosi/react-virtuoso/assets/65659727/cdc38950-5bc8-4b89-8646-ef3dce7cbf9d">

## Conclusion
When looked into e2e tests in current main branch, it seems there're adjustments needed, but it could be separately to another PR only for fixing current e2e tests.

If purpose of this PR is focused enough and  seems like a good fix, it'd be cool to see it become part of the library. Thanks for your time, and kudos for your fantastic works in open-source 🙇