### PR TITLE
Drop `engines` field

### DIFF
--- a/apps/virtuoso.dev/package.json
+++ b/apps/virtuoso.dev/package.json
@@ -77,9 +77,6 @@
       "last 5 safari version"
     ]
   },
-  "engines": {
-    "node": "22"
-  },
   "prettier": {
     "printWidth": 140,
     "semi": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,6 @@
       "devDependencies": {
         "@changesets/cli": "^2.27.12",
         "turbo": "^2.4.4"
-      },
-      "engines": {
-        "node": "22"
       }
     },
     "apps/virtuoso.dev": {
@@ -70,9 +67,6 @@
         "eslint-plugin-react-hooks": "^5.1.0",
         "prettier": "^3.4.2",
         "typedoc-plugin-no-inherit": "^1.6.1"
-      },
-      "engines": {
-        "node": "22"
       }
     },
     "apps/virtuoso.dev/node_modules/esbuild-wasm": {
@@ -35803,9 +35797,6 @@
         "vite-plugin-dts": "^4.5.0",
         "vitest": "^3.0.4"
       },
-      "engines": {
-        "node": "22"
-      },
       "peerDependencies": {
         "react": ">= 18 || >= 19",
         "react-dom": ">= 18 || >= 19"
@@ -35899,7 +35890,7 @@
       }
     },
     "packages/react-virtuoso": {
-      "version": "4.13.0",
+      "version": "4.14.0",
       "license": "MIT",
       "devDependencies": {
         "@emotion/core": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     "@changesets/cli": "^2.27.12",
     "turbo": "^2.4.4"
   },
-  "engines": {
-    "node": "22"
-  },
   "packageManager": "npm@10.8.2",
   "workspaces": [
     "packages/*",

--- a/packages/masonry/package.json
+++ b/packages/masonry/package.json
@@ -72,9 +72,6 @@
     "vite-plugin-dts": "^4.5.0",
     "vitest": "^3.0.4"
   },
-  "engines": {
-    "node": "22"
-  },
   "files": [
     "dist",
     "CHANGELOG.md"


### PR DESCRIPTION
This PR is similar to https://github.com/petyosi/react-virtuoso/issues/1185.

I've removed the `engines`, all apps, and packages to ensure this would not break our users' development experience.