### PR TITLE
wip: scroll into view on change prop

### DIFF
--- a/packages/react-virtuoso/examples/scroll-into-view-on-change.tsx
+++ b/packages/react-virtuoso/examples/scroll-into-view-on-change.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+
+import { Virtuoso, VirtuosoHandle } from '../src'
+
+export function Example() {
+  const ref = React.useRef<VirtuosoHandle>(null)
+  const [currentItemIndex, setCurrentItemIndex] = React.useState(-1)
+  const [nextIndex, setNextIndex] = React.useState(-1)
+  const [count, setCount] = React.useState(100)
+  const increment = 50
+  const bottomOffset = 10
+
+  return (
+    <div>
+      <button
+        id="add-and-scroll"
+        style={{ whiteSpace: 'nowrap' }}
+        onClick={() => {
+          const newCount = count + increment
+          setNextIndex(newCount - bottomOffset)
+          setCount(newCount)
+          return false
+        }}
+      >
+        Add {increment} and go to {count + (increment - bottomOffset)}
+      </button>
+      <Virtuoso
+        ref={ref}
+        totalCount={count}
+        context={{ currentItemIndex, nextIndex }}
+        scrollIntoViewOnChange={({ context: { nextIndex } }) => {
+          return {
+            align: `start`,
+            index: nextIndex,
+            behavior: 'auto',
+            done: () => {
+              setCurrentItemIndex(nextIndex)
+            },
+          }
+        }}
+        itemContent={(index, _, { currentItemIndex }) => (
+          <div style={{ background: 'white', color: index === currentItemIndex ? 'red' : 'black', height: 50 }}>Item {index}</div>
+        )}
+        style={{ height: 300 }}
+      />
+    </div>
+  )
+}

--- a/packages/react-virtuoso/src/Virtuoso.tsx
+++ b/packages/react-virtuoso/src/Virtuoso.tsx
@@ -21,7 +21,6 @@ export function identity<T>(value: T) {
 
 const listComponentPropsSystem = /*#__PURE__*/ u.system(() => {
   const itemContent = u.statefulStream<GroupItemContent<any, any> | ItemContent<any, any>>((index: number) => `Item ${index}`)
-  const context = u.statefulStream<unknown>(null)
   const groupContent = u.statefulStream<GroupContent<any>>((index: number) => `Group ${index}`)
   const components = u.statefulStream<Components<any>>({})
   const computeItemKey = u.statefulStream<ComputeItemKey<any, any>>(identity)
@@ -42,7 +41,6 @@ const listComponentPropsSystem = /*#__PURE__*/ u.system(() => {
   return {
     components,
     computeItemKey,
-    context,
     EmptyPlaceholder: distinctProp('EmptyPlaceholder'),
     FooterComponent: distinctProp('Footer'),
     GroupComponent: distinctProp('Group', 'div'),
@@ -482,6 +480,7 @@ export const {
       restoreStateFrom: 'restoreStateFrom',
       context: 'context',
       followOutput: 'followOutput',
+      scrollIntoViewOnChange: 'scrollIntoViewOnChange',
       itemContent: 'itemContent',
       groupContent: 'groupContent',
       overscan: 'overscan',

--- a/packages/react-virtuoso/src/component-interfaces/Virtuoso.ts
+++ b/packages/react-virtuoso/src/component-interfaces/Virtuoso.ts
@@ -203,6 +203,18 @@ export interface VirtuosoProps<D, C> extends ListRootProps {
   followOutput?: FollowOutput
 
   /**
+   * Implement this callback if you want to adjust the list position when the list total count changes.
+   * Return a `ScrollIntoViewLocation` object to scroll to a specific item, or falsey value to avoid scrolling.
+   * Use the context contents if you need to implement custom logic based on the current state of the list.
+   */
+  scrollIntoViewOnChange?: (params: {
+    context: C
+    totalCount: number
+    scrollingInProgress: boolean
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+  }) => ScrollIntoViewLocation | null | undefined | false | void
+
+  /**
    * Set to customize the wrapper tag for the header and footer components (default is `div`).
    */
   headerFooterTag?: string

--- a/packages/react-virtuoso/src/contextSystem.ts
+++ b/packages/react-virtuoso/src/contextSystem.ts
@@ -1,0 +1,9 @@
+import * as u from './urx'
+
+export const contextSystem = u.system(() => {
+  const context = u.statefulStream<unknown>(null)
+
+  return {
+    context,
+  }
+})

--- a/packages/react-virtuoso/src/listSystem.ts
+++ b/packages/react-virtuoso/src/listSystem.ts
@@ -1,4 +1,5 @@
 import { alignToBottomSystem } from './alignToBottomSystem'
+import { contextSystem } from './contextSystem'
 import { domIOSystem } from './domIOSystem'
 import { followOutputSystem } from './followOutputSystem'
 import { groupedListSystem } from './groupedListSystem'
@@ -32,6 +33,7 @@ const featureGroup1System = u.system(
     windowScroller,
     scrollIntoView,
     logger,
+    context,
   ]) => {
     return {
       ...sizeRange,
@@ -44,6 +46,7 @@ const featureGroup1System = u.system(
       ...windowScroller,
       ...scrollIntoView,
       ...logger,
+      ...context,
     }
   },
   u.tup(
@@ -56,7 +59,8 @@ const featureGroup1System = u.system(
     alignToBottomSystem,
     windowScrollerSystem,
     scrollIntoViewSystem,
-    loggerSystem
+    loggerSystem,
+    contextSystem
   )
 )
 


### PR DESCRIPTION
Related to #1276 . It's less invasive and aligns with the `followOutput` prop design. 