### PR TITLE
add shouldDisableIntersectionObserverCallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-virtuoso",
+  "name": "fyf-react-virtuoso",
   "author": "Petyo Ivanov",
   "sideEffects": false,
   "version": "0.0.0-semantic-release",

--- a/src/VirtuosoGrid.tsx
+++ b/src/VirtuosoGrid.tsx
@@ -17,7 +17,7 @@ const gridComponentPropsSystem = /*#__PURE__*/ u.system(() => {
   const components = u.statefulStream<GridComponents>({})
   const context = u.statefulStream<unknown>(null)
   const itemClassName = u.statefulStream('virtuoso-grid-item')
-  const shouldDisableIntersectionObserverCallback = u.statefulStream('shouldDisableIntersectionObserverCallback')
+  const shouldDisableIntersectionObserverCallback = u.statefulStream<(el: HTMLElement) => boolean>(() => false)
   const listClassName = u.statefulStream('virtuoso-grid-list')
   const computeItemKey = u.statefulStream<GridComputeItemKey<any, any>>(identity)
   const headerFooterTag = u.statefulStream('div')
@@ -76,9 +76,9 @@ const GridItems: React.FC = /*#__PURE__*/ React.memo(function GridItems() {
   const stateRestoreInProgress = useEmitterValue('stateRestoreInProgress')
 
   const listRef = useSize((el) => {
-    const shouldDisable = shouldDisableIntersectionObserverCallback(el);
+    const shouldDisable = shouldDisableIntersectionObserverCallback(el)
 
-    if (shouldDisable) return;
+    if (shouldDisable) return
 
     const scrollHeight = el.parentElement!.parentElement!.scrollHeight
     scrollHeightCallback(scrollHeight)

--- a/src/VirtuosoGrid.tsx
+++ b/src/VirtuosoGrid.tsx
@@ -17,6 +17,7 @@ const gridComponentPropsSystem = /*#__PURE__*/ u.system(() => {
   const components = u.statefulStream<GridComponents>({})
   const context = u.statefulStream<unknown>(null)
   const itemClassName = u.statefulStream('virtuoso-grid-item')
+  const shouldDisableIntersectionObserverCallback = u.statefulStream('shouldDisableIntersectionObserverCallback')
   const listClassName = u.statefulStream('virtuoso-grid-list')
   const computeItemKey = u.statefulStream<GridComputeItemKey<any, any>>(identity)
   const headerFooterTag = u.statefulStream('div')
@@ -40,6 +41,7 @@ const gridComponentPropsSystem = /*#__PURE__*/ u.system(() => {
     computeItemKey,
     itemClassName,
     listClassName,
+    shouldDisableIntersectionObserverCallback,
     headerFooterTag,
     scrollerRef,
     FooterComponent: distinctProp('Footer'),
@@ -57,6 +59,7 @@ const combinedSystem = /*#__PURE__*/ u.system(([gridSystem, gridComponentPropsSy
 
 const GridItems: React.FC = /*#__PURE__*/ React.memo(function GridItems() {
   const gridState = useEmitterValue('gridState')
+  const shouldDisableIntersectionObserverCallback = useEmitterValue('shouldDisableIntersectionObserverCallback')
   const listClassName = useEmitterValue('listClassName')
   const itemClassName = useEmitterValue('itemClassName')
   const itemContent = useEmitterValue('itemContent')
@@ -73,6 +76,10 @@ const GridItems: React.FC = /*#__PURE__*/ React.memo(function GridItems() {
   const stateRestoreInProgress = useEmitterValue('stateRestoreInProgress')
 
   const listRef = useSize((el) => {
+    const shouldDisable = shouldDisableIntersectionObserverCallback(el);
+
+    if (shouldDisable) return;
+
     const scrollHeight = el.parentElement!.parentElement!.scrollHeight
     scrollHeightCallback(scrollHeight)
     const firstItem = el.firstChild as HTMLElement
@@ -222,6 +229,7 @@ const {
       initialItemCount: 'initialItemCount',
       scrollSeekConfiguration: 'scrollSeekConfiguration',
       headerFooterTag: 'headerFooterTag',
+      shouldDisableIntersectionObserverCallback: 'shouldDisableIntersectionObserverCallback',
       listClassName: 'listClassName',
       itemClassName: 'itemClassName',
       useWindowScroll: 'useWindowScroll',

--- a/src/component-interfaces/VirtuosoGrid.ts
+++ b/src/component-interfaces/VirtuosoGrid.ts
@@ -126,6 +126,12 @@ export interface VirtuosoGridProps<D, C = unknown> extends GridRootProps {
   listClassName?: string
 
   /**
+   * Whether to disable the re-rendering of the grid list on scroll, resize etc.
+   * This is needed for elements like fullscreen video mode which affects element sizes even when you don't want it to.
+   */
+  shouldDisableIntersectionObserverCallback: (el: HTMLElement) => boolean
+
+  /**
    * Sets the grid items' className
    */
   itemClassName?: string

--- a/src/component-interfaces/VirtuosoGrid.ts
+++ b/src/component-interfaces/VirtuosoGrid.ts
@@ -129,7 +129,7 @@ export interface VirtuosoGridProps<D, C = unknown> extends GridRootProps {
    * Whether to disable the re-rendering of the grid list on scroll, resize etc.
    * This is needed for elements like fullscreen video mode which affects element sizes even when you don't want it to.
    */
-  shouldDisableIntersectionObserverCallback: (el: HTMLElement) => boolean
+  shouldDisableIntersectionObserverCallback?: (el: HTMLElement) => boolean
 
   /**
    * Sets the grid items' className


### PR DESCRIPTION
Why is this needed?

When you have a responsive grid that changes size and you have html5 video elements in that grid, when the user goes fullscreen it affects the size of the elements in the grid and causes a re-render due to the intersectionObserver (i debugged this a lot and it seems to just be how the fullscreen API works, i.e it affects the parent element of the fullscreen size).

When a user is going fullscreen mode you never want this to happen, you just want to disable this re-rendering from happening.

The solution is to provide a callback and disable this when in fullScreenMode.

Here's my implementation of it:

```ts
  const [currentFullscreenElement, setCurrentFullscreenElement] = useState(null)
  const previousFullscreenElement = useRef(null)

  useEffect(() => {
    const handleFullscreenChange = () => {
      previousFullscreenElement.current = currentFullscreenElement

      setCurrentFullscreenElement(document.fullscreenElement)

      if (document.fullscreenElement === null) {
        // kind of hacky to use setTimeout but it's needed to allow enough time for the intersectionObserver stuff to finish and then reset the previous element when going out of fullscreen
        setTimeout(() => {
          previousFullscreenElement.current = document.fullscreenElement
        }, 500)
      }
    }

    document.addEventListener('fullscreenchange', handleFullscreenChange)

    return () => {
      document.removeEventListener('fullscreenchange', handleFullscreenChange)
    }
  }, [currentFullscreenElement])

 const shouldDisableIntersectionObserverCallback = useCallback(() => {
    const disable =
      document.fullscreenElement !== null ||
      previousFullscreenElement.current !== null

    return disable
  }, [])
  
 <VirtuosoGrid
      shouldDisableIntersectionObserverCallback={
        shouldDisableIntersectionObserverCallback
      }
    />
```