### PR TITLE
feat: add scrollElementRef prop and deprecate useWindowScroll

### DIFF
--- a/.changeset/scroll-element-ref.md
+++ b/.changeset/scroll-element-ref.md
@@ -1,0 +1,6 @@
+---
+'react-virtuoso': minor
+'@virtuoso.dev/masonry': minor
+---
+
+Add `scrollElementRef` prop to all virtuoso components (Virtuoso, VirtuosoGrid, TableVirtuoso, VirtuosoMasonry) for using an external scroll container via a React ref. Deprecate `useWindowScroll` and `customScrollParent` in favor of the new prop.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,6 @@ jobs:
         run: |
           gh pr merge --squash --auto "${{ steps.changesets.outputs.pullRequestNumber }}"
 
-
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v6

--- a/packages/gurx/CHANGELOG.md
+++ b/packages/gurx/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Patch Changes
 
 - [#1369](https://github.com/petyosi/react-virtuoso/pull/1369) [`5b57a93`](https://github.com/petyosi/react-virtuoso/commit/5b57a93ea047dbb9351bfd5786be496bc6ee9b14) Thanks [@petyosi](https://github.com/petyosi)! - Reduce per-publish CPU cost and fix memory leaks in the reactive engine
-
   - Cache `combineCells()` by source set to prevent orphaned graph nodes on repeated calls
   - Clean up `subMultiple()` synthetic nodes on unsubscribe
   - Fast-path `pub()` to skip object allocation for single-node publishes

--- a/packages/masonry/src/VirtuosoMasonry.tsx
+++ b/packages/masonry/src/VirtuosoMasonry.tsx
@@ -5,7 +5,16 @@ import { Realm, RealmContext, useCellValue, useCellValues, useRealm } from '@vir
 
 import { DefaultItemContent, itemContent$ } from './content'
 import { context$, data$ } from './data'
-import { listOffset$, scrollHeight$, scrollTop$, useWindowScroll$, viewportHeight$, viewportWidth$ } from './dom'
+import {
+  hasExternalScroller$,
+  listOffset$,
+  scrollElementRef$,
+  scrollHeight$,
+  scrollTop$,
+  useWindowScroll$,
+  viewportHeight$,
+  viewportWidth$,
+} from './dom'
 import { masonryItemsState$ } from './masonry-item-state'
 import { absoluteSizes$, columnCount$, indexesInColumns$, initialItemCount$, knownSizes$, masonryRanges$ } from './masonry-sizes'
 
@@ -70,8 +79,24 @@ export interface VirtuosoMasonryProps<Data, Context> extends ScrollerProps {
   ItemContent?: NoInfer<ItemContent<Data, Context>>
   /**
    * Set to true to make the component use the document scroller instead of creating an element with `overflow-y: auto`.
+   * @deprecated Use {@link scrollElementRef} instead.
    */
   useWindowScroll?: boolean
+  /**
+   * Pass a ref to an external scrollable element to use as the scroll container
+   * instead of the component's built-in scroller. This replaces `useWindowScroll`.
+   *
+   * @example
+   * ```tsx
+   * const scrollerRef = useRef<HTMLDivElement>(null)
+   * return (
+   *   <div ref={scrollerRef} style={{ overflow: 'auto', height: '100vh' }}>
+   *     <VirtuosoMasonry scrollElementRef={scrollerRef} columnCount={3} data={items} ItemContent={MyItem} />
+   *   </div>
+   * )
+   * ```
+   */
+  scrollElementRef?: React.RefObject<HTMLElement | null>
 }
 
 /**
@@ -83,7 +108,16 @@ export interface VirtuosoMasonryProps<Data, Context> extends ScrollerProps {
  */
 export const VirtuosoMasonry = forwardRef<Record<string, never>, VirtuosoMasonryProps<unknown, unknown>>(
   (
-    { columnCount, context, data, initialItemCount = 0, ItemContent = DefaultItemContent, useWindowScroll = false, ...scrollerProps },
+    {
+      columnCount,
+      context,
+      data,
+      initialItemCount = 0,
+      ItemContent = DefaultItemContent,
+      useWindowScroll = false, // oxlint-disable-line typescript-eslint(no-deprecated) -- backward compat
+      scrollElementRef,
+      ...scrollerProps
+    },
     ref
   ) => {
     const realm = useMemo(() => {
@@ -91,6 +125,7 @@ export const VirtuosoMasonry = forwardRef<Record<string, never>, VirtuosoMasonry
       r.register(indexesInColumns$)
       r.register(masonryItemsState$)
       r.register(knownSizes$)
+      r.register(hasExternalScroller$)
       r.pubIn({
         [columnCount$]: columnCount,
         [context$]: context,
@@ -98,6 +133,7 @@ export const VirtuosoMasonry = forwardRef<Record<string, never>, VirtuosoMasonry
         [initialItemCount$]: initialItemCount,
         [itemContent$]: ItemContent,
         [useWindowScroll$]: useWindowScroll,
+        [scrollElementRef$]: scrollElementRef,
       })
 
       return r
@@ -145,7 +181,7 @@ const VirtuosoScroller: React.FC<ScrollerProps> = ({ style: passedStyle, ...html
     return new ResizeObserver((entries) => {
       const length = entries.length
       const columnCount = realm.getValue(columnCount$)
-      const useWindowScroll = realm.getValue(useWindowScroll$)
+      const hasExternalScroller = realm.getValue(hasExternalScroller$)
 
       const results: SizeRange[][] = Array.from({ length: columnCount }, () => [])
       const absoluteSizes: Record<number, number> = {}
@@ -158,15 +194,35 @@ const VirtuosoScroller: React.FC<ScrollerProps> = ({ style: passedStyle, ...html
         const element = entry.target as HTMLDivElement
 
         if (element === scrollerRef.current) {
-          const theWindow = element.ownerDocument.defaultView!
+          const scrollRef = realm.getValue(scrollElementRef$)
+          const scrollParent = scrollRef?.current
 
-          pubPayload = {
-            ...pubPayload,
-            [scrollHeight$]: useWindowScroll ? theWindow.document.documentElement.scrollHeight : element.scrollHeight,
-            [scrollTop$]: useWindowScroll ? theWindow.scrollY : element.scrollTop,
-            [viewportHeight$]: useWindowScroll ? theWindow.innerHeight : entry.contentRect.height,
-            [viewportWidth$]: useWindowScroll ? theWindow.innerWidth : element.clientWidth,
-            ...(useWindowScroll ? {} : { [listOffset$]: entry.contentRect.top, [scrollHeight$]: element.scrollHeight }),
+          if (scrollParent) {
+            pubPayload = {
+              ...pubPayload,
+              [scrollHeight$]: scrollParent.scrollHeight,
+              [scrollTop$]: scrollParent.scrollTop,
+              [viewportHeight$]: scrollParent.clientHeight,
+              [viewportWidth$]: scrollParent.clientWidth,
+            }
+          } else if (hasExternalScroller) {
+            const theWindow = element.ownerDocument.defaultView!
+            pubPayload = {
+              ...pubPayload,
+              [scrollHeight$]: theWindow.document.documentElement.scrollHeight,
+              [scrollTop$]: theWindow.scrollY,
+              [viewportHeight$]: theWindow.innerHeight,
+              [viewportWidth$]: theWindow.innerWidth,
+            }
+          } else {
+            pubPayload = {
+              ...pubPayload,
+              [scrollHeight$]: element.scrollHeight,
+              [scrollTop$]: element.scrollTop,
+              [viewportHeight$]: entry.contentRect.height,
+              [viewportWidth$]: element.clientWidth,
+              [listOffset$]: entry.contentRect.top,
+            }
           }
           continue
         }
@@ -280,9 +336,36 @@ const VirtuosoScroller: React.FC<ScrollerProps> = ({ style: passedStyle, ...html
     [observer, onScroll]
   )
 
-  const [itemsState, ItemContent, useWindowScroll] = useCellValues(masonryItemsState$, itemContent$, useWindowScroll$)
+  const [itemsState, ItemContent, useWindowScroll, scrollElementRef] = useCellValues(
+    masonryItemsState$,
+    itemContent$,
+    useWindowScroll$,
+    scrollElementRef$
+  )
+  const hasExternalScroller = useWindowScroll || (scrollElementRef?.current !== undefined && scrollElementRef?.current !== null)
 
   useEffect(() => {
+    if (scrollElementRef?.current) {
+      const scrollParent = scrollElementRef.current
+
+      const handleExternalScroll = () => {
+        realm.pubIn({
+          [listOffset$]: scrollerRef.current?.getBoundingClientRect().top ?? 0,
+          [scrollHeight$]: scrollParent.scrollHeight,
+          [scrollTop$]: scrollParent.scrollTop,
+          [viewportHeight$]: scrollParent.clientHeight,
+        })
+      }
+      scrollParent.addEventListener('scroll', handleExternalScroll)
+      const resizeObserver = new ResizeObserver(handleExternalScroll)
+      resizeObserver.observe(scrollParent)
+      handleExternalScroll()
+      return () => {
+        scrollParent.removeEventListener('scroll', handleExternalScroll)
+        resizeObserver.disconnect()
+      }
+    }
+
     if (useWindowScroll) {
       const theWin = scrollerRef.current?.ownerDocument.defaultView!
 
@@ -301,9 +384,9 @@ const VirtuosoScroller: React.FC<ScrollerProps> = ({ style: passedStyle, ...html
       }
     }
     return undefined
-  }, [useWindowScroll, realm])
+  }, [useWindowScroll, scrollElementRef, realm])
 
-  const builtInStyle: CSSProperties = useWindowScroll
+  const builtInStyle: CSSProperties = hasExternalScroller
     ? {
         boxSizing: 'border-box',
         display: 'flex',

--- a/packages/masonry/src/_stories/masonry.stories.tsx
+++ b/packages/masonry/src/_stories/masonry.stories.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { VirtuosoMasonry } from '../VirtuosoMasonry'
 
@@ -76,6 +76,39 @@ export const WindowExample = () => {
         // oxlint-disable-next-line typescript-eslint(no-deprecated) -- example for deprecated prop
         useWindowScroll
       />
+    </div>
+  )
+}
+
+export const ScrollElementRefExample = () => {
+  const scrollerRef = useRef<HTMLDivElement>(null)
+  const data = useMemo(() => {
+    return Array.from({ length: 1000 }, (_, index) => index)
+  }, [])
+  return (
+    <div>
+      <div
+        ref={scrollerRef}
+        style={{
+          border: '2px solid blue',
+          height: '80vh',
+          overflow: 'auto',
+        }}
+      >
+        <div style={{ background: '#eee', padding: 16 }}>
+          <h2 style={{ margin: 0 }}>Header inside scroll container</h2>
+          <p style={{ margin: '8px 0 0' }}>This header scrolls with the masonry grid below.</p>
+        </div>
+        <VirtuosoMasonry
+          columnCount={3}
+          data={data}
+          ItemContent={ItemContent}
+          scrollElementRef={scrollerRef}
+          style={{
+            border: '1px solid black',
+          }}
+        />
+      </div>
     </div>
   )
 }

--- a/packages/masonry/src/_stories/masonry.stories.tsx
+++ b/packages/masonry/src/_stories/masonry.stories.tsx
@@ -73,6 +73,7 @@ export const WindowExample = () => {
         style={{
           border: '1px solid black',
         }}
+        // oxlint-disable-next-line typescript-eslint(no-deprecated) -- example for deprecated prop
         useWindowScroll
       />
     </div>

--- a/packages/masonry/src/dom.ts
+++ b/packages/masonry/src/dom.ts
@@ -1,3 +1,5 @@
+import type React from 'react'
+
 import { Cell, combine, DerivedCell, map, pipe } from '@virtuoso.dev/gurx'
 
 export const scrollTop$ = Cell(0)
@@ -12,11 +14,22 @@ export const listOffset$ = Cell(0)
 
 export const useWindowScroll$ = Cell(false)
 
+export const scrollElementRef$ = Cell<React.RefObject<HTMLElement | null> | undefined>(undefined)
+
+export const hasExternalScroller$ = DerivedCell(false, () => {
+  return pipe(
+    combine(useWindowScroll$, scrollElementRef$),
+    map(([useWindowScroll, scrollElementRef]) => {
+      return useWindowScroll || (scrollElementRef?.current !== undefined && scrollElementRef?.current !== null)
+    })
+  )
+})
+
 export const visibleListHeight$ = DerivedCell(0, () => {
   return pipe(
-    combine(viewportHeight$, useWindowScroll$, listOffset$),
-    map(([viewportHeight, useWindowScroll, listOffset]) => {
-      const result = useWindowScroll ? viewportHeight - Math.max(listOffset, 0) : viewportHeight
+    combine(viewportHeight$, hasExternalScroller$, listOffset$),
+    map(([viewportHeight, hasExternalScroller, listOffset]) => {
+      const result = hasExternalScroller ? viewportHeight - Math.max(listOffset, 0) : viewportHeight
       return result
     })
   )

--- a/packages/masonry/src/masonry-item-state.ts
+++ b/packages/masonry/src/masonry-item-state.ts
@@ -1,7 +1,7 @@
 import { Cell, combine, filter, link, pipe, pub, scan, sub } from '@virtuoso.dev/gurx'
 
 import { data$, totalCount$ } from './data'
-import { listOffset$, scrollTop$, useWindowScroll$, visibleListHeight$ } from './dom'
+import { hasExternalScroller$, listOffset$, scrollTop$, visibleListHeight$ } from './dom'
 import { columnCount$, indexesInColumns$, initialItemCount$, offsetTrees$, sizeTrees$, totalHeights$ } from './masonry-sizes'
 import { empty, newTree } from './sizing/AATree'
 import { rangesWithinOffsets } from './sizing/rangesWithinOffsets'
@@ -49,7 +49,7 @@ export const masonryItemsState$ = Cell<MasonryItemsState<unknown>>({ columns: []
         indexesInColumns$,
         initialItemCount$,
         listOffset$,
-        useWindowScroll$
+        hasExternalScroller$
       ),
       scan(
         (
@@ -66,14 +66,14 @@ export const masonryItemsState$ = Cell<MasonryItemsState<unknown>>({ columns: []
             indexesInColumns,
             initialItemCount,
             listOffset,
-            useWindowScroll,
+            hasExternalScroller,
           ]
         ) => {
           if (totalCount === 0) {
             return current
           }
 
-          const listOffsetTop = useWindowScroll ? listOffset + scrollTop : 0
+          const listOffsetTop = hasExternalScroller ? listOffset + scrollTop : 0
           const viewportTop = Math.min(Math.max(scrollTop - listOffsetTop, 0), Math.max(...totalHeights) - visibleListHeight)
           const viewportBottom = viewportTop + visibleListHeight
 

--- a/packages/react-virtuoso/examples/scroll-element-ref.tsx
+++ b/packages/react-virtuoso/examples/scroll-element-ref.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+
+import { Virtuoso } from '../src'
+
+export function Example() {
+  const scrollerRef = React.useRef<HTMLDivElement>(null)
+  return (
+    <div ref={scrollerRef} style={{ background: 'lightgrey', height: '50vh', overflow: 'auto', padding: '50px' }}>
+      <p>This content is above the list and scrolls with it inside a custom scroll container.</p>
+      <Virtuoso
+        scrollElementRef={scrollerRef}
+        itemContent={(index) => <div style={{ height: index % 2 ? 50 : 20 }}>Item {index}</div>}
+        style={{ border: '1px solid red' }}
+        totalCount={100}
+      />
+    </div>
+  )
+}

--- a/packages/react-virtuoso/src/TableVirtuoso.tsx
+++ b/packages/react-virtuoso/src/TableVirtuoso.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import useChangedListContentsSizes from './hooks/useChangedChildSizes'
+import useIsomorphicLayoutEffect from './hooks/useIsomorphicLayoutEffect'
 import useSize from './hooks/useSize'
 import useWindowViewportRectRef from './hooks/useWindowViewportRect'
 import { listSystem } from './listSystem'
@@ -297,11 +298,20 @@ const WindowViewport: React.FC<React.PropsWithChildren> = ({ children }) => {
 const TableRoot: React.FC<TableRootProps> = /*#__PURE__*/ React.memo(function TableVirtuosoRoot(props) {
   const useWindowScroll = useEmitterValue('useWindowScroll')
   const customScrollParent = useEmitterValue('customScrollParent')
+  const scrollElementRef = useEmitterValue('scrollElementRef')
+  const publishCustomScrollParent = usePublisher('customScrollParent')
   const fixedHeaderHeight = usePublisher('fixedHeaderHeight')
   const fixedFooterHeight = usePublisher('fixedFooterHeight')
   const fixedHeaderContent = useEmitterValue('fixedHeaderContent')
   const fixedFooterContent = useEmitterValue('fixedFooterContent')
   const context = useEmitterValue('context')
+
+  useIsomorphicLayoutEffect(() => {
+    if (scrollElementRef?.current) {
+      publishCustomScrollParent(scrollElementRef.current)
+    }
+  }, [scrollElementRef, publishCustomScrollParent])
+
   const theadRef = useSize(
     React.useMemo(() => u.compose(fixedHeaderHeight, (el) => correctItemSize(el, 'height')), [fixedHeaderHeight]),
     true,
@@ -312,8 +322,9 @@ const TableRoot: React.FC<TableRootProps> = /*#__PURE__*/ React.memo(function Ta
     true,
     useEmitterValue('skipAnimationFrameInResizeObserver')
   )
-  const TheScroller = customScrollParent || useWindowScroll ? WindowScroller : Scroller
-  const TheViewport = customScrollParent || useWindowScroll ? WindowViewport : Viewport
+  const hasExternalScroller = Boolean(customScrollParent || scrollElementRef?.current || useWindowScroll)
+  const TheScroller = hasExternalScroller ? WindowScroller : Scroller
+  const TheViewport = hasExternalScroller ? WindowViewport : Viewport
   const TheTable = useEmitterValue('TableComponent') as any
   const TheTHead = useEmitterValue('TableHeadComponent') as any
   const TheTFoot = useEmitterValue('TableFooterComponent') as any
@@ -391,6 +402,7 @@ const {
       alignToBottom: 'alignToBottom',
       useWindowScroll: 'useWindowScroll',
       customScrollParent: 'customScrollParent',
+      scrollElementRef: 'scrollElementRef',
       scrollerRef: 'scrollerRef',
       logLevel: 'logLevel',
     },

--- a/packages/react-virtuoso/src/Virtuoso.tsx
+++ b/packages/react-virtuoso/src/Virtuoso.tsx
@@ -444,9 +444,19 @@ const ListRoot: React.FC<ListRootProps> = /*#__PURE__*/ React.memo(function Virt
   const useWindowScroll = useEmitterValue('useWindowScroll')
   const showTopList = useEmitterValue('topItemsIndexes').length > 0
   const customScrollParent = useEmitterValue('customScrollParent')
+  const scrollElementRef = useEmitterValue('scrollElementRef')
+  const publishCustomScrollParent = usePublisher('customScrollParent')
   const context = useEmitterValue('context')
-  const TheScroller = customScrollParent || useWindowScroll ? WindowScroller : Scroller
-  const TheViewport = customScrollParent || useWindowScroll ? WindowViewport : Viewport
+
+  useIsomorphicLayoutEffect(() => {
+    if (scrollElementRef?.current) {
+      publishCustomScrollParent(scrollElementRef.current)
+    }
+  }, [scrollElementRef, publishCustomScrollParent])
+
+  const hasExternalScroller = Boolean(customScrollParent || scrollElementRef?.current || useWindowScroll)
+  const TheScroller = hasExternalScroller ? WindowScroller : Scroller
+  const TheViewport = hasExternalScroller ? WindowViewport : Viewport
   return (
     <TheScroller {...props} context={context}>
       {showTopList && (
@@ -503,6 +513,7 @@ export const {
       alignToBottom: 'alignToBottom',
       useWindowScroll: 'useWindowScroll',
       customScrollParent: 'customScrollParent',
+      scrollElementRef: 'scrollElementRef',
       scrollerRef: 'scrollerRef',
       logLevel: 'logLevel',
       horizontalDirection: 'horizontalDirection',

--- a/packages/react-virtuoso/src/VirtuosoGrid.tsx
+++ b/packages/react-virtuoso/src/VirtuosoGrid.tsx
@@ -248,9 +248,19 @@ const WindowViewport: React.FC<React.PropsWithChildren> = ({ children }) => {
 const GridRoot: React.FC<GridRootProps> = /*#__PURE__*/ React.memo(function GridRoot({ ...props }) {
   const useWindowScroll = useEmitterValue('useWindowScroll')
   const customScrollParent = useEmitterValue('customScrollParent')
-  const TheScroller = customScrollParent || useWindowScroll ? WindowScroller : Scroller
-  const TheViewport = customScrollParent || useWindowScroll ? WindowViewport : Viewport
+  const scrollElementRef = useEmitterValue('scrollElementRef')
+  const publishCustomScrollParent = usePublisher('customScrollParent')
   const context = useEmitterValue('context')
+
+  useIsomorphicLayoutEffect(() => {
+    if (scrollElementRef?.current) {
+      publishCustomScrollParent(scrollElementRef.current)
+    }
+  }, [scrollElementRef, publishCustomScrollParent])
+
+  const hasExternalScroller = Boolean(customScrollParent || scrollElementRef?.current || useWindowScroll)
+  const TheScroller = hasExternalScroller ? WindowScroller : Scroller
+  const TheViewport = hasExternalScroller ? WindowViewport : Viewport
 
   return (
     <TheScroller {...props} {...contextPropIfNotDomElement(TheScroller, context)}>
@@ -286,6 +296,7 @@ const {
       itemClassName: 'itemClassName',
       useWindowScroll: 'useWindowScroll',
       customScrollParent: 'customScrollParent',
+      scrollElementRef: 'scrollElementRef',
       scrollerRef: 'scrollerRef',
       logLevel: 'logLevel',
       restoreStateFrom: 'restoreStateFrom',

--- a/packages/react-virtuoso/src/component-interfaces/TableVirtuoso.ts
+++ b/packages/react-virtuoso/src/component-interfaces/TableVirtuoso.ts
@@ -131,8 +131,25 @@ export interface TableVirtuosoProps<Data, Context> extends Omit<VirtuosoProps<Da
 
   /**
    * Pass a reference to a scrollable parent element, so that the table won't wrap in its own.
+   * @deprecated Use {@link scrollElementRef} instead.
    */
   customScrollParent?: HTMLElement
+
+  /**
+   * Pass a ref to an external scrollable element to use as the scroll container
+   * instead of the component's built-in scroller. This replaces both `useWindowScroll` and `customScrollParent`.
+   *
+   * @example
+   * ```tsx
+   * const scrollerRef = useRef<HTMLDivElement>(null)
+   * return (
+   *   <div ref={scrollerRef} style={{ overflow: 'auto', height: '100vh' }}>
+   *     <TableVirtuoso scrollElementRef={scrollerRef} totalCount={100} fixedHeaderContent={() => <tr><th>Header</th></tr>} />
+   *   </div>
+   * )
+   * ```
+   */
+  scrollElementRef?: React.RefObject<HTMLElement | null>
 
   /**
    * The data items to be rendered. If data is set, the total count will be inferred from the length of the array.
@@ -309,6 +326,7 @@ export interface TableVirtuosoProps<Data, Context> extends Omit<VirtuosoProps<Da
   totalListHeightChanged?: (height: number) => void
   /**
    * Uses the document scroller rather than wrapping the list in its own.
+   * @deprecated Use {@link scrollElementRef} instead.
    */
   useWindowScroll?: boolean
 }

--- a/packages/react-virtuoso/src/component-interfaces/Virtuoso.ts
+++ b/packages/react-virtuoso/src/component-interfaces/Virtuoso.ts
@@ -202,8 +202,25 @@ export interface VirtuosoProps<Data, Context> extends ListRootProps {
 
   /**
    * Pass a reference to a scrollable parent element, so that the list won't wrap in its own.
+   * @deprecated Use {@link scrollElementRef} instead.
    */
   customScrollParent?: HTMLElement
+
+  /**
+   * Pass a ref to an external scrollable element to use as the scroll container
+   * instead of the component's built-in scroller. This replaces both `useWindowScroll` and `customScrollParent`.
+   *
+   * @example
+   * ```tsx
+   * const scrollerRef = useRef<HTMLDivElement>(null)
+   * return (
+   *   <div ref={scrollerRef} style={{ overflow: 'auto', height: '100vh' }}>
+   *     <Virtuoso scrollElementRef={scrollerRef} totalCount={100} itemContent={(index) => <div>Item {index}</div>} />
+   *   </div>
+   * )
+   * ```
+   */
+  scrollElementRef?: React.RefObject<HTMLElement | null>
 
   /**
    * The data items to be rendered. If data is set, the total count will be inferred from the length of the array.
@@ -442,6 +459,7 @@ export interface VirtuosoProps<Data, Context> extends ListRootProps {
 
   /**
    * Uses the document scroller rather than wrapping the list in its own.
+   * @deprecated Use {@link scrollElementRef} instead. Pass a ref to the window's scroll container or use `document.documentElement`.
    */
   useWindowScroll?: boolean
 }

--- a/packages/react-virtuoso/src/component-interfaces/VirtuosoGrid.ts
+++ b/packages/react-virtuoso/src/component-interfaces/VirtuosoGrid.ts
@@ -117,8 +117,25 @@ export interface VirtuosoGridProps<Data, Context = unknown> extends GridRootProp
 
   /**
    * Pass a reference to a scrollable parent element, so that the grid won't wrap in its own.
+   * @deprecated Use {@link scrollElementRef} instead.
    */
   customScrollParent?: HTMLElement
+
+  /**
+   * Pass a ref to an external scrollable element to use as the scroll container
+   * instead of the component's built-in scroller. This replaces both `useWindowScroll` and `customScrollParent`.
+   *
+   * @example
+   * ```tsx
+   * const scrollerRef = useRef<HTMLDivElement>(null)
+   * return (
+   *   <div ref={scrollerRef} style={{ overflow: 'auto', height: '100vh' }}>
+   *     <VirtuosoGrid scrollElementRef={scrollerRef} totalCount={100} itemContent={(index) => <div>Item {index}</div>} />
+   *   </div>
+   * )
+   * ```
+   */
+  scrollElementRef?: React.RefObject<HTMLElement | null>
 
   /**
    * The data items to be rendered. If data is set, the total count will be inferred from the length of the array.
@@ -233,6 +250,7 @@ export interface VirtuosoGridProps<Data, Context = unknown> extends GridRootProp
 
   /**
    * Uses the document scroller rather than wrapping the grid in its own.
+   * @deprecated Use {@link scrollElementRef} instead.
    */
   useWindowScroll?: boolean
 }

--- a/packages/react-virtuoso/src/gridSystem.ts
+++ b/packages/react-virtuoso/src/gridSystem.ts
@@ -79,7 +79,7 @@ export const gridSystem = /*#__PURE__*/ u.system(
     stateFlags,
     scrollSeek,
     { didMount, propsReady },
-    { customScrollParent, useWindowScroll, windowScrollContainerState, windowScrollTo, windowViewportRect },
+    { customScrollParent, scrollElementRef, useWindowScroll, windowScrollContainerState, windowScrollTo, windowViewportRect },
     log,
   ]) => {
     const totalCount = u.statefulStream(0)
@@ -419,6 +419,7 @@ export const gridSystem = /*#__PURE__*/ u.system(
 
     return {
       customScrollParent,
+      scrollElementRef,
       // input
       data,
       deviation,

--- a/packages/react-virtuoso/src/windowScrollerSystem.ts
+++ b/packages/react-virtuoso/src/windowScrollerSystem.ts
@@ -1,3 +1,5 @@
+import type React from 'react'
+
 import { domIOSystem } from './domIOSystem'
 import * as u from './urx'
 
@@ -9,6 +11,7 @@ export const windowScrollerSystem = u.system(([{ scrollContainerState, scrollTo 
   const windowScrollTo = u.stream<ScrollToOptions>()
   const useWindowScroll = u.statefulStream(false)
   const customScrollParent = u.statefulStream<HTMLElement | undefined>(undefined)
+  const scrollElementRef = u.statefulStream<React.RefObject<HTMLElement | null> | undefined>(undefined)
 
   u.connect(
     u.pipe(
@@ -40,6 +43,7 @@ export const windowScrollerSystem = u.system(([{ scrollContainerState, scrollTo 
 
   return {
     customScrollParent,
+    scrollElementRef,
     // config
     useWindowScroll,
 

--- a/packages/reactive-engine-react/CHANGELOG.md
+++ b/packages/reactive-engine-react/CHANGELOG.md
@@ -26,7 +26,6 @@
 ### Minor Changes
 
 - [`34097be`](https://github.com/petyosi/react-virtuoso/commit/34097bec6b2d69642ac6ff4c942ae457bbecce2d) Thanks [@petyosi](https://github.com/petyosi)! - Add remote hooks for accessing engine state from anywhere in the app
-
   - Add `engineId` prop to `EngineProvider` to register engine in global registry
   - Add `useRemoteCellValue(cell$, engineId)` - returns cell value or `undefined` if engine not available
   - Add `useRemotePublisher(node$, engineId)` - returns publisher function (noop if no engine)


### PR DESCRIPTION
## Summary

- Add new `scrollElementRef` prop to `Virtuoso`, `VirtuosoGrid`, `TableVirtuoso`, and `VirtuosoMasonry` that accepts a `React.RefObject<HTMLElement | null>` for using an external scroll container
- Deprecate `useWindowScroll` and `customScrollParent` props in favor of the new `scrollElementRef`
- Full implementation for the masonry package including external scroll container support (resolves #1305)

### Usage

```tsx
const scrollerRef = useRef<HTMLDivElement>(null)
return (
  <div ref={scrollerRef} style={{ overflow: 'auto', height: '100vh' }}>
    <VirtuosoMasonry
      scrollElementRef={scrollerRef}
      columnCount={3}
      data={items}
      ItemContent={MyItem}
    />
  </div>
)
```

## Test plan

- [x] All existing unit tests pass (`pnpm test` in react-virtuoso and masonry)
- [x] Lint passes across all packages (`pnpm lint`)
- [x] Both packages build successfully


🤖 Generated with [Claude Code](https://claude.com/claude-code)