### PR TITLE
feat: add prependItems and shiftItems methods to GroupedVirtuoso

### DIFF
--- a/.changeset/honest-lies-strive.md
+++ b/.changeset/honest-lies-strive.md
@@ -1,0 +1,5 @@
+---
+"react-virtuoso": major
+---
+
+Add prependItems and shiftItems methods to GroupedVirtuoso to prevent flicker when adding/removing items from the beginning

--- a/package-lock.json
+++ b/package-lock.json
@@ -35663,7 +35663,7 @@
     },
     "packages/masonry": {
       "name": "@virtuoso.dev/masonry",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "@virtuoso.dev/gurx": "*"
@@ -35787,7 +35787,7 @@
       }
     },
     "packages/react-virtuoso": {
-      "version": "4.14.0",
+      "version": "4.14.1",
       "license": "MIT",
       "devDependencies": {
         "@emotion/core": "^11.0.0",

--- a/packages/react-virtuoso/examples/grouped-prepend-imperative.tsx
+++ b/packages/react-virtuoso/examples/grouped-prepend-imperative.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react'
+import { GroupedVirtuoso, GroupedVirtuosoHandle } from '../src'
+
+const ITEMS_PER_GROUP = 10
+const INITIAL_GROUP_COUNT = 21
+const FIRST_ITEM_INDEX = 20000
+const ITEMS_PER_PREPEND = 100
+
+export function GroupedPrependImperative() {
+  const virtuosoRef = React.useRef<GroupedVirtuosoHandle>(null)
+  const [firstItemIndex, setFirstItemIndex] = React.useState(FIRST_ITEM_INDEX)
+  const [groupCounts, setGroupCounts] = React.useState(() => {
+    return Array.from({ length: INITIAL_GROUP_COUNT }, () => ITEMS_PER_GROUP)
+  })
+
+  const prepend = React.useCallback(() => {
+    virtuosoRef.current?.prependItems?.({ groupIndex: 0, count: ITEMS_PER_PREPEND })
+
+    setFirstItemIndex((val) => val - ITEMS_PER_PREPEND)
+    setGroupCounts((prev) => {
+      const result = [...prev]
+      result[0] = (result[0] || 0) + ITEMS_PER_PREPEND
+      return result
+    })
+  }, [])
+
+  return (
+    <div>
+      <button onClick={prepend} style={{ marginBottom: '10px', padding: '10px', background: 'blue', color: 'white' }}>
+        Prepend {ITEMS_PER_PREPEND} items (Imperative API - No Flicker)
+      </button>
+      <GroupedVirtuoso
+        ref={virtuosoRef}
+        firstItemIndex={firstItemIndex}
+        groupCounts={groupCounts}
+        groupContent={(index) => <div style={{ backgroundColor: '#f5f5f5', height: '30px', padding: '5px' }}>Group {index}</div>}
+        itemContent={(index) => <div style={{ height: '20px', padding: '2px' }}>Item {index}</div>}
+        style={{ height: '400px', border: '1px solid #ccc' }}
+      />
+    </div>
+  )
+}
+export function GroupedPrependAndShift() {
+  const ref = React.useRef<GroupedVirtuosoHandle>(null)
+  const [firstItemIndex, setFirstItemIndex] = React.useState(20000)
+  const [groupCounts, setGroupCounts] = React.useState<number[]>(() => Array(21).fill(10))
+
+  const prepend = () => {
+    ref.current?.prependItems?.({ groupIndex: 0, count: 100 })
+
+    setFirstItemIndex((v) => v - 100)
+    setGroupCounts((p) => {
+      const result = [...p]
+      result[0] = (result[0] || 0) + 100
+      return result
+    })
+  }
+
+  const shift = () => {
+    const removeCount = Math.min(100, groupCounts[0] || 0)
+    if (removeCount === 0) return
+
+    ref.current?.shiftItems?.({ groupIndex: 0, count: removeCount })
+
+    setFirstItemIndex((v) => v + removeCount)
+    setGroupCounts((p) => {
+      const result = [...p]
+      result[0] = Math.max(0, result[0] - removeCount)
+      return result
+    })
+  }
+
+  return (
+    <div>
+      <button onClick={prepend}>Prepend 100</button>
+      <button onClick={shift}>Remove 100 from start</button>
+      <GroupedVirtuoso
+        ref={ref}
+        firstItemIndex={firstItemIndex}
+        groupCounts={groupCounts}
+        groupContent={(i) => <div style={{ background: '#f5f5f5', height: '30px' }}>Group {i}</div>}
+        itemContent={(i) => <div style={{ height: '20px' }}>Item {i}</div>}
+        style={{ height: '400px' }}
+      />
+    </div>
+  )
+}

--- a/packages/react-virtuoso/src/Virtuoso.tsx
+++ b/packages/react-virtuoso/src/Virtuoso.tsx
@@ -514,6 +514,8 @@ export const {
       scrollBy: 'scrollBy',
       autoscrollToBottom: 'autoscrollToBottom',
       getState: 'getState',
+      prependItems: 'prependItems',
+      shiftItems: 'shiftItems',
     },
     events: {
       isScrolling: 'isScrolling',

--- a/packages/react-virtuoso/src/component-interfaces/Virtuoso.ts
+++ b/packages/react-virtuoso/src/component-interfaces/Virtuoso.ts
@@ -29,6 +29,8 @@ export interface GroupedVirtuosoHandle {
   scrollBy(location: ScrollToOptions): void
   scrollIntoView(location: number | ScrollIntoViewLocation): void
   scrollTo(location: ScrollToOptions): void
+  prependItems?: (config: { groupIndex: number; count: number }) => void
+  shiftItems?: (config: { groupIndex: number; count: number }) => void
 
   scrollToIndex(location: IndexLocationWithAlign | number): void
 }


### PR DESCRIPTION
## Fixes #1291
Adds two imperative methods to GroupedVirtuoso to prevent flicker when adding/removing items from the beginning of the list.

## Problem
When prepending items, updating firstItemIndex and groupCounts via separate React state updates causes visible flicker because they render in different frames.

## Solution
Added two methods that update internal urx streams atomically.

prependItems({ groupIndex, count }) - Add items to the beginning
shiftItems({ groupIndex, count }) - Remove items from the beginning

Both methods synchronize state updates and adjust scroll position to maintain visual stability.

## Usage

 `
import { GroupedVirtuoso, **GroupedVirtuosoHandle** } from "react-virtuoso";

**const ref = useRef<GroupedVirtuosoHandle>(null);**

const prepend = React.useCallback((amount: number) => () => {
  //Call imperative API to synchronize internal state for prepended items
  **ref.current?.prependItems?.({ groupIndex: 0, count: amount });**

// Or, to remove items
  **ref.current?.shiftItems?.({ groupIndex: 0, count: 100 });**

// Update React state
  setFirstItemIndex((val) => val - amount);
  setGroupCounts((prevGroups) => {
    const result = [...prevGroups];
    result[0] += amount;
    return result;
  });
}, []);

// Pass ref to component
<GroupedVirtuoso **ref={ref}** {...props} />;
`

## Testing
- ✅All existing tests pass (151 passed)
- ✅TypeScript compilation successful
- ✅Linting passes
- ✅Examples added demonstrating both operations
