### PR TITLE
Fix useWindowScroll SSR viewport layout

### DIFF
--- a/.changeset/curvy-brooms-smoke.md
+++ b/.changeset/curvy-brooms-smoke.md
@@ -1,0 +1,5 @@
+---
+'react-virtuoso': patch
+---
+
+Fix `useWindowScroll` SSR layout collapse by rendering the window viewport in normal flow while preserving sticky top items.

--- a/examples/react-virtuoso/window-scroll-top-items.stories.tsx
+++ b/examples/react-virtuoso/window-scroll-top-items.stories.tsx
@@ -1,0 +1,91 @@
+import type { CSSProperties } from 'react'
+import { Virtuoso } from 'react-virtuoso'
+
+const data = Array.from({ length: 100 }, (_, index) => index)
+
+const pageStyle: CSSProperties = {
+  background: '#f3f4f6',
+  minHeight: '160vh',
+  padding: '24px',
+}
+
+const listStyle: CSSProperties = {
+  background: 'white',
+  boxShadow: '0 12px 30px rgb(15 23 42 / 0.12)',
+  margin: '0 auto',
+  maxWidth: 720,
+}
+
+const elementScrollListStyle: CSSProperties = {
+  ...listStyle,
+  height: 480,
+}
+
+const headerStyle: CSSProperties = {
+  alignItems: 'center',
+  background: '#facc15',
+  border: '4px solid #92400e',
+  boxSizing: 'border-box',
+  color: '#111827',
+  display: 'flex',
+  fontWeight: 700,
+  height: 96,
+  padding: '0 24px',
+}
+
+const pageHeaderStyle: CSSProperties = {
+  ...headerStyle,
+  margin: '0 auto',
+  maxWidth: 720,
+}
+
+function itemStyle(index: number): CSSProperties {
+  const isTopItem = index < 2
+
+  return {
+    alignItems: 'center',
+    background: isTopItem ? '#b91c1c' : index % 2 ? '#f8fafc' : '#ffffff',
+    borderBottom: '1px solid #d1d5db',
+    boxSizing: 'border-box',
+    color: isTopItem ? '#ffffff' : '#1f2937',
+    display: 'flex',
+    fontWeight: isTopItem ? 700 : 400,
+    height: isTopItem ? 72 : 56,
+    padding: '0 24px',
+  }
+}
+
+export const WindowScrollHeaderWithTopItems = () => {
+  return (
+    <main style={pageStyle}>
+      <div style={pageHeaderStyle}>Page header rendered before Virtuoso</div>
+      <Virtuoso
+        data={data}
+        itemContent={(index) => {
+          return <div style={itemStyle(index)}>{index < 2 ? `Sticky top item ${index}` : `Item ${index}`}</div>
+        }}
+        style={listStyle}
+        topItemCount={2}
+        useWindowScroll
+      />
+    </main>
+  )
+}
+
+export const ElementScrollHeaderWithTopItems = () => {
+  return (
+    <main style={pageStyle}>
+      <Virtuoso
+        components={{
+          Header: () => <div style={headerStyle}>Header rendered through components.Header</div>,
+        }}
+        data={data}
+        itemContent={(index) => {
+          return <div style={itemStyle(index)}>{index < 2 ? `Sticky top item ${index}` : `Item ${index}`}</div>
+        }}
+        style={elementScrollListStyle}
+        topItemCount={2}
+      />
+    </main>
+  )
+}

--- a/packages/react-virtuoso/src/TableVirtuoso.tsx
+++ b/packages/react-virtuoso/src/TableVirtuoso.tsx
@@ -16,6 +16,7 @@ import {
   identity,
   itemPropIfNotDomElement,
   viewportStyle,
+  windowViewportStyle,
 } from './Virtuoso'
 
 import type {
@@ -274,6 +275,7 @@ const WindowViewport: React.FC<React.PropsWithChildren> = ({ children }) => {
   const windowViewportRect = usePublisher('windowViewportRect')
   const fixedItemHeight = usePublisher('fixedItemHeight')
   const customScrollParent = useEmitterValue('customScrollParent')
+  const useWindowScroll = useEmitterValue('useWindowScroll')
   const viewportRef = useWindowViewportRectRef(
     windowViewportRect,
     customScrollParent,
@@ -288,7 +290,7 @@ const WindowViewport: React.FC<React.PropsWithChildren> = ({ children }) => {
   }, [ctx, windowViewportRect, fixedItemHeight])
 
   return (
-    <div data-viewport-type="window" ref={viewportRef} style={viewportStyle(false)}>
+    <div data-viewport-type="window" ref={viewportRef} style={windowViewportStyle(false, useWindowScroll)}>
       {children}
     </div>
   )

--- a/packages/react-virtuoso/src/Virtuoso.tsx
+++ b/packages/react-virtuoso/src/Virtuoso.tsx
@@ -227,6 +227,12 @@ export const viewportStyle: (alignToBottom: boolean) => React.CSSProperties = (a
   ...(alignToBottom ? { display: 'flex', flexDirection: 'column' } : undefined),
 })
 
+export const windowViewportStyle = (alignToBottom: boolean, useWindowScroll: boolean, topOffset = 0): React.CSSProperties => ({
+  ...viewportStyle(alignToBottom),
+  position: useWindowScroll ? 'relative' : 'absolute',
+  top: useWindowScroll ? -topOffset : 0,
+})
+
 const topItemListStyle: React.CSSProperties = {
   position: positionStickyCssValue(),
   top: 0,
@@ -407,6 +413,8 @@ const WindowViewport: React.FC<React.PropsWithChildren> = ({ children }) => {
   const windowViewportRect = usePublisher('windowViewportRect')
   const fixedItemHeight = usePublisher('fixedItemHeight')
   const customScrollParent = useEmitterValue('customScrollParent')
+  const useWindowScroll = useEmitterValue('useWindowScroll')
+  const topListHeight = useEmitterValue('topListHeight')
   const viewportRef = useWindowViewportRectRef(
     windowViewportRect,
     customScrollParent,
@@ -422,7 +430,7 @@ const WindowViewport: React.FC<React.PropsWithChildren> = ({ children }) => {
   }, [ctx, windowViewportRect, fixedItemHeight])
 
   return (
-    <div data-viewport-type="window" ref={viewportRef} style={viewportStyle(alignToBottom)}>
+    <div data-viewport-type="window" ref={viewportRef} style={windowViewportStyle(alignToBottom, useWindowScroll, topListHeight)}>
       {children}
     </div>
   )

--- a/packages/react-virtuoso/src/VirtuosoGrid.tsx
+++ b/packages/react-virtuoso/src/VirtuosoGrid.tsx
@@ -9,7 +9,7 @@ import { systemToComponent } from './react-urx'
 import * as u from './urx'
 import { VirtuosoGridMockContext } from './utils/context'
 import { correctItemSize } from './utils/correctItemSize'
-import { buildScroller, buildWindowScroller, contextPropIfNotDomElement, identity, viewportStyle } from './Virtuoso'
+import { buildScroller, buildWindowScroller, contextPropIfNotDomElement, identity, viewportStyle, windowViewportStyle } from './Virtuoso'
 
 import type { VirtuosoGridHandle, VirtuosoGridProps } from './component-interfaces/VirtuosoGrid'
 import type { GridComponents, GridComputeItemKey, GridItemContent, GridRootProps } from './interfaces'
@@ -229,6 +229,7 @@ const WindowViewport: React.FC<React.PropsWithChildren> = ({ children }) => {
   const windowViewportRect = usePublisher('windowViewportRect')
   const itemDimensions = usePublisher('itemDimensions')
   const customScrollParent = useEmitterValue('customScrollParent')
+  const useWindowScroll = useEmitterValue('useWindowScroll')
   const viewportRef = useWindowViewportRectRef(windowViewportRect, customScrollParent, false)
 
   React.useEffect(() => {
@@ -239,7 +240,7 @@ const WindowViewport: React.FC<React.PropsWithChildren> = ({ children }) => {
   }, [ctx, windowViewportRect, itemDimensions])
 
   return (
-    <div ref={viewportRef} style={viewportStyle(false)}>
+    <div ref={viewportRef} style={windowViewportStyle(false, useWindowScroll)}>
       {children}
     </div>
   )

--- a/packages/react-virtuoso/test/VirtuosoMockContext.test.tsx
+++ b/packages/react-virtuoso/test/VirtuosoMockContext.test.tsx
@@ -39,6 +39,16 @@ describe('VirtuosoMockContext', () => {
 
       expect(container).toMatchSnapshot()
     })
+
+    it('offsets the window viewport by the sticky top items height', () => {
+      const { container } = render(<Virtuoso data={data} topItemCount={2} useWindowScroll />, {
+        wrapper: ({ children }) => (
+          <VirtuosoMockContext.Provider value={{ itemHeight: 100, viewportHeight: 300 }}>{children}</VirtuosoMockContext.Provider>
+        ),
+      })
+
+      expect(container).toMatchSnapshot()
+    })
   })
 
   describe('Table', () => {

--- a/packages/react-virtuoso/test/__snapshots__/VirtuosoMockContext.test.tsx.snap
+++ b/packages/react-virtuoso/test/__snapshots__/VirtuosoMockContext.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`VirtuosoMockContext > Grid > correctly renders items with useWindowScro
     style="position: relative; height: 300px;"
   >
     <div
-      style="height: 100%; position: absolute; top: 0px; width: 100%;"
+      style="height: 100%; position: relative; top: 0px; width: 100%;"
     >
       <div
         class="virtuoso-grid-list"
@@ -168,7 +168,7 @@ exports[`VirtuosoMockContext > List > correctly renders items with useWindowScro
   >
     <div
       data-viewport-type="window"
-      style="height: 100%; position: absolute; top: 0px; width: 100%;"
+      style="height: 100%; position: relative; top: 0px; width: 100%;"
     >
       <div
         data-testid="virtuoso-item-list"
@@ -190,6 +190,58 @@ exports[`VirtuosoMockContext > List > correctly renders items with useWindowScro
         >
           Item 1
         </div>
+        <div
+          data-index="2"
+          data-item-index="2"
+          data-known-size="100"
+          style="overflow-anchor: none;"
+        >
+          Item 2
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`VirtuosoMockContext > List > offsets the window viewport by the sticky top items height 1`] = `
+<div>
+  <div
+    data-virtuoso-scroller="true"
+    style="position: relative; height: 800px;"
+  >
+    <div
+      style="position: -webkit-sticky; top: 0px; width: 100%; z-index: 1; margin-top: 0px;"
+    >
+      <div
+        data-testid="virtuoso-top-item-list"
+      >
+        <div
+          data-index="0"
+          data-item-index="0"
+          data-known-size="100"
+          style="overflow-anchor: none;"
+        >
+          Item 0
+        </div>
+        <div
+          data-index="1"
+          data-item-index="1"
+          data-known-size="100"
+          style="overflow-anchor: none;"
+        >
+          Item 1
+        </div>
+      </div>
+    </div>
+    <div
+      data-viewport-type="window"
+      style="height: 100%; position: relative; top: -200px; width: 100%;"
+    >
+      <div
+        data-testid="virtuoso-item-list"
+        style="box-sizing: border-box; margin-top: 0px; padding-bottom: 500px; padding-top: 200px;"
+      >
         <div
           data-index="2"
           data-item-index="2"
@@ -275,7 +327,7 @@ exports[`VirtuosoMockContext > Table > correctly renders items with useWindowScr
   >
     <div
       data-viewport-type="window"
-      style="height: 100%; position: absolute; top: 0px; width: 100%;"
+      style="height: 100%; position: relative; top: 0px; width: 100%;"
     >
       <table
         style="border-spacing: 0px; overflow-anchor: none;"


### PR DESCRIPTION
Summary:
- render the useWindowScroll viewport in normal flow instead of absolutely positioning it
- offset the window viewport by sticky top items so pinned items keep their existing behavior
- add a patch changeset and snapshot coverage for the sticky top-item offset

Testing:
- pnpm vitest run test/VirtuosoMockContext.test.tsx test/windowScrollerSystem.test.ts test/ssr.test.tsx -u

Closes #1392