### PR TITLE
fix: update `initialTopMostItemIndex` type in `TableVirtuoso` interface

### DIFF
--- a/src/component-interfaces/TableVirtuoso.ts
+++ b/src/component-interfaces/TableVirtuoso.ts
@@ -13,6 +13,7 @@ import type {
   TableComponents,
   StateSnapshot,
   StateCallback,
+  IndexLocationWithAlign,
 } from '../interfaces'
 import type { VirtuosoProps } from './Virtuoso'
 
@@ -59,8 +60,9 @@ export interface TableVirtuosoProps<D, C> extends Omit<VirtuosoProps<D, C>, 'com
 
   /**
    * Set to a value between 0 and totalCount - 1 to make the list start scrolled to that item.
+   * Pass in an object to achieve additional effects similar to `scrollToIndex`.
    */
-  initialTopMostItemIndex?: number
+  initialTopMostItemIndex?: number | IndexLocationWithAlign
 
   /**
    * Set this value to offset the initial location of the list.


### PR DESCRIPTION
Hey @petyosi! First of all, thanks for the awesome library!

I've noticed that `initialTopMostItemIndex` in `<TableVirtuoso />` has type `number`, but `IndexLocationWithAlign` is also supported.

[Demo](https://shortlurl.com/6650acc92d00b)

<img width="1001" alt="Screenshot at May 24 16-58-28" src="https://github.com/petyosi/react-virtuoso/assets/20929344/6ccb2be2-870d-48ac-8932-b8eec743cbb9">
