### PR TITLE
Stick Virtuoso Group Header also horizontally

### DIFF
--- a/packages/react-virtuoso/src/Virtuoso.tsx
+++ b/packages/react-virtuoso/src/Virtuoso.tsx
@@ -230,6 +230,7 @@ export const viewportStyle: (alignToBottom: boolean) => React.CSSProperties = (a
 const topItemListStyle: React.CSSProperties = {
   position: positionStickyCssValue(),
   top: 0,
+  left: 0,
   width: '100%',
   zIndex: 1,
 }


### PR DESCRIPTION
When Virtuoso has a horizontal scrollbar and user moved the scrollbar... the header actually didn't stick.

With this fix, the header sticks both vertically and horizontally.