### PR TITLE
Speed up Release workflow by caching Playwright browsers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(pnpm --filter react-virtuoso exec playwright --version | head -1)" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Run CI checks
         run: pnpm run ci
         env:

--- a/packages/react-virtuoso/package.json
+++ b/packages/react-virtuoso/package.json
@@ -54,7 +54,7 @@
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "ladle": "LADLE=true ladle serve",
-    "ci-setup": "npx playwright install --with-deps"
+    "ci-setup": "npx playwright install --with-deps chromium"
   },
   "devDependencies": {
     "@emotion/styled": "^11.10.8",


### PR DESCRIPTION
## Summary

- Adds Playwright browser caching using `actions/cache@v4` keyed by Playwright version
- Changes `ci-setup` to only install chromium (matches PR workflow behavior)

## Problem

The Release workflow `ci-setup` step was taking ~22 minutes to download all Playwright browsers on every run. The "Version Packages" release took 27m22s total, with most of that time spent on browser downloads.

## Expected improvement

- First run: same as before (cache miss, installs browsers)
- Subsequent runs: ~20 minutes faster (cache hit, skips download)