### PR TITLE
feat: Adds GroupedTableVirtuoso to support grouping on tables

### DIFF
--- a/apps/virtuoso.dev/docs/guides/table-virtuoso/table-grouped.md
+++ b/apps/virtuoso.dev/docs/guides/table-virtuoso/table-grouped.md
@@ -1,0 +1,59 @@
+---
+id: table-grouped
+title: Table Virtuoso Example with Grouped Items
+sidebar_label: Table with Grouped Items
+slug: /table-grouped/
+---
+
+If set, the `fixedHeaderContent` property specifies the content of the `thead` element. The header element remains fixed while scrolling.
+Ensure that the header elements are not transparent. Otherwise, the table cells will be visible.
+
+## Table with `fixedHeaderContent`
+
+```tsx live
+import { TableVirtuoso } from 'react-virtuoso'
+import { useMemo } from 'react'
+
+export default function App() {
+  const groupCounts = useMemo(() => {
+    return Array(10).fill(10)
+  }, [])
+
+  const users = useMemo(() => {
+    return groupCounts.flatMap((count, index) =>
+      Array.from({ length: count }, (_, i) => ({
+        name: `User ${index * count + i}`,
+        description: `Description for user ${index * count + i}`,
+        group: index,
+      }))
+    )
+  }, [])
+
+  return (
+    <TableVirtuoso
+      style={{ height: '100%', '--background': 'whitesmoke' }}
+      groupCounts={groupCounts}
+      fixedHeaderContent={() => (
+        <tr>
+          <th style={{ height: 50, width: 150, background: 'var(--background)' }}>Name</th>
+          <th style={{ background: 'var(--background)' }}>Description</th>
+        </tr>
+      )}
+      groupContent={(index) => (
+        <td colSpan={1000} style={{ height: 30, background: 'var(--background)' }}>
+          Group {index}
+        </td>
+      )}
+      itemContent={(index, groupIndex) => {
+        const user = users[index]
+        return (
+          <>
+            <td style={{ width: 150 }}>{user.name}</td>
+            <td>{user.description}</td>
+          </>
+        )
+      }}
+    />
+  )
+}
+```

--- a/apps/virtuoso.dev/docs/guides/table-virtuoso/table-grouped.md
+++ b/apps/virtuoso.dev/docs/guides/table-virtuoso/table-grouped.md
@@ -1,14 +1,14 @@
 ---
 id: table-grouped
-title: Table Virtuoso Example with Grouped Items
-sidebar_label: Table with Grouped Items
+title: Table Virtuoso Example with Grouped Rows
+sidebar_label: Grouped Rows
 slug: /table-grouped/
 ---
 
 If set, the `fixedHeaderContent` property specifies the content of the `thead` element. The header element remains fixed while scrolling.
-Ensure that the header elements are not transparent. Otherwise, the table cells will be visible.
+Ensure that the header elements and the group elements are not transparent. Otherwise, the table cells will be visible.
 
-## Table with `fixedHeaderContent`
+## Table with grouped rows
 
 ```tsx live
 import { TableVirtuoso } from 'react-virtuoso'
@@ -34,13 +34,13 @@ export default function App() {
       style={{ height: '100%', '--background': 'whitesmoke' }}
       groupCounts={groupCounts}
       fixedHeaderContent={() => (
-        <tr>
-          <th style={{ height: 50, width: 150, background: 'var(--background)' }}>Name</th>
-          <th style={{ background: 'var(--background)' }}>Description</th>
+        <tr style={{ background: 'var(--background)' }}>
+          <th style={{ width: 150 }}>Name</th>
+          <th>Description</th>
         </tr>
       )}
       groupContent={(index) => (
-        <td colSpan={1000} style={{ height: 30, background: 'var(--background)' }}>
+        <td colSpan={1000} style={{ background: 'var(--background)', fontWeight: 'bold' }}>
           Group {index}
         </td>
       )}

--- a/packages/react-virtuoso/src/component-interfaces/TableVirtuoso.ts
+++ b/packages/react-virtuoso/src/component-interfaces/TableVirtuoso.ts
@@ -5,10 +5,13 @@ import type {
   FlatIndexLocationWithAlign,
   FlatScrollIntoViewLocation,
   FollowOutput,
+  GroupContent,
+  GroupItemContent,
   IndexLocationWithAlign,
   ItemContent,
   ListItem,
   ListRange,
+  ScrollIntoViewLocationOptions,
   ScrollSeekConfiguration,
   SizeFunction,
   StateCallback,
@@ -17,16 +20,23 @@ import type {
 } from '../interfaces'
 import type { VirtuosoProps } from './Virtuoso'
 
-export interface TableVirtuosoHandle {
+interface BaseTableVirtuosoHandle {
   /**
    * Obtains the internal size state of the component, so that it can be restored later. This does not include the data items.
    */
   getState(stateCb: StateCallback): void
   scrollBy(location: ScrollToOptions): void
-  scrollIntoView(location: FlatScrollIntoViewLocation | number): void
   scrollTo(location: ScrollToOptions): void
+}
 
+export interface TableVirtuosoHandle extends BaseTableVirtuosoHandle {
+  scrollIntoView(location: FlatScrollIntoViewLocation | number): void
   scrollToIndex(location: FlatIndexLocationWithAlign | number): void
+}
+
+export interface GroupedTableVirtuosoHandle extends BaseTableVirtuosoHandle {
+  scrollIntoView(location: ScrollIntoViewLocationOptions): void
+  scrollToIndex(location: IndexLocationWithAlign | number): void
 }
 
 export interface TableVirtuosoProps<D, C> extends Omit<VirtuosoProps<D, C>, 'components' | 'headerFooterTag'> {
@@ -241,4 +251,37 @@ export interface TableVirtuosoProps<D, C> extends Omit<VirtuosoProps<D, C>, 'com
    * Uses the document scroller rather than wrapping the list in its own.
    */
   useWindowScroll?: boolean
+}
+
+export interface GroupedTableVirtuosoProps<D, C> extends Omit<TableVirtuosoProps<D, C>, 'itemContent' | 'totalCount'> {
+  /**
+   * Use when implementing inverse infinite scrolling, decrease the value this property
+   * in combination with a change in `groupCounts` to prepend groups items to the top of the list.
+   * Both new groups and extending the top group is supported.
+   *
+   * The delta of the firstItemIndex should equal the amount of new items introduced, without the group themselves.
+   * As an example, if you prepend 2 groups with 20 and 30 items each, the firstItemIndex should be decreased with 50.
+   *
+   * You can also prepend more items to the first group, for example:
+   * `{ groupCounts: [20, 30], firstItemIndex: 1000 }` can become `{ groupCounts: [10, 30, 30], firstItemIndex: 980 }`
+   *
+   * Warning: the firstItemIndex should **be a positive number**, based on the total amount of items to be displayed.
+   */
+  firstItemIndex?: number
+
+  /**
+   * Specifies how each each group header gets rendered. The callback receives the zero-based index of the group.
+   */
+  groupContent?: GroupContent<C>
+
+  /**
+   * Specifies the amount of items in each group (and, actually, how many groups are there).
+   * For example, passing [20, 30] will display 2 groups with 20 and 30 items each.
+   */
+  groupCounts?: number[]
+
+  /**
+   * Specifies how each each item gets rendered.
+   */
+  itemContent?: GroupItemContent<D, C>
 }

--- a/packages/react-virtuoso/src/interfaces.ts
+++ b/packages/react-virtuoso/src/interfaces.ts
@@ -385,6 +385,11 @@ export interface TableComponents<Data = unknown, Context = unknown> {
   TableBody?: React.ComponentType<TableBodyProps & ContextProp<Context>>
 
   /**
+   * Set to customize the group item wrapping element. Use only if you would like to render list from elements different than a `tr`.
+   */
+  Group?: React.ComponentType<GroupProps & ContextProp<Context>>
+
+  /**
    * Set to render a fixed footer at the bottom of the table (`tfoot`). use [[fixedFooterContent]] to set the contents
    */
   TableFoot?: React.ComponentType<


### PR DESCRIPTION
I'm interested in leveraging the functionality added in #792, but it seems that PR has stalled out.

It appears `topList` support had been added to TableVirtuoso since that PR was active, which did most of the heavy lifting. The issues with height calculations from #792 were most likely due to trying to include the sticky group items in the `thead`, as opposed to `tbody`/`<Items />` as they are here.

Let me know if there's anything I can do to clean this up to prepare it for release, and thanks for your great work on this package! The `react-urx` FRP systems were fun to explore