### PR TITLE
Fix useSyncExternalStore detection for React 19+

### DIFF
--- a/.changeset/fix-react-19-sync-store.md
+++ b/.changeset/fix-react-19-sync-store.md
@@ -1,0 +1,7 @@
+---
+'react-virtuoso': patch
+---
+
+Fix useSyncExternalStore detection for React 19+
+
+The version check used `startsWith('18')` which excluded React 19, causing it to fall back to the legacy useState+useLayoutEffect subscription path. This could cause tearing issues in concurrent rendering scenarios. Changed to `parseInt(React.version) >= 18` to correctly use useSyncExternalStore for React 18 and above.

--- a/packages/react-virtuoso/src/react-urx/index.tsx
+++ b/packages/react-virtuoso/src/react-urx/index.tsx
@@ -299,7 +299,7 @@ export function systemToComponent<SS extends AnySystemSpec, M extends SystemProp
     return value
   }
 
-  const useEmitterValue = React.version.startsWith('18') ? useEmitterValue18 : useEmitterValueLegacy
+  const useEmitterValue = parseInt(React.version) >= 18 ? useEmitterValue18 : useEmitterValueLegacy
 
   const useEmitter = <K extends keyof S, V = S[K] extends Stream<infer R> ? R : never>(key: K, callback: (value: V) => void) => {
     const context = React.useContext(Context)


### PR DESCRIPTION
## Summary

- Changes version check from `startsWith('18')` to `parseInt(React.version) >= 18`
- React 19 now correctly uses `useSyncExternalStore` instead of legacy `useState + useLayoutEffect` fallback
- Prevents tearing issues in concurrent rendering scenarios reported by users

Fixes #1387