### PR TITLE
Fix horizontal RTL list positioning (#1395)

### DIFF
--- a/.changeset/fix-horizontal-rtl.md
+++ b/.changeset/fix-horizontal-rtl.md
@@ -1,0 +1,5 @@
+---
+'react-virtuoso': patch
+---
+
+Fix horizontal Virtuoso item positioning and scrolling in RTL layouts.

--- a/packages/react-virtuoso/e2e/horizontal-rtl.test.ts
+++ b/packages/react-virtuoso/e2e/horizontal-rtl.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test'
+
+import { navigateToExample } from './utils.ts'
+
+import type { Page } from '@playwright/test'
+
+function itemPosition(page: Page, index: number) {
+  return page.evaluate((index) => {
+    const scroller = document.querySelector('[data-testid=virtuoso-scroller]')!
+    const item = document.querySelector(`[data-item-index="${index}"]`)!
+    const scrollerRect = scroller.getBoundingClientRect()
+    const itemRect = item.getBoundingClientRect()
+
+    return {
+      itemLeft: Math.round(itemRect.left),
+      itemRight: Math.round(itemRect.right),
+      scrollerLeft: Math.round(scrollerRect.left),
+      scrollerRight: Math.round(scrollerRect.right),
+    }
+  }, index)
+}
+
+function expectClosePosition(actual: number, expected: number) {
+  expect(Math.abs(actual - expected)).toBeLessThanOrEqual(1)
+}
+
+test.describe('horizontal list in rtl', () => {
+  test.beforeEach(async ({ baseURL, page }) => {
+    await navigateToExample(page, baseURL, 'horizontal-rtl')
+  })
+
+  test('renders initial items from the right edge', async ({ page }) => {
+    const position = await itemPosition(page, 0)
+
+    expectClosePosition(position.itemRight, position.scrollerRight)
+  })
+
+  test('scrolls to an index using logical offsets', async ({ page }) => {
+    await page.click('#start-20')
+    await expect(page.locator('[data-testid=range]')).toHaveText('20-25')
+
+    let position = await itemPosition(page, 20)
+    expectClosePosition(position.itemRight, position.scrollerRight)
+
+    await page.click('#end-20')
+    await expect(page.locator('[data-testid=range]')).toHaveText('15-20')
+
+    position = await itemPosition(page, 20)
+    expectClosePosition(position.itemLeft, position.scrollerLeft)
+  })
+})

--- a/packages/react-virtuoso/examples/horizontal-rtl.tsx
+++ b/packages/react-virtuoso/examples/horizontal-rtl.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react'
+
+import { Virtuoso } from '../src'
+
+import type { ListRange, VirtuosoHandle } from '../src'
+
+const itemStyle: React.CSSProperties = {
+  alignItems: 'center',
+  background: '#e8edf5',
+  border: '1px solid #aeb7c6',
+  boxSizing: 'border-box',
+  display: 'flex',
+  height: '100%',
+  justifyContent: 'center',
+  width: 100,
+}
+
+export function Example() {
+  const ref = React.useRef<VirtuosoHandle>(null)
+  const [range, setRange] = React.useState<ListRange>({ endIndex: 0, startIndex: 0 })
+
+  return (
+    <div style={{ height: 160, width: 520 }}>
+      <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+        <button
+          id="start-0"
+          onClick={() => {
+            ref.current!.scrollToIndex({ align: 'start', index: 0 })
+          }}
+        >
+          Start 0
+        </button>
+        <button
+          id="start-20"
+          onClick={() => {
+            ref.current!.scrollToIndex({ align: 'start', index: 20 })
+          }}
+        >
+          Start 20
+        </button>
+        <button
+          id="end-20"
+          onClick={() => {
+            ref.current!.scrollToIndex({ align: 'end', index: 20 })
+          }}
+        >
+          End 20
+        </button>
+        <span data-testid="range">
+          {range.startIndex}-{range.endIndex}
+        </span>
+      </div>
+      <Virtuoso
+        computeItemKey={(key: number) => `item-${key.toString()}`}
+        horizontalDirection
+        itemContent={(index) => <div style={itemStyle}>Item {index}</div>}
+        rangeChanged={setRange}
+        ref={ref}
+        style={{ direction: 'rtl', height: 100, width: '100%' }}
+        totalCount={100}
+      />
+    </div>
+  )
+}

--- a/packages/react-virtuoso/src/Virtuoso.tsx
+++ b/packages/react-virtuoso/src/Virtuoso.tsx
@@ -128,9 +128,9 @@ const Items = /*#__PURE__*/ React.memo(function VirtuosoItems({ showTopList = fa
           ? {
               display: 'inline-block',
               height: '100%',
-              marginLeft: deviation !== 0 ? deviation : alignToBottom ? 'auto' : 0,
-              paddingLeft: listState.offsetTop,
-              paddingRight: listState.offsetBottom,
+              marginInlineStart: deviation !== 0 ? deviation : alignToBottom ? 'auto' : 0,
+              paddingInlineEnd: listState.offsetBottom,
+              paddingInlineStart: listState.offsetTop,
               whiteSpace: 'nowrap',
             }
           : {

--- a/packages/react-virtuoso/src/hooks/useChangedChildSizes.ts
+++ b/packages/react-virtuoso/src/hooks/useChangedChildSizes.ts
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { LogLevel } from '../loggerSystem'
+import { getLogicalScrollLeft } from '../utils/horizontalScroll'
 import { useSizeWithElRef } from './useSize'
 
 import type { ScrollContainerState, SizeFunction, SizeRange } from '../interfaces'
@@ -31,18 +32,6 @@ export default function useChangedListContentsSizes(
         theWindow = scrollableElement.ownerDocument.defaultView!
       }
 
-      const scrollTop = customScrollParent
-        ? horizontalDirection
-          ? customScrollParent.scrollLeft
-          : customScrollParent.scrollTop
-        : windowScrolling
-          ? horizontalDirection
-            ? theWindow.scrollX || theWindow.document.documentElement.scrollLeft
-            : theWindow.scrollY || theWindow.document.documentElement.scrollTop
-          : horizontalDirection
-            ? scrollableElement.scrollLeft
-            : scrollableElement.scrollTop
-
       const scrollHeight = customScrollParent
         ? horizontalDirection
           ? customScrollParent.scrollWidth
@@ -66,6 +55,18 @@ export default function useChangedListContentsSizes(
           : horizontalDirection
             ? scrollableElement.offsetWidth
             : scrollableElement.offsetHeight
+
+      const scrollTop = customScrollParent
+        ? horizontalDirection
+          ? getLogicalScrollLeft(customScrollParent, customScrollParent.scrollLeft)
+          : customScrollParent.scrollTop
+        : windowScrolling
+          ? horizontalDirection
+            ? getLogicalScrollLeft(theWindow, theWindow.scrollX || theWindow.document.documentElement.scrollLeft)
+            : theWindow.scrollY || theWindow.document.documentElement.scrollTop
+          : horizontalDirection
+            ? getLogicalScrollLeft(scrollableElement, scrollableElement.scrollLeft)
+            : scrollableElement.scrollTop
 
       scrollContainerStateCallback({
         scrollHeight,

--- a/packages/react-virtuoso/src/hooks/useScrollTop.ts
+++ b/packages/react-virtuoso/src/hooks/useScrollTop.ts
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom'
 import * as u from '../urx'
 import { approximatelyEqual } from '../utils/approximatelyEqual'
 import { correctItemSize } from '../utils/correctItemSize'
+import { clearHorizontalScrollDirectionCache, getLogicalScrollLeft, getPhysicalScrollLeft } from '../utils/horizontalScroll'
 
 import type { ScrollContainerState } from '../interfaces'
 
@@ -39,14 +40,14 @@ export default function useScrollTop(
 
       if (isDocument(el) || isWindow(el)) {
         const theWindow = isWindow(el) ? el : (el as unknown as Document).defaultView!
-        scrollTop = horizontalDirection === true ? theWindow.scrollX : theWindow.scrollY
+        scrollTop = horizontalDirection === true ? getLogicalScrollLeft(theWindow, theWindow.scrollX) : theWindow.scrollY
 
         scrollHeight =
           horizontalDirection === true ? theWindow.document.documentElement.scrollWidth : theWindow.document.documentElement.scrollHeight
 
         viewportHeight = horizontalDirection === true ? theWindow.innerWidth : theWindow.innerHeight
       } else {
-        scrollTop = horizontalDirection === true ? el.scrollLeft : el.scrollTop
+        scrollTop = horizontalDirection === true ? getLogicalScrollLeft(el, el.scrollLeft) : el.scrollTop
 
         scrollHeight = horizontalDirection === true ? el.scrollWidth : el.scrollHeight
 
@@ -83,11 +84,13 @@ export default function useScrollTop(
   React.useEffect(() => {
     const localRef = customScrollParent ? customScrollParent : scrollerRef.current!
 
+    clearHorizontalScrollDirectionCache(localRef)
     scrollerRefCallback(customScrollParent ? customScrollParent : scrollerRef.current)
     handler({ suppressFlushSync: true, target: localRef } as unknown as Event)
     localRef.addEventListener('scroll', handler, { passive: true })
 
     return () => {
+      clearHorizontalScrollDirectionCache(localRef)
       scrollerRefCallback(null)
       localRef.removeEventListener('scroll', handler)
     }
@@ -119,20 +122,27 @@ export default function useScrollTop(
           : scrollerElement.document.documentElement.scrollHeight
       )
       offsetHeight = horizontalDirection === true ? scrollerElement.innerWidth : scrollerElement.innerHeight
-      scrollTop = horizontalDirection === true ? window.scrollX : window.scrollY
+      scrollTop = horizontalDirection === true ? getLogicalScrollLeft(scrollerElement, scrollerElement.scrollX) : scrollerElement.scrollY
     } else {
       scrollHeight = scrollerElement[horizontalDirection === true ? 'scrollWidth' : 'scrollHeight']
       offsetHeight = correctItemSize(scrollerElement, horizontalDirection === true ? 'width' : 'height')
-      scrollTop = scrollerElement[horizontalDirection === true ? 'scrollLeft' : 'scrollTop']
+      scrollTop =
+        horizontalDirection === true ? getLogicalScrollLeft(scrollerElement, scrollerElement.scrollLeft) : scrollerElement.scrollTop
     }
 
     const maxScrollTop = scrollHeight - offsetHeight
-    location.top = Math.ceil(Math.max(Math.min(maxScrollTop, location.top!), 0))
+    if (location.top === undefined) {
+      scrollerElement.scrollTo(location)
+      return
+    }
+
+    const top = Math.ceil(Math.max(Math.min(maxScrollTop, location.top), 0))
+    location.top = top
 
     // avoid system hanging because the DOM never called back
     // with the scrollTop
     // scroller is already at this location
-    if (approximatelyEqual(offsetHeight, scrollHeight) || location.top === scrollTop) {
+    if (approximatelyEqual(offsetHeight, scrollHeight) || top === scrollTop) {
       scrollContainerStateCallback({ scrollHeight, scrollTop, viewportHeight: offsetHeight })
       if (isSmooth) {
         smoothScrollTargetReached(true)
@@ -141,7 +151,7 @@ export default function useScrollTop(
     }
 
     if (isSmooth) {
-      scrollTopTarget.current = location.top
+      scrollTopTarget.current = top
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current)
       }
@@ -156,7 +166,10 @@ export default function useScrollTop(
     }
 
     if (horizontalDirection === true) {
-      location = { ...(location.behavior !== undefined ? { behavior: location.behavior } : {}), left: location.top }
+      location = {
+        ...(location.behavior !== undefined ? { behavior: location.behavior } : {}),
+        left: getPhysicalScrollLeft(scrollerElement, top),
+      }
     }
 
     scrollerElement.scrollTo(location)
@@ -166,7 +179,7 @@ export default function useScrollTop(
     if (horizontalDirection === true) {
       location = {
         ...(location.behavior !== undefined ? { behavior: location.behavior } : {}),
-        ...(location.top !== undefined ? { left: location.top } : {}),
+        ...(location.top !== undefined ? { left: getPhysicalScrollLeft(scrollerRef.current!, location.top) } : {}),
       }
     }
     scrollerRef.current!.scrollBy(location)

--- a/packages/react-virtuoso/src/utils/horizontalScroll.ts
+++ b/packages/react-virtuoso/src/utils/horizontalScroll.ts
@@ -1,0 +1,33 @@
+const cachedRtlElements = new WeakMap<HTMLElement, boolean>()
+
+function scrollerElement(scroller: HTMLElement | Window) {
+  return 'self' in scroller ? scroller.document.documentElement : scroller
+}
+
+function isRtl(scroller: HTMLElement | Window) {
+  const element = scrollerElement(scroller)
+  const cached = cachedRtlElements.get(element)
+
+  if (cached !== undefined) {
+    return cached
+  }
+
+  const value = element.ownerDocument.defaultView!.getComputedStyle(element).direction === 'rtl'
+  cachedRtlElements.set(element, value)
+  return value
+}
+
+export function clearHorizontalScrollDirectionCache(scroller: HTMLElement | Window) {
+  cachedRtlElements.delete(scrollerElement(scroller))
+}
+
+function convertHorizontalScrollLeft(scroller: HTMLElement | Window, scrollLeft: number) {
+  // Supported browsers expose RTL horizontal scrolling as 0 at the right edge
+  // and negative values while scrolling left, making the conversion symmetric.
+  return isRtl(scroller) ? -scrollLeft : scrollLeft
+}
+
+export const getLogicalScrollLeft = convertHorizontalScrollLeft
+export function getPhysicalScrollLeft(scroller: HTMLElement | Window, scrollLeft: number) {
+  return convertHorizontalScrollLeft(scroller, scrollLeft)
+}


### PR DESCRIPTION
## Summary

Fixes #1395.

Fixes horizontal Virtuoso lists rendered inside an RTL scroller.

The list previously used physical left/right spacing and passed browser `scrollLeft` values directly into the logical scroll state. In supported modern browsers, RTL horizontal scrolling reports `0` at the right edge and negative values while scrolling left, so the rendered range could remain stuck at the initial items while the list content was positioned off-screen.

This change:

- switches horizontal item-list offsets to logical inline spacing
- normalizes RTL horizontal `scrollLeft` values at the DOM boundary
- guards `scrollTo` when no logical `top` offset is provided
- adds a Ladle repro story for horizontal RTL scrolling
- adds Playwright coverage for initial RTL placement and `scrollToIndex`
- adds a patch changeset for `react-virtuoso`

## Validation

- `pnpm --filter react-virtuoso typecheck`
- `pnpm --filter react-virtuoso lint`
- `pnpm --filter react-virtuoso exec playwright test e2e/horizontal-rtl.test.ts e2e/scroll-to-index.test.ts e2e/data.test.ts --workers=1`
- `pnpm --filter react-virtuoso exec playwright test --workers=1`

The repository pre-commit hook runs monorepo-wide lint; that currently fails in unrelated workspace packages because internal reactive-engine package imports are not resolving in the hook environment. The focused package checks above pass.
