### PR TITLE
feat: topItemCount for TableVirtuoso

### DIFF
--- a/src/component-interfaces/TableVirtuoso.ts
+++ b/src/component-interfaces/TableVirtuoso.ts
@@ -17,7 +17,7 @@ import type {
 } from '../interfaces'
 import type { VirtuosoProps } from './Virtuoso'
 
-export interface TableVirtuosoProps<D, C> extends Omit<VirtuosoProps<D, C>, 'components' | 'headerFooterTag' | 'topItemCount'> {
+export interface TableVirtuosoProps<D, C> extends Omit<VirtuosoProps<D, C>, 'components' | 'headerFooterTag'> {
   /**
    * Use the `components` property for advanced customization of the elements rendered by the table.
    */
@@ -32,6 +32,11 @@ export interface TableVirtuosoProps<D, C> extends Omit<VirtuosoProps<D, C>, 'com
    * Set the contents of the table footer.
    */
   fixedFooterContent?: FixedFooterContent
+
+  /**
+   * Set the amount of items to remain fixed at the top of the table.
+   */
+  topItemCount?: number
 
   /**
    * The total amount of items to be rendered.


### PR DESCRIPTION
Resolves #1130 .
I wanted to separate topItems from items as in `Virtuoso.tsx`, but in the case of `TableVirtsuoso.tsx`, the Items component contains a TableBodyComponent, so I could not put a TableRowComponent outside of it, and So, this is how it is implemented.
If you have any ideas for a better implementation, I'd be happy to point them out.