### PR TITLE
Author the agent skills and publish them to virtuoso-dev/skills

### DIFF
--- a/.changeset/great-pugs-attend.md
+++ b/.changeset/great-pugs-attend.md
@@ -1,0 +1,5 @@
+---
+'@virtuoso.dev/virtuoso-skills': patch
+---
+
+Author the skill content for all four skills: react-virtuoso, message-list, data-table, and a new reactive-engine skill covering the @virtuoso.dev/reactive-engine-\* package family. Each SKILL.md now provides component/package selection guidance, core usage rules with reasoning, common patterns, pitfalls, and an index into the generated reference docs.

--- a/.changeset/itchy-flies-design.md
+++ b/.changeset/itchy-flies-design.md
@@ -1,0 +1,9 @@
+---
+'@virtuoso.dev/reactive-engine-core': patch
+'@virtuoso.dev/reactive-engine-react': patch
+'@virtuoso.dev/reactive-engine-query': patch
+'@virtuoso.dev/reactive-engine-router': patch
+'@virtuoso.dev/reactive-engine-storage': patch
+---
+
+Add READMEs, docs guides, and package descriptions so the packages present themselves on npm and feed the reactive-engine agent skill. The core docs cover concepts, engine lifecycle, transaction semantics, the operator/combinator reference, and the architecture patterns used by data-table; the satellite packages document React integration, queries/mutations, routing, and storage links.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "virtuoso-skills",
       "source": "./packages/virtuoso-skills",
-      "description": "Agent guidance for react-virtuoso, message-list, and data-table",
+      "description": "Agent guidance for react-virtuoso, message-list, data-table, and the reactive engine",
       "homepage": "https://virtuoso.dev",
       "repository": "https://github.com/petyosi/react-virtuoso",
       "license": "MIT",

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -243,12 +243,13 @@ jobs:
           git -C "$tmpdir" init
           (
             cd "$tmpdir"
-            npx skills add "$repo" --skill react-virtuoso --skill message-list --skill data-table -a codex -a opencode -a cursor --copy -y
+            npx skills add "$repo" --skill react-virtuoso --skill message-list --skill data-table --skill reactive-engine -a codex -a opencode -a cursor --copy -y
           )
 
           test -f "$tmpdir/.agents/skills/react-virtuoso/SKILL.md"
           test -f "$tmpdir/.agents/skills/message-list/SKILL.md"
           test -f "$tmpdir/.agents/skills/data-table/SKILL.md"
+          test -f "$tmpdir/.agents/skills/reactive-engine/SKILL.md"
 
   e2e:
     name: E2E Tests

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -1,0 +1,52 @@
+name: Sync Skills Mirror
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'skills/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync skills to virtuoso-dev/skills
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      # SKILLS_SYNC_TOKEN is a fine-grained PAT with contents read/write on virtuoso-dev/skills.
+      - name: Clone target repository
+        run: git clone "https://x-access-token:${SKILLS_SYNC_TOKEN}@github.com/virtuoso-dev/skills.git" target
+        env:
+          SKILLS_SYNC_TOKEN: ${{ secrets.SKILLS_SYNC_TOKEN }}
+
+      # Only the skill directories are managed by the sync; root files (README, LICENSE)
+      # are owned by the target repository.
+      - name: Copy skill directories
+        run: |
+          for skill in skills/*/; do
+            name=$(basename "$skill")
+            rsync -a --delete "$skill" "target/$name/"
+          done
+
+      - name: Commit and push
+        run: |
+          cd target
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Mirror already up to date"
+            exit 0
+          fi
+          git config user.name "virtuoso-skills-sync[bot]"
+          git config user.email "support@virtuoso.dev"
+          git commit -m "Sync skills from petyosi/react-virtuoso@${GITHUB_SHA}"
+          git push

--- a/apps/virtuoso.dev/src/components/Header.astro
+++ b/apps/virtuoso.dev/src/components/Header.astro
@@ -82,6 +82,15 @@ function isActive(path: string) {
       >
         Pricing
       </a>
+      <a
+        class:list={[
+          'text-sm font-medium no-underline transition-colors duration-200',
+          isActive('/skills/') ? 'text-(--sl-color-text-accent)' : 'text-(--sl-color-white) hover:text-(--sl-color-text-accent)',
+        ]}
+        href="/skills/"
+      >
+        Agent Skills
+      </a>
     </nav>
     <div class="sl-flex w-full md:w-96">
       {shouldRenderSearch && <Search />}

--- a/apps/virtuoso.dev/src/components/MobileMenu.astro
+++ b/apps/virtuoso.dev/src/components/MobileMenu.astro
@@ -16,6 +16,7 @@ const navLinks = [
   { badge: 'New', href: '/data-table/', isActive: isActive('/data-table/'), label: 'Data Table' },
   { href: '/masonry/', isActive: isActive('/masonry/'), label: 'Virtuoso Masonry' },
   { href: '/pricing/', isActive: isActive('/pricing/'), label: 'Pricing' },
+  { href: '/skills/', isActive: isActive('/skills/'), label: 'Agent Skills' },
 ]
 ---
 

--- a/apps/virtuoso.dev/src/content/docs/skills.mdx
+++ b/apps/virtuoso.dev/src/content/docs/skills.mdx
@@ -1,0 +1,51 @@
+---
+title: 'Agent Skills'
+description: Install agent skills that teach Claude Code, Codex, Cursor, and other coding agents how to use react-virtuoso, message-list, data-table, and the reactive engine correctly.
+tableOfContents: false
+template: splash
+---
+
+The Virtuoso packages ship [Agent Skills](https://agentskills.io) — structured guidance that teaches coding agents how to use each package correctly. Instead of guessing from training data (and carrying over habits from other virtualization libraries), an agent with the skills installed knows the component selection rules, the measurement constraints, the common pitfalls, and has the full package documentation at hand as references.
+
+Four skills are available:
+
+| Skill             | Covers                                                                                                |
+| ----------------- | ----------------------------------------------------------------------------------------------------- |
+| `react-virtuoso`  | Virtualized lists, grids, and tables — `Virtuoso`, `GroupedVirtuoso`, `VirtuosoGrid`, `TableVirtuoso` |
+| `message-list`    | Chat and AI conversation UIs — `VirtuosoMessageList`                                                  |
+| `data-table`      | The virtualized data grid — `@virtuoso.dev/data-table`                                                |
+| `reactive-engine` | The `@virtuoso.dev/reactive-engine-*` state management family                                         |
+
+## Claude Code
+
+Install the plugin from the repository marketplace:
+
+```text
+/plugin marketplace add petyosi/react-virtuoso
+/plugin install virtuoso-skills@virtuoso
+```
+
+## Codex
+
+```bash
+codex plugin marketplace add petyosi/react-virtuoso --ref main --sparse .agents/plugins --sparse plugins/virtuoso-skills
+codex plugin add virtuoso-skills@virtuoso
+```
+
+## Cursor, OpenCode, and other agents
+
+Use the [Agent Skills CLI](https://github.com/vercel-labs/skills) against the [virtuoso-dev/skills](https://github.com/virtuoso-dev/skills) mirror:
+
+```bash
+npx skills add virtuoso-dev/skills --skill '*'
+```
+
+Or install individual skills:
+
+```bash
+npx skills add virtuoso-dev/skills --skill react-virtuoso
+```
+
+## How the skills are maintained
+
+The skills are authored and versioned in the [react-virtuoso monorepo](https://github.com/petyosi/react-virtuoso) next to the packages they describe. Each skill bundles the package documentation as references, regenerated on every change — so the guidance ships from the same source, at the same time, as the code it documents. The [virtuoso-dev/skills](https://github.com/virtuoso-dev/skills) repository is a generated mirror for skill installers; report issues and contribute in the monorepo.

--- a/packages/react-virtuoso/README.md
+++ b/packages/react-virtuoso/README.md
@@ -29,6 +29,12 @@ React components for efficiently rendering large lists, grids, and tables with v
 npm install react-virtuoso
 ```
 
+If you work with a coding agent (Claude Code, Codex, Cursor), install the [Virtuoso agent skills](https://virtuoso.dev/skills/) so it knows the component selection rules, measurement constraints, and common pitfalls:
+
+```bash
+npx skills add virtuoso-dev/skills --skill react-virtuoso
+```
+
 ## Quick Start
 
 ### Virtuoso

--- a/packages/react-virtuoso/package.json
+++ b/packages/react-virtuoso/package.json
@@ -61,7 +61,7 @@
     "@faker-js/faker": "^7.6.0",
     "@ladle/react": "catalog:",
     "@microsoft/api-extractor": "catalog:",
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "^1.60.0",
     "@testing-library/react": "catalog:",
     "@types/jsdom": "^21.1.1",
     "@types/lodash": "^4.14.194",

--- a/packages/reactive-engine-core/README.md
+++ b/packages/reactive-engine-core/README.md
@@ -1,0 +1,46 @@
+# Reactive Engine Core
+
+`@virtuoso.dev/reactive-engine-core` is a framework-agnostic reactive state engine. State is modeled as a graph of typed nodes — stateful cells, stateless streams, and valueless triggers — connected through operators and combinators. An `Engine` instance activates the graph, propagates values, and manages subscriptions.
+
+The package is part of the Reactive Engine family:
+
+- [`@virtuoso.dev/reactive-engine-react`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-react) - React bindings (provider and hooks)
+- [`@virtuoso.dev/reactive-engine-query`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-query) - data fetching with queries and mutations
+- [`@virtuoso.dev/reactive-engine-router`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-router) - routing with routes, layouts, and guards
+- [`@virtuoso.dev/reactive-engine-storage`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-storage) - cell persistence in local/session storage or cookies
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core
+```
+
+## Quick Example
+
+```ts
+import { Cell, Engine } from '@virtuoso.dev/reactive-engine-core'
+
+const count$ = Cell(0)
+const engine = new Engine()
+
+engine.sub(count$, (value) => {
+  console.log('count is now', value)
+})
+
+engine.pub(count$, 1)
+engine.getValue(count$) // 1
+```
+
+## Concepts
+
+- **Cells** are stateful nodes that always hold a current value.
+- **Streams** are stateless nodes that emit values to their subscribers.
+- **Triggers** are valueless streams used to signal events.
+- **Resources** are cells with factory initialization and automatic disposal.
+- **Operators** (`map`, `filter`, `scan`, `debounceTime`, `throttleTime`, `withLatestFrom`, and more) transform values as they flow between nodes.
+- **Combinators** (`link`, `pipe`, `combine`, `merge`) wire nodes into a graph.
+- **Engine** instances activate node definitions, propagate published values, and manage subscriptions.
+
+## License
+
+MIT

--- a/packages/reactive-engine-core/docs/01.core-concepts.md
+++ b/packages/reactive-engine-core/docs/01.core-concepts.md
@@ -1,0 +1,113 @@
+---
+title: Core Concepts
+description: Nodes, engines, and the separation between graph definitions and runtime state.
+---
+
+The reactive engine models application logic as a graph of typed nodes. Two ideas carry everything else:
+
+1. **Nodes are definitions, not state.** A node constructor returns an inert reference — at runtime it is literally a `Symbol`. Creating a node records its definition (type, initial value, distinct behavior) in a global registry, but holds no value.
+2. **Engines hold state.** An `Engine` instance activates nodes on first use and owns their values. The same node used by two engines has two independent values.
+
+```ts
+import { Cell, Engine } from '@virtuoso.dev/reactive-engine-core'
+
+const count$ = Cell(0) // a definition, usually at module scope
+
+const a = new Engine()
+const b = new Engine()
+a.pub(count$, 5)
+a.getValue(count$) // 5
+b.getValue(count$) // 0 — independent state
+```
+
+This split is what makes the engine suitable for building reusable components: a library defines its node graph once at module scope, and every component instance gets its own engine — its own state — without re-declaring anything.
+
+## Node types
+
+| Node                            | State          | Emits                  | Use for                                            |
+| ------------------------------- | -------------- | ---------------------- | -------------------------------------------------- |
+| `Cell(initial, distinct?)`      | Current value  | On value change        | App state, configuration, derived values           |
+| `Stream<T>(distinct?)`          | None           | On publish             | Events, commands, transient data                   |
+| `Trigger()`                     | None           | On publish (valueless) | "Something happened" signals                       |
+| `Resource(factory)`             | Factory result | —                      | Per-engine objects with setup/teardown             |
+| `DerivedCell(initial, source$)` | Current value  | When the source emits  | Read-only computed state                           |
+| `Pipe<T>(...operators)`         | —              | —                      | An input/output node pair with a transform between |
+
+```ts
+import { Cell, Stream, Trigger, Resource } from '@virtuoso.dev/reactive-engine-core'
+
+const theme$ = Cell<'light' | 'dark'>('light')
+const keyPressed$ = Stream<string>()
+const reset$ = Trigger()
+const cache$ = Resource(() => ({
+  data: new Map<string, unknown>(),
+  dispose() {
+    this.data.clear()
+  },
+}))
+```
+
+A `Resource` factory runs once per engine, the first time the engine touches the node. On `engine.dispose()` the engine calls the instance's `[Symbol.dispose]()` if present, falling back to `dispose()`.
+
+`DerivedCell` is a cell whose value tracks a source expression:
+
+```ts
+import { DerivedCell, e } from '@virtuoso.dev/reactive-engine-core'
+
+const fahrenheit$ = DerivedCell(
+  32,
+  e.pipe(
+    celsius$,
+    e.map((c) => c * 1.8 + 32)
+  )
+)
+```
+
+Components read it like any cell; nothing can publish into it directly without going through the source.
+
+## Distinct semantics
+
+Every Cell and Stream filters duplicate emissions by default:
+
+- `true` (default) — compare with `===` (the `defaultComparator`; reference equality, not deep equality)
+- `false` — never filter; every publish emits
+- `(prev, next) => boolean` — custom comparator returning `true` when values are equal (suppress emission)
+
+```ts
+const user$ = Cell<User | null>(null, (prev, next) => prev?.id === next?.id)
+```
+
+Two consequences worth internalizing:
+
+- Because the default is reference equality, publishing a mutated object does not emit. Always publish new references (`new Map(old)`, spread), the same discipline React state requires.
+- The comparator receives `undefined` as `prev` on the first emission — write comparators with optional chaining.
+
+Triggers never filter; every publish fires.
+
+## The `e` namespace
+
+The package exports each operator and combinator individually, and also bundles them in a single `e` object — convenient when wiring many connections:
+
+```ts
+import { e } from '@virtuoso.dev/reactive-engine-core'
+
+e.link(
+  e.pipe(
+    toggleTheme$,
+    e.withLatestFrom(theme$),
+    e.map(([, current]) => (current === 'light' ? 'dark' : 'light'))
+  ),
+  theme$
+)
+```
+
+`e` contains the combinators (`link`, `pipe`, `combine`, `merge`, `sub`, `changeWith`, ...), the operators (`map`, `filter`, `scan`, ...), and the context-bound utilities (`pub`, `getValue`, `pubIn` — see [Engine and Lifecycle](./02.engine-and-lifecycle.md) for where those are allowed).
+
+## Naming conventions
+
+- Node references take a `$` suffix: `count$`, `setColumnVisibility$`.
+- Input streams that represent user actions read as commands: `resizeColumn$`, `toggleTheme$`.
+- State cells read as nouns: `theme$`, `scrollLocation$`.
+- Plain helper functions take no suffix.
+
+These conventions come from the packages built on the engine (data-table follows them throughout) and make the input/output boundary of a module visible at a glance.

--- a/packages/reactive-engine-core/docs/02.engine-and-lifecycle.md
+++ b/packages/reactive-engine-core/docs/02.engine-and-lifecycle.md
@@ -1,0 +1,108 @@
+---
+title: Engine and Lifecycle
+description: How engines activate nodes, the three API flavors, engine context, child engines, and disposal.
+---
+
+## Activation: how a node comes alive in an engine
+
+Nodes register lazily. The first time an engine touches a node — through `pub`, `sub`, `getValue`, `link`, or an explicit `engine.register(node$)` — the engine:
+
+1. Looks up the node's definition in the global registry and creates its state slot (or runs the `Resource` factory).
+2. Runs every **node init** attached to the node, once per engine, inside engine context.
+
+Node inits are the deferred-wiring mechanism. `addNodeInit(fn, ...nodes$)` attaches a function that runs when any of the listed nodes first activates in an engine:
+
+```ts
+import { addNodeInit } from '@virtuoso.dev/reactive-engine-core'
+
+addNodeInit((engine) => {
+  engine.link(source$, sink$)
+}, source$)
+```
+
+You rarely call `addNodeInit` directly — the module-scope combinators do it for you (next section). But understanding it explains the engine's central trick: _wiring declared at module scope applies to every engine that ever uses those nodes, paid for only when used._
+
+## The three API flavors
+
+The same verbs exist in three forms. Choosing the right one is most of the learning curve:
+
+| Flavor                   | Examples                                                        | Where it works                                    | What it does                                                                          |
+| ------------------------ | --------------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Module-scope combinators | `link`, `pipe`, `sub`, `changeWith`, `combine` (also via `e.*`) | Anywhere, including module top level              | Registers a node init — deferred wiring for **every** engine that activates the nodes |
+| Engine instance methods  | `engine.pub`, `engine.sub`, `engine.link`, `engine.getValue`    | Anywhere you hold an engine                       | Acts immediately on **that** engine                                                   |
+| Context-bound utilities  | `pub`, `getValue`, `pubIn` (standalone or via `e.*`)            | Only inside subscription callbacks and node inits | Acts on the currently executing engine                                                |
+
+```ts
+import { Cell, Stream, Engine, e } from '@virtuoso.dev/reactive-engine-core'
+
+const saveRequested$ = Stream<void>()
+const draft$ = Cell('')
+const save$ = Stream<string>()
+
+// Module scope: wiring for all engines, applied lazily
+e.sub(saveRequested$, () => {
+  // Context-bound: we are inside a subscription, an engine is active
+  e.pub(save$, e.getValue(draft$))
+})
+
+// Imperative code with an engine in hand
+const engine = new Engine()
+engine.pub(draft$, 'hello')
+engine.pub(saveRequested$)
+```
+
+Calling a context-bound utility outside engine context throws:
+
+```text
+No active engine found. You can use getValue only in the context of node subscription callbacks.
+```
+
+When you hit this error, the fix is one of: use the engine instance method, use a React hook (`useCellValue`, `usePublisher`), or move the code into a subscription/init where context exists.
+
+Note the asymmetry: standalone `sub`/`link`/`changeWith` are safe at module scope (they defer), but standalone `pub`/`getValue`/`pubIn` are not (they need a live engine). The subscription callback also receives the engine as a second argument — `sub(node$, (value, engine) => ...)` — when you prefer being explicit.
+
+## Engine construction
+
+```ts
+new Engine(initialValues?: Record<symbol, unknown>, id?: string, parentEngine?: Engine)
+```
+
+- `initialValues` — seed cell values, keyed by node: `new Engine({ [theme$]: 'dark' })`.
+- `id` — names the engine; used for storage key namespacing and the React engine registry.
+- `parentEngine` — creates a child engine (below).
+
+Key instance methods beyond the verbs already covered: `pubIn(values)` (batch several publishes into one transaction — see [Transactions](./03.transactions.md)), `subMultiple(nodes, cb)`, `singletonSub(node$, cb)`, `combineCells(cells)` (cached combination used by the React bindings), `register(node$)`, `onDispose(cb)`, `dispose()`, and the low-level `connect({ sources, pulls, sink, map })` that all operators reduce to.
+
+## singletonSub: subscriptions that replace themselves
+
+`engine.singletonSub(node$, callback)` keeps at most one subscription per node, replacing the previous one on each call. Regular `sub` subscriptions accumulate — calling `sub` in code that re-runs (React renders, update functions) leaks duplicate callbacks. `singletonSub` exists precisely for "the latest callback wins" situations, such as forwarding a node to a React prop:
+
+```ts
+// In an EngineProvider initFn AND updateFn — safe, replaces rather than stacks
+engine.singletonSub(onScroll$, onScroll)
+```
+
+`engine.resetSingletonSubs()` clears them all.
+
+## Child engines
+
+```ts
+const parent = new Engine()
+const child = new Engine({}, 'child-id', parent)
+```
+
+A child engine delegates operations on nodes the parent has registered: publishing or subscribing to a parent-owned node from the child reaches the parent's state, and parent emissions propagate into child subscriptions. Nodes the parent does not own activate locally in the child. Use child engines to scope a feature's state while still seeing shared application state.
+
+## Disposal
+
+`engine.dispose()`:
+
+- runs callbacks registered with `engine.onDispose(cb)`
+- disposes `Resource` instances (`[Symbol.dispose]()` or `dispose()`)
+- clears subscriptions and state; `engine.isDisposed` becomes `true`
+
+Anything that bridges the engine to the outside world (DOM listeners, timers, external stores) should register cleanup with `onDispose` at the point where the bridge is created. The React `EngineProvider` disposes its engine on unmount.
+
+## Debugging
+
+`debug(node$, 'label')` logs every emission of a node with the given label. Subscriptions also receive the engine, so ad-hoc inspection from a callback is `console.log(engine.getValue(other$))`.

--- a/packages/reactive-engine-core/docs/03.transactions.md
+++ b/packages/reactive-engine-core/docs/03.transactions.md
@@ -1,0 +1,56 @@
+---
+title: Transactions and Execution
+description: How publishing works - transactional cycles, topological ordering, and how the engine differs from RxJS.
+---
+
+## One publish, one cycle
+
+Every `engine.pub(node$, value)` runs a complete computation cycle, synchronously:
+
+1. The engine computes the **execution map**: a topological sort of every node reachable from the published node through the graph.
+2. It walks the map sources-before-sinks, computing each node's new value from the latest values of its inputs.
+3. Each node's distinct comparator decides whether it actually emits; nodes that don't emit prune their downstream.
+4. Subscriptions fire for every node that emitted, inside engine context.
+
+By the time `pub` returns, the whole graph is consistent and all subscriptions have run.
+
+## pubIn: batching into a single transaction
+
+`engine.pubIn({ [a$]: 1, [b$]: 2 })` publishes several nodes in **one** cycle. Derived nodes that depend on both inputs compute once, seeing both new values — instead of twice with an inconsistent intermediate state. Whenever you publish more than one related value, use `pubIn`:
+
+```ts
+engine.pubIn({
+  [data$]: rows,
+  [groupIndices$]: groups,
+})
+```
+
+## Diamond dependencies emit once
+
+Given `a$ → b$`, `a$ → c$`, and `(b$, c$) → d$`, publishing to `a$` makes `d$` emit exactly once per cycle, after both `b$` and `c$` computed. This is the property that makes derived state composable — you never observe a "glitch" where `d$` fires with one fresh and one stale input.
+
+## When distinct is checked
+
+The comparator runs during node computation, comparing against the node's current value. It is not a pre-publish check on the caller's side. Implications:
+
+- A `Cell` that receives the same value emits nothing downstream — derived nodes and subscriptions stay quiet.
+- `map(fn, distinct?)` takes its own distinct parameter; a derived node can filter duplicates even when its source always emits.
+- The comparator sees `prev === undefined` on a node's first computation.
+
+## Re-entrancy
+
+Publishing from inside a subscription starts a **nested cycle** — cycles are not queued or merged. This is allowed and common (a subscription reacting to one node by publishing another), but recursive publishes to the same node must terminate, or you have an infinite loop. To defer work to after the current cycle, route it through `delayWithMicrotask()`:
+
+```ts
+e.link(e.pipe(burst$, e.delayWithMicrotask()), settled$)
+```
+
+## Differences from RxJS
+
+If you come from RxJS (or urx), recalibrate on these points:
+
+- **No completion, no error channel.** Nodes never complete; exceptions in operators or subscriptions propagate to the publisher and abort the cycle. Handle errors at the edges — inside `queryFn`-style async work or subscription bodies — not in the graph.
+- **Synchronous by default.** Emissions happen during `pub`, not on a scheduler. Only `throttleTime`, `debounceTime`, `delayWithMicrotask`, and `handlePromise` introduce asynchrony.
+- **Subscribing does not replay.** Subscribing to a `Cell` does not invoke the callback with the current value — read it with `getValue` if needed at subscribe time. (The React hooks do this for you.) Streams have no current value at all; `getValue` on a stream returns `undefined`.
+- **No per-subscription operator chains.** Operators transform nodes into new nodes (`pipe` returns a `NodeRef`); they are part of the shared graph, not private to a subscriber.
+- **Promises resolve out of order.** `handlePromise` emits results as promises settle; a slow earlier request can emit after a fast later one. Abort or sequence-guard async work where ordering matters (the `Query` package does this for you).

--- a/packages/reactive-engine-core/docs/04.operators-and-combinators.md
+++ b/packages/reactive-engine-core/docs/04.operators-and-combinators.md
@@ -1,0 +1,68 @@
+---
+title: Operators and Combinators
+description: Reference for transforming and connecting nodes.
+---
+
+Combinators connect nodes; operators transform values inside a `pipe`. All are available as named exports and on the `e` namespace object. The module-scope forms register deferred wiring (applied per engine on activation); the `Engine` instance methods of the same names act immediately on one engine.
+
+## Combinators
+
+| Combinator                                                    | Purpose                                                                  |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `link(source$, sink$)`                                        | Forward every emission from source to sink                               |
+| `pipe(source$, ...operators)`                                 | Derive a new node by running emissions through operators                 |
+| `combine(a$, b$, ...)`                                        | Node emitting `[a, b, ...]` whenever any source emits (up to 22 sources) |
+| `merge(a$, b$, ...)`                                          | Node emitting each source's values individually                          |
+| `sub(node$, cb)`                                              | Subscribe; `cb(value, engine)`                                           |
+| `singletonSub(node$, cb)`                                     | Exclusive subscription — replaces the previous singleton on the node     |
+| `subMultiple([a$, b$], cb)`                                   | One callback over several nodes                                          |
+| `changeWith(cell$, source$, (cell, value) => next)`           | Update a cell from a stream, reducer-style                               |
+| `withResource(source$, resource$, (value, resource) => void)` | Side effect pairing emissions with a resource instance                   |
+
+`changeWith` is the workhorse for "action stream updates state cell":
+
+```ts
+e.changeWith(columnWidths$, resizeColumn$, (widths, { key, width }) => {
+  const next = new Map(widths)
+  next.set(key, width)
+  return next
+})
+```
+
+Return a **new** reference from the reducer — cells are distinct by reference equality, so mutating and returning the same Map emits nothing.
+
+## Operators
+
+| Operator                                    | Behavior                                                                                          |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `map(fn, distinct?)`                        | Transform each value; optional distinct filter on the output                                      |
+| `filter(predicate)`                         | Drop values failing the predicate; supports type-guard predicates for narrowing                   |
+| `mapTo(value)`                              | Replace every emission with a constant                                                            |
+| `scan((acc, value) => acc, seed)`           | Running accumulation                                                                              |
+| `once()`                                    | Pass only the first emission                                                                      |
+| `withLatestFrom(...nodes$)`                 | Append the latest values of other nodes to each source emission; emits only when the source emits |
+| `throttleTime(ms)`                          | Rate-limit emissions                                                                              |
+| `debounceTime(ms)`                          | Emit only after the source goes quiet for the duration                                            |
+| `delayWithMicrotask()`                      | Re-emit in a microtask, after the current cycle                                                   |
+| `onNext(buf$)`                              | Buffer the source value, emit `[buffered, value]` when `buf$` next emits                          |
+| `handlePromise(onLoad, onSuccess, onError)` | Expand a promise-emitting node into loading/success/error emissions                               |
+
+Two distinctions that prevent common mistakes:
+
+- `combine` vs `withLatestFrom`: `combine` emits when _any_ input changes; `withLatestFrom` only when the _source_ emits, with the other nodes read passively. Use `withLatestFrom` for "when the user clicks, read the current settings", `combine` for "recompute whenever anything changes".
+- `map(..., distinct)` vs node distinct: pass `false` as map's distinct when piping into a Trigger-like sink that must fire every time — for example mapping mutation successes to `undefined` for a refetch trigger:
+
+```ts
+e.link(
+  e.pipe(
+    e.merge(create.data$, remove.data$),
+    e.filter((r) => r.type === 'success'),
+    e.map(() => undefined, false) // without false, the second success would be filtered as a duplicate undefined
+  ),
+  tasksQuery.refetch$
+)
+```
+
+## The low-level primitive: connect
+
+Every operator and combinator reduces to `engine.connect({ sources, pulls, sink, map })`: when any node in `sources` emits, call `map(done)(...sourceValues, ...pullValues)`; calling `done(value)` proposes an emission on `sink` (still subject to the sink's distinct check). `pulls` are read passively without triggering. Reach for `connect` only when no operator combination expresses the dependency shape — it is the engine's assembly language.

--- a/packages/reactive-engine-core/docs/05.building-on-the-engine.md
+++ b/packages/reactive-engine-core/docs/05.building-on-the-engine.md
@@ -1,0 +1,142 @@
+---
+title: Building on the Engine
+description: Architecture patterns for components and libraries built on the reactive engine, extracted from @virtuoso.dev/data-table.
+---
+
+`@virtuoso.dev/data-table` is the largest production system built on the engine. Its architecture demonstrates the patterns that make engine-based components scale. Each pattern below is generic; data-table serves as the worked example.
+
+## Module-scope graph, per-instance engine
+
+Define the entire node graph and its wiring at module scope. Instantiate one engine per component instance. Because module-scope combinators register deferred inits, the wiring applies automatically to every engine that activates the nodes — and each instance's state stays isolated.
+
+```ts
+// feature module, module scope — runs once per import, applies to every engine
+export const setColumnVisibility$ = Stream<SetColumnVisibilityPayload>()
+export const resetColumnVisibility$ = Trigger()
+
+e.changeWith(
+  columnVisibilityOverrides$,
+  e.pipe(setColumnVisibility$, e.withLatestFrom(columns$)),
+  (overrides, [{ key, visible }, columns]) => {
+    /* return a new Map */
+  }
+)
+```
+
+Two tables on one page (`engineId="orders"` / `engineId="invoices"`) share this wiring but never share state.
+
+## Action streams in, state cells out
+
+Design a module's public API as a boundary of nodes:
+
+- **Inputs**: streams and triggers named as commands — `setColumnVisibility$`, `resizeColumn$`, `resetColumnOrder$`. The outside world publishes; it never writes state directly.
+- **Outputs**: cells (often `DerivedCell`) named as state — `columnVisibilityState$`, `scrollLocation$`. The outside world reads and subscribes; it cannot publish into a derived cell.
+
+The wiring between inputs and outputs is internal. This gives the module the same encapsulation a reducer gives a store: all state transitions are enumerable, and every consumer (React component, persistence adapter, test) goes through the same two node kinds.
+
+## Derived cells for computed state
+
+Represent any state computable from other state as a `DerivedCell` over `combine`:
+
+```ts
+export const columnVisibilityState$ = DerivedCell(
+  new Map<string, boolean>(),
+  e.pipe(
+    e.combine(columns$, columnVisibilityOverrides$),
+    e.map(([columns, overrides]) => new Map([...columns].map(([key, c]) => [key, overrides.get(key) ?? c.visible !== false])))
+  )
+)
+```
+
+Store only the minimal independent state (the overrides) and derive the rest. The transaction system guarantees derived cells never observe partially-updated inputs.
+
+## React props flow in through initFn/updateFn; callbacks flow out through singletonSub
+
+The component shell is thin: an `EngineProvider` that pushes props into cells and forwards node emissions to callback props.
+
+```tsx
+<EngineProvider
+  initFn={(e) => {
+    e.register(columns$) // activate nodes whose inits must run eagerly
+    e.pubIn({ [context$]: context, [computeRowKey$]: computeRowKey })
+    e.singletonSub(onScroll$, onScroll)
+  }}
+  updateFn={(e) => {
+    e.pubIn({ [context$]: context, [computeRowKey$]: computeRowKey })
+    e.singletonSub(onScroll$, onScroll) // replaces, never stacks
+  }}
+  updateDeps={[context, computeRowKey, onScroll]}
+  engineId={engineId}
+  engineRef={engineRef}
+>
+```
+
+- `initFn` runs once at engine creation: register nodes, seed cells with `pubIn`, attach bridges.
+- `updateFn` runs whenever `updateDeps` change: re-publish the changed props. Distinct cells make redundant publishes free.
+- Callback props always go through `singletonSub` so re-renders replace the subscription instead of accumulating duplicates.
+
+Inside the component tree, rendering is just `useCellValue(cell$)` and event handlers are just `usePublisher(action$)` — components contain no logic, only projection.
+
+## Batch related publishes with pubIn
+
+When several cells change together (a data result and its group indices; a set of props), publish them in one `pubIn` transaction so derived nodes compute once with a consistent view.
+
+## Feature modules as opt-in subpath exports
+
+Each optional feature lives in its own module exporting its action streams, state cells, pure helper converters, and UI fragments — published as a package subpath (`@virtuoso.dev/data-table/column-visibility`). The core never imports features; features import core nodes and attach wiring. Because wiring is deferred inits, an unused feature costs nothing: its inits never run in engines that never touch its nodes.
+
+## Remote control: engineRef and engineId
+
+Because state lives in an engine rather than React state, external UI does not need prop drilling or lifted state. The component accepts an identity (`engineRef` from `useEngineRef()` for nearby UI, string `engineId` for distant UI), and external components use remote hooks against the exported nodes:
+
+```tsx
+const scrollToRow = useRemotePublisher(scrollToRow$, engineRef)
+const location = useRemoteCellValue(scrollLocation$, engineRef)
+```
+
+The public node set defines exactly what external control is possible. Remote hooks return `undefined` until the target engine mounts — design consumers to tolerate that.
+
+## Bridging imperative systems
+
+Non-reactive subsystems (data sources, network layers) connect through a bridge: a function that subscribes both directions and returns a cleanup, registered with `engine.onDispose`.
+
+```ts
+function bridgeModelToEngine(model: DataModelHandle, engine: Engine): () => void {
+  const unsubModel = model.subscribe((msg) => {
+    engine.pubIn({ [data$]: msg.rows, [groupIndices$]: msg.groups })
+  })
+  const unsubViewport = engine.sub(viewportRange$, (range) => {
+    model.send({ action: 'viewportChange', payload: range })
+  })
+  return () => {
+    unsubModel()
+    unsubViewport()
+  }
+}
+```
+
+The engine side stays declarative (cells and streams); the imperative side keeps its own protocol. data-table uses this to keep its data models (`localModel`, `remoteModel`) engine-free and independently testable.
+
+## Persistence adapters
+
+Persisting feature state generalizes into an adapter interface that each feature implements with its own pure serializers:
+
+```ts
+interface PersistenceAdapter<State> {
+  key: string
+  capture(context, previous: State | null): State // engine state -> storable shape
+  restore(context, state: State | null): void // storable shape -> publishes into the engine
+  subscribe(context, onChange): () => void // watch the nodes that mean "state changed, save it"
+  subscribeRestore?(context, onChange): () => void // watch the nodes that mean "re-apply saved state"
+}
+```
+
+An orchestrator component owns the storage, debounces writes, restores on mount, and knows nothing about any feature. Note the two subscription channels: `subscribe` watches user actions (save triggers), `subscribeRestore` watches structural changes like the column set (re-apply triggers). For simple cases — one cell, one storage key — skip the adapter machinery and use `linkCellToStorage` from `@virtuoso.dev/reactive-engine-storage`.
+
+## Invariants to respect
+
+- **Register dependency nodes before attaching bridges** in `initFn` — wiring inits must be in place before data starts flowing.
+- **Always return new references from reducers** (`changeWith`, `map`) — distinct is reference equality.
+- **Every bridge returns a cleanup**, and every cleanup reaches `engine.onDispose` (or the provider's unmount path).
+- **Keep the graph acyclic.** If two cells must influence each other, route one direction through an action stream or `delayWithMicrotask`.
+- **`singletonSub` for anything driven by React renders**; plain `sub` only in module wiring and inits.

--- a/packages/reactive-engine-core/package.json
+++ b/packages/reactive-engine-core/package.json
@@ -2,6 +2,7 @@
   "name": "@virtuoso.dev/reactive-engine-core",
   "version": "0.0.7",
   "private": false,
+  "description": "Framework-agnostic reactive state engine built on a graph of typed nodes.",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/reactive-engine-query/README.md
+++ b/packages/reactive-engine-query/README.md
@@ -1,0 +1,41 @@
+# Reactive Engine Query
+
+`@virtuoso.dev/reactive-engine-query` adds data fetching to [`@virtuoso.dev/reactive-engine-core`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-core). Queries and mutations are reactive nodes: parameters flow in, and pending/success/error results flow out to the rest of the graph.
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core @virtuoso.dev/reactive-engine-query
+```
+
+## Quick Example
+
+```ts
+import { Query } from '@virtuoso.dev/reactive-engine-query'
+
+interface Task {
+  id: string
+  title: string
+}
+
+export const tasksQuery = Query<{ listId: string }, Task[]>({
+  queryFn: async ({ listId }, signal) => {
+    const res = await fetch(`/api/tasks?listId=${listId}`, { signal })
+    if (!res.ok) {
+      throw new Error('Failed to fetch tasks')
+    }
+    return res.json()
+  },
+  initialParams: { listId: '' },
+})
+```
+
+## Features
+
+- `Query` - parameterized async reads with abort signal support, retries, and typed pending/success/error results
+- `Mutation` - async writes with typed idle/pending/success/error results
+- `executeWithRetry` / `defaultRetryDelay` - retry utilities used by both
+
+## License
+
+MIT

--- a/packages/reactive-engine-query/docs/01.queries-and-mutations.md
+++ b/packages/reactive-engine-query/docs/01.queries-and-mutations.md
@@ -1,0 +1,124 @@
+---
+title: Queries and Mutations
+description: Data fetching as nodes - lifecycle, result states, retries, and wiring patterns.
+---
+
+`@virtuoso.dev/reactive-engine-query` expresses data fetching as engine nodes, so queries compose with the rest of the graph: route params can drive query params, mutation successes can trigger refetches, and components consume results with `useCellValue` like any other state.
+
+## Query
+
+```ts
+export const tasksQuery = Query<{ listId: string }, Task[]>({
+  queryFn: async ({ listId }, signal) => {
+    const res = await fetch(`/api/tasks?listId=${listId}`, { signal })
+    if (!res.ok) throw new Error('Failed to fetch tasks')
+    return res.json()
+  },
+  initialParams: { listId: '' },
+})
+```
+
+`Query()` returns a bundle of nodes:
+
+| Node          | Kind    | Role                                                        |
+| ------------- | ------- | ----------------------------------------------------------- |
+| `data$`       | Cell    | The query result (discriminated union below)                |
+| `params$`     | Cell    | Publishing new params re-executes the query                 |
+| `refetch$`    | Trigger | Re-execute with current params                              |
+| `invalidate$` | Trigger | Mark stale: keep showing data, set `isFetching`, re-execute |
+| `unload$`     | Trigger | Abort, clear data, return to pending                        |
+| `enabled$`    | Cell    | Gate execution; toggling to `true` executes                 |
+
+Options: `enabled` (default `true`), `retry` (default `3`; `retry: 3` means up to 4 attempts), `retryDelay` (default exponential backoff capped at 30s), `refetchInterval` (polling, starts after a successful fetch), `initialData`.
+
+### Result shape
+
+`data$` emits one of three states, discriminated on `type`:
+
+```ts
+{ type: 'pending', data: null,  isLoading: true,  isFetching: true,  isSuccess: false, isError: false, error: null }
+{ type: 'success', data: T,     isLoading: false, isFetching: boolean, isSuccess: true,  isError: false, error: null, dataUpdatedAt: number }
+{ type: 'error',   data: null,  isLoading: false, isFetching: false, isSuccess: false, isError: true,  error: unknown }
+```
+
+`isFetching: true` inside the success state means a background refresh is in flight while stale data stays visible — that is what `invalidate$` produces, versus `unload$` which drops to pending.
+
+### Lifecycle rules
+
+- A query executes when its `data$` first activates in an engine (if enabled), whenever `params$` emits (if enabled), on `refetch$`/`invalidate$`, and when `enabled$` flips to `true`.
+- Each execution aborts the previous in-flight request — the `signal` passed to `queryFn` must reach the actual fetch.
+- Disabling aborts in-flight work and stops polling.
+- Query state is per engine, like all node state; the same query in two engines fetches independently.
+
+## Mutation
+
+```ts
+export const createTask = Mutation<{ listId: string; title: string }, Task>({
+  mutationFn: async (params) => {
+    /* POST */
+  },
+})
+```
+
+Returns `data$` (states `idle | pending | success | error`, with `isPending`/`isSuccess`/`isError` flags), `mutate$` (publish params to execute), and `reset$` (back to idle). Mutations never auto-execute and don't retry by default. `onSuccess(data)`/`onError(error)` callbacks fire after the state publish.
+
+```tsx
+const create = usePublisher(createTask.mutate$)
+const result = useCellValue(createTask.data$)
+
+<button disabled={result.isPending} onClick={() => create({ listId, title })}>Add</button>
+```
+
+## Wiring patterns
+
+**Mutations trigger refetches in the graph, not in components.** Declare the relationship once at module scope:
+
+```ts
+e.link(
+  e.pipe(
+    e.merge(createTask.data$, updateTask.data$, deleteTask.data$),
+    e.filter((r) => r.type === 'success'),
+    e.map(() => undefined, false) // distinct=false: consecutive successes must each fire
+  ),
+  tasksQuery.refetch$
+)
+```
+
+**Routes drive query params.** A route node emits its params when matched; pipe it into `params$`:
+
+```ts
+e.link(
+  e.pipe(
+    tasks$, // Route('/lists/{id:string}', TasksPage)
+    e.filter((params) => params !== null),
+    e.map((params) => ({ listId: params.id }))
+  ),
+  tasksQuery.params$
+)
+```
+
+Navigation then transparently refetches — no effect hooks, no param threading through components.
+
+**Dependent queries** gate on their prerequisite:
+
+```ts
+e.link(
+  e.pipe(
+    userQuery.data$,
+    e.map((r) => r.type === 'success')
+  ),
+  ordersQuery.enabled$
+)
+```
+
+## Rendering results
+
+Branch on the discriminated union:
+
+```tsx
+const result = useCellValue(tasksQuery.data$)
+
+if (result.isLoading) return <Spinner />
+if (result.isError) return <ErrorView error={result.error} />
+return <TaskList tasks={result.data} refreshing={result.isFetching} />
+```

--- a/packages/reactive-engine-query/package.json
+++ b/packages/reactive-engine-query/package.json
@@ -2,6 +2,7 @@
   "name": "@virtuoso.dev/reactive-engine-query",
   "version": "0.0.3",
   "private": false,
+  "description": "Reactive data fetching with queries and mutations for the Virtuoso reactive engine.",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/reactive-engine-react/README.md
+++ b/packages/reactive-engine-react/README.md
@@ -1,0 +1,45 @@
+# Reactive Engine React
+
+`@virtuoso.dev/reactive-engine-react` provides React bindings for [`@virtuoso.dev/reactive-engine-core`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-core): an `EngineProvider` component and hooks for reading cell values and publishing into nodes from components.
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core @virtuoso.dev/reactive-engine-react
+```
+
+## Quick Example
+
+```tsx
+import { Cell } from '@virtuoso.dev/reactive-engine-core'
+import { EngineProvider, useCellValue, usePublisher } from '@virtuoso.dev/reactive-engine-react'
+
+const count$ = Cell(0)
+
+function Counter() {
+  const count = useCellValue(count$)
+  const setCount = usePublisher(count$)
+
+  return <button onClick={() => setCount(count + 1)}>{count}</button>
+}
+
+export function App() {
+  return (
+    <EngineProvider>
+      <Counter />
+    </EngineProvider>
+  )
+}
+```
+
+## Hooks
+
+- `useCellValue` / `useCellValues` - subscribe to one or several cells
+- `useCell` - read a cell value and get a publisher for it
+- `usePublisher` - get a publisher function for a node
+- `useEngine` / `useEngineRef` - access the engine instance from context
+- `useRemoteCell`, `useRemoteCellValue`, `useRemoteCellValues`, `useRemotePublisher` - work with cells from another engine instance
+
+## License
+
+MIT

--- a/packages/reactive-engine-react/docs/01.react-integration.md
+++ b/packages/reactive-engine-react/docs/01.react-integration.md
@@ -1,0 +1,93 @@
+---
+title: React Integration
+description: EngineProvider lifecycle, hooks, and remote engine access.
+---
+
+## EngineProvider
+
+`EngineProvider` creates an engine when it mounts, provides it through context, and disposes it on unmount. While the provider is mounted, the engine is the source of truth; React components project its state.
+
+```tsx
+<EngineProvider
+  initWith={{ [theme$]: 'dark' }} // seed cell values at construction
+  initFn={(engine) => {
+    /* one-time setup: register nodes, bridges, singleton subs */
+  }}
+  updateFn={(engine) => {
+    /* re-publish changed props */
+  }}
+  updateDeps={[propA, propB]}
+  engineId="my-feature" // optional: global registry + storage namespacing
+  engineRef={engineRef} // optional: handle for remote hooks
+>
+  {children}
+</EngineProvider>
+```
+
+Lifecycle details that matter:
+
+- The engine is created in a `useState` initializer and `initFn` runs synchronously right after — before the first render of children.
+- `updateFn` runs in a layout effect whenever `updateDeps` change (including once after mount). It is independent of `initFn`; both should be written idempotently. Use `pubIn` for prop values (distinct cells absorb no-op republishes) and `singletonSub` for callback props.
+- On unmount the engine is disposed and (if set) removed from the registry/ref.
+- Nesting providers shadows the engine context — `useEngine()` returns the nearest provider's engine. Providers do not automatically parent-link; coordinate separate engines through remote hooks or construct child engines yourself.
+
+## Hooks
+
+| Hook                         | Returns                             | Notes                                                                                |
+| ---------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------ |
+| `useCellValue(cell$)`        | Current value, re-renders on change | Backed by `useSyncExternalStore`; SSR-safe                                           |
+| `useCellValues(a$, b$, ...)` | Tuple of values                     | Single subscription via a combined cell — one re-render when several change together |
+| `useCell(cell$)`             | `[value, publish]`                  | The `useState` shape                                                                 |
+| `usePublisher(node$)`        | Stable `(value) => void`            | Safe in effect dependency arrays                                                     |
+| `useEngine()`                | The provider's engine               | For imperative escape hatches                                                        |
+| `useEngineRef()`             | A stable `EngineRef`                | Pass to a provider's `engineRef` and to remote hooks                                 |
+
+Prefer `useCellValues` over several `useCellValue` calls when a component reads multiple cells that change in the same transaction — it collapses them into one re-render.
+
+## Remote hooks: reaching an engine from outside its tree
+
+Remote hooks accept an `EngineSource` — an `EngineRef` or a string `engineId` — and resolve the engine through the ref or a global registry:
+
+```tsx
+const value = useRemoteCellValue(scrollLocation$, engineRef)
+const publish = useRemotePublisher(scrollToRow$, 'orders-table')
+const [v, setV] = useRemoteCell(theme$, engineRef)
+const values = useRemoteCellValues({ cells: [a$, b$], engineSource: engineRef })
+```
+
+The defining behavior: **remote hooks return `undefined` until the target engine exists**. They subscribe to the ref/registry and start delivering values as soon as the provider mounts. Guard accordingly:
+
+```tsx
+const location = useRemoteCellValue(scrollLocation$, engineRef)
+if (location === undefined) return null // table not mounted yet
+```
+
+Use an `engineRef` when the controlling UI and the provider share a component (a toolbar next to its table); use an `engineId` when they are far apart and threading a ref is impractical. The id registry is global to the page — namespace ids if several independent features use them.
+
+## SSR
+
+`useCellValue` provides a server snapshot through `useSyncExternalStore`, so server rendering reads the engine's initial values. Reading a cell during render must stay side-effect free. Effect-timing hooks use a layout effect in the browser and a regular effect on the server (`useIsomorphicLayoutEffect`).
+
+## Component patterns
+
+Keep components projection-only:
+
+```tsx
+const VisibilityMenu = () => {
+  const visibility = useCellValue(columnVisibilityState$)
+  const setVisibility = usePublisher(setColumnVisibility$)
+
+  return (
+    <>
+      {[...visibility].map(([key, visible]) => (
+        <label key={key}>
+          <input type="checkbox" checked={visible} onChange={(ev) => setVisibility({ key, visible: ev.target.checked })} />
+          {key}
+        </label>
+      ))}
+    </>
+  )
+}
+```
+
+Logic — what a visibility change means, how it composes with declarations — lives in the module-scope wiring, where it is shared by every instance and testable with a bare `Engine` and no React at all.

--- a/packages/reactive-engine-react/package.json
+++ b/packages/reactive-engine-react/package.json
@@ -2,6 +2,7 @@
   "name": "@virtuoso.dev/reactive-engine-react",
   "version": "0.2.2",
   "private": false,
+  "description": "React bindings for the Virtuoso reactive engine.",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/reactive-engine-router/README.md
+++ b/packages/reactive-engine-router/README.md
@@ -1,0 +1,51 @@
+# Reactive Engine Router
+
+`@virtuoso.dev/reactive-engine-router` is a router built on [`@virtuoso.dev/reactive-engine-core`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-core). Routes are reactive nodes - navigation is publishing into a route node, and the current route flows through the graph like any other value.
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core @virtuoso.dev/reactive-engine-react @virtuoso.dev/reactive-engine-router
+```
+
+## Quick Example
+
+```tsx
+import { usePublisher } from '@virtuoso.dev/reactive-engine-react'
+import { Layout, Router } from '@virtuoso.dev/reactive-engine-router'
+
+import { about$, home$ } from './routes'
+
+const rootLayout = Layout('/', ({ children }) => (
+  <div>
+    <Navigation />
+    <main>{children}</main>
+  </div>
+))
+
+function Navigation() {
+  const goHome = usePublisher(home$)
+  const goToAbout = usePublisher(about$)
+
+  return (
+    <nav>
+      <button onClick={() => goHome({})}>Home</button>
+      <button onClick={() => goToAbout({})}>About</button>
+    </nav>
+  )
+}
+
+export function App() {
+  return <Router layouts={[rootLayout]} routes={[home$, about$]} />
+}
+```
+
+## Features
+
+- **Routes** - typed route definitions with parameters
+- **Layouts** - nested layout components matched by path, with slot/fill composition (`LayoutSlot`, `LayoutSlotFill`)
+- **Guards** - sync or async navigation guards that can continue, redirect, or navigate elsewhere
+
+## License
+
+MIT

--- a/packages/reactive-engine-router/docs/01.routing.md
+++ b/packages/reactive-engine-router/docs/01.routing.md
@@ -68,7 +68,7 @@ Layouts match by URL prefix and nest by specificity — `Layout('/')` wraps ever
 ## Guards
 
 ```tsx
-const authGuard = Guard('/admin/*', (context) => {
+const authGuard = Guard('/admin', (context) => {
   const user = context.engine.getValue(currentUser$)
   if (!user) {
     return context.redirect(login$, {})

--- a/packages/reactive-engine-router/docs/01.routing.md
+++ b/packages/reactive-engine-router/docs/01.routing.md
@@ -1,0 +1,99 @@
+---
+title: Routing
+description: Typed routes as nodes, navigation, layouts, guards, and browser history.
+---
+
+`@virtuoso.dev/reactive-engine-router` represents each route as a node. A route node emits its parsed params when the route is active and `null` when it is not — which makes routing composable with the rest of the graph (drive query params from routes, gate features on the active route).
+
+## Defining routes
+
+```tsx
+import { Route } from '@virtuoso.dev/reactive-engine-router'
+
+export const home$ = Route('/', HomePage)
+export const user$ = Route('/users/{id:number}', UserPage)
+export const blog$ = Route('/blog/{slug}/?category={category?}&tag={tag?}', BlogPage)
+export const files$ = Route('/files/{*rest}', FilesPage)
+```
+
+The path syntax is parsed at the type level — params arrive typed:
+
+- `{id:number}` → `{ id: number }`; `{slug}` defaults to string
+- `?q={query}&limit={limit?:number}` → optional search params under `$search`
+- `{*rest}` → catch-all, `string[]`
+
+The route component receives the params as props, typed as `RouteParams<'/users/{id:number}'>`:
+
+```tsx
+export const UserPage: React.ComponentType<RouteParams<'/users/{id:number}'>> = ({ id }) => <h1>User {id}</h1>
+```
+
+## Mounting and navigating
+
+```tsx
+<EngineProvider>
+  <Router routes={[home$, user$, blog$]} layouts={[rootLayout]} guards={[authGuard]} />
+</EngineProvider>
+```
+
+`Router` needs an engine (mount it inside an `EngineProvider`). Props: `routes`, `layouts`, `guards`, `basePath`, `useBrowserHistory` (default `true` — syncs with the address bar and back/forward buttons).
+
+Navigation is publishing params to a route node:
+
+```tsx
+const goToUser = usePublisher(user$)
+goToUser({ id: 42 }) // navigates to /users/42
+```
+
+Since route nodes are also outputs, the same node tells you whether the route is active:
+
+```tsx
+const userParams = useCellValue(user$) // null when not on /users/...
+```
+
+## Layouts
+
+```tsx
+const rootLayout = Layout('/', ({ children }) => (
+  <main>
+    <Nav />
+    {children}
+  </main>
+))
+const blogLayout = Layout('/blog', ({ children }) => <BlogShell>{children}</BlogShell>)
+```
+
+Layouts match by URL prefix and nest by specificity — `Layout('/')` wraps everything, `Layout('/blog')` wraps inside it for blog routes. For regions a route fills inside a layout (a context-dependent sidebar), create a slot cell with `LayoutSlotPortal()`, render it in the layout with `<LayoutSlot slotPortal={...}>`, and provide content from a page with `<LayoutSlotFill slotPortal={...}>`.
+
+## Guards
+
+```tsx
+const authGuard = Guard('/admin/*', (context) => {
+  const user = context.engine.getValue(currentUser$)
+  if (!user) {
+    return context.redirect(login$, {})
+  }
+  return context.continue()
+})
+```
+
+- A guard's pattern uses route syntax; all guards matching the target URL run in order (priority option, then specificity, then registration order).
+- The context offers `continue()`, `navigate(urlOrRoute, params?)` (retarget and keep evaluating guards against the new URL), `redirect(urlOrRoute, params?)` (abort and navigate), plus `params`, `location`, and `engine`.
+- Guards may be async — the route renders inside `Suspense` while pending, so provide a Suspense boundary above the `Router`.
+
+## Wiring routes into the graph
+
+The canonical pattern — route activation drives data fetching:
+
+```ts
+e.link(
+  e.pipe(
+    user$,
+    e.filter((params) => params !== null),
+    e.map((params) => ({ userId: params.id }))
+  ),
+  userQuery.params$
+)
+```
+
+Pages then need no fetch logic at all: navigating publishes params, params trigger the query, the page reads `userQuery.data$`.

--- a/packages/reactive-engine-router/package.json
+++ b/packages/reactive-engine-router/package.json
@@ -2,6 +2,7 @@
   "name": "@virtuoso.dev/reactive-engine-router",
   "version": "0.0.3",
   "private": false,
+  "description": "Reactive router with routes, layouts, and guards for the Virtuoso reactive engine.",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/reactive-engine-storage/README.md
+++ b/packages/reactive-engine-storage/README.md
@@ -1,0 +1,27 @@
+# Reactive Engine Storage
+
+`@virtuoso.dev/reactive-engine-storage` persists [`@virtuoso.dev/reactive-engine-core`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-core) cells in `localStorage`, `sessionStorage`, or cookies. A storage link hydrates the cell on engine startup and writes changes back as the cell updates.
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core @virtuoso.dev/reactive-engine-storage
+```
+
+## Quick Example
+
+```ts
+import { Cell } from '@virtuoso.dev/reactive-engine-core'
+import { linkCellToStorage } from '@virtuoso.dev/reactive-engine-storage'
+
+const theme$ = Cell<'light' | 'dark'>('light')
+
+linkCellToStorage(theme$, {
+  key: 'app-theme',
+  storageType: 'localStorage',
+})
+```
+
+## License
+
+MIT

--- a/packages/reactive-engine-storage/docs/01.storage-links.md
+++ b/packages/reactive-engine-storage/docs/01.storage-links.md
@@ -1,0 +1,47 @@
+---
+title: Storage Links
+description: Persisting cells to localStorage, sessionStorage, and cookies.
+---
+
+`linkCellToStorage` keeps a cell in sync with browser storage. Declare it at module scope next to the cell:
+
+```ts
+import { Cell } from '@virtuoso.dev/reactive-engine-core'
+import { linkCellToStorage } from '@virtuoso.dev/reactive-engine-storage'
+
+export const theme$ = Cell<'light' | 'dark'>('light')
+
+linkCellToStorage(theme$, {
+  storageType: 'localStorage',
+  key: 'app-theme',
+  debounceMs: 300,
+})
+```
+
+Options form a union on `storageType`:
+
+- `'localStorage'` / `'sessionStorage'` — `{ key, debounceMs?, serialize?, deserialize? }`
+- `'cookie'` — additionally `cookieOptions`: `{ expires?: Date | '7d' | '1h' | '30m', path?, domain?, sameSite?, secure? }`
+
+Serialization defaults to `JSON.stringify`/`JSON.parse`; failures in either direction are swallowed (the cell keeps its in-memory value).
+
+## Timing semantics
+
+The link is implemented as a node init, so everything is lazy and per engine:
+
+- **Read** happens once per engine, when the engine first activates the cell. The stored value (if any) is published into the cell at that moment — before components subscribe through the provider. Reading the cell before any engine activates it yields the constructor's initial value.
+- **Write** happens on cell changes, debounced (default 500ms for localStorage, 0 otherwise). Pending writes are flushed/cleared on engine disposal.
+- **Cross-tab sync** applies to localStorage only: changes from other tabs publish into the cell; the link ignores echoes of its own writes.
+
+## Key namespacing
+
+If the engine has an id (`new Engine({}, 'my-app')` or `<EngineProvider engineId="my-app">`), localStorage/sessionStorage keys become `my-app:app-theme`. This is how multiple instances of the same engine-based component (for example two data tables) persist independently while sharing node definitions. Cookies are not namespaced.
+
+## Server-side rendering
+
+The link is a no-op when `window` is unavailable or the storage type is inaccessible — cells keep their initial values on the server, and storage hydrates them on the client when the engine activates the cell. Expect a possible flash of the initial value before client hydration, and avoid branching server-rendered markup on persisted state.
+
+## When to use what
+
+- One cell, one key: `linkCellToStorage`.
+- Composite, versioned feature state (like a table's column layout): a persistence adapter orchestrator — see "Building on the Engine" in the core docs for the pattern data-table uses.

--- a/packages/reactive-engine-storage/package.json
+++ b/packages/reactive-engine-storage/package.json
@@ -2,6 +2,7 @@
   "name": "@virtuoso.dev/reactive-engine-storage",
   "version": "2.0.1",
   "private": false,
+  "description": "Cell persistence in web storage and cookies for the Virtuoso reactive engine.",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/virtuoso-skills/.claude-plugin/plugin.json
+++ b/packages/virtuoso-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "virtuoso-skills",
-  "description": "Agent skills for react-virtuoso, message-list, and data-table",
+  "description": "Agent skills for react-virtuoso, message-list, data-table, and the reactive engine",
   "version": "0.1.0",
   "author": {
     "name": "Virtuoso.dev",
@@ -9,5 +9,5 @@
   "homepage": "https://virtuoso.dev",
   "repository": "https://github.com/petyosi/react-virtuoso",
   "license": "MIT",
-  "keywords": ["react-virtuoso", "virtualization", "table", "chat", "data-table"]
+  "keywords": ["react-virtuoso", "virtualization", "table", "chat", "data-table", "reactive-engine"]
 }

--- a/packages/virtuoso-skills/README.md
+++ b/packages/virtuoso-skills/README.md
@@ -1,6 +1,6 @@
 # Virtuoso Skills
 
-This private workspace package is the canonical source for the `virtuoso-skills` agent distribution. It packages the same three skills for Claude Code, Codex, and Agent Skills consumers such as Codex, OpenCode, and Cursor.
+This private workspace package is the canonical source for the `virtuoso-skills` agent distribution. It packages the same four skills (react-virtuoso, message-list, data-table, and reactive-engine) for Claude Code, Codex, and Agent Skills consumers such as Codex, OpenCode, and Cursor.
 
 The package is not imported by the runtime libraries. It owns the hand-authored `SKILL.md` source files under `packages/virtuoso-skills/skills/` and generates the documentation references and public mirrors used by installers.
 

--- a/packages/virtuoso-skills/scripts/build-skills.ts
+++ b/packages/virtuoso-skills/scripts/build-skills.ts
@@ -2,27 +2,76 @@ import { cp, mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { dirname, extname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-interface SkillSource {
-  name: 'react-virtuoso' | 'message-list' | 'data-table'
-  docsDir: string
+interface SkillDocsSource {
+  // Destination subdirectory inside references/. Omit for single-package skills.
+  dest?: string
+  // Optional because some packages document themselves through README only.
+  docsDir?: string
   readme: string
+}
+
+interface SkillSource {
+  name: 'react-virtuoso' | 'message-list' | 'data-table' | 'reactive-engine'
+  sources: SkillDocsSource[]
 }
 
 const skillSources: SkillSource[] = [
   {
     name: 'react-virtuoso',
-    docsDir: 'packages/react-virtuoso/docs',
-    readme: 'packages/react-virtuoso/README.md',
+    sources: [
+      {
+        docsDir: 'packages/react-virtuoso/docs',
+        readme: 'packages/react-virtuoso/README.md',
+      },
+    ],
   },
   {
     name: 'message-list',
-    docsDir: 'packages/message-list/docs',
-    readme: 'packages/message-list/README.md',
+    sources: [
+      {
+        docsDir: 'packages/message-list/docs',
+        readme: 'packages/message-list/README.md',
+      },
+    ],
   },
   {
     name: 'data-table',
-    docsDir: 'packages/data-table/docs',
-    readme: 'packages/data-table/README.md',
+    sources: [
+      {
+        docsDir: 'packages/data-table/docs',
+        readme: 'packages/data-table/README.md',
+      },
+    ],
+  },
+  {
+    name: 'reactive-engine',
+    sources: [
+      {
+        dest: 'core',
+        docsDir: 'packages/reactive-engine-core/docs',
+        readme: 'packages/reactive-engine-core/README.md',
+      },
+      {
+        dest: 'react',
+        docsDir: 'packages/reactive-engine-react/docs',
+        readme: 'packages/reactive-engine-react/README.md',
+      },
+      {
+        dest: 'query',
+        docsDir: 'packages/reactive-engine-query/docs',
+        readme: 'packages/reactive-engine-query/README.md',
+      },
+      {
+        dest: 'router',
+        docsDir: 'packages/reactive-engine-router/docs',
+        readme: 'packages/reactive-engine-router/README.md',
+      },
+      {
+        dest: 'storage',
+        docsDir: 'packages/reactive-engine-storage/docs',
+        readme: 'packages/reactive-engine-storage/README.md',
+      },
+    ],
   },
 ]
 
@@ -85,23 +134,34 @@ async function copyTree(source: string, destination: string) {
   }
 }
 
-async function regenerateReferences(source: SkillSource) {
-  const sourceDocsDir = resolve(repoRoot, source.docsDir)
-  const sourceReadmePath = resolve(repoRoot, source.readme)
-  const referencesDir = resolve(packageSkillsRoot, source.name, 'references')
+async function regenerateReferences(skill: SkillSource) {
+  const referencesDir = resolve(packageSkillsRoot, skill.name, 'references')
 
   await rm(referencesDir, { force: true, recursive: true })
   await mkdir(referencesDir, { recursive: true })
 
-  const markdownFiles = await listMarkdownFiles(sourceDocsDir)
+  let fileCount = 0
 
-  for (const markdownFile of markdownFiles) {
-    const relativePath = relative(sourceDocsDir, markdownFile)
-    await copyTextFile(markdownFile, resolve(referencesDir, relativePath))
+  for (const source of skill.sources) {
+    const destinationDir = source.dest ? resolve(referencesDir, source.dest) : referencesDir
+
+    if (source.docsDir) {
+      const sourceDocsDir = resolve(repoRoot, source.docsDir)
+      const markdownFiles = await listMarkdownFiles(sourceDocsDir)
+
+      for (const markdownFile of markdownFiles) {
+        const relativePath = relative(sourceDocsDir, markdownFile)
+        await copyTextFile(markdownFile, resolve(destinationDir, relativePath))
+      }
+
+      fileCount += markdownFiles.length
+    }
+
+    await copyTextFile(resolve(repoRoot, source.readme), resolve(destinationDir, 'README.md'))
+    fileCount += 1
   }
 
-  await copyTextFile(sourceReadmePath, resolve(referencesDir, 'README.md'))
-  console.log(`Generated ${source.name} references from ${markdownFiles.length + 1} markdown files`)
+  console.log(`Generated ${skill.name} references from ${fileCount} markdown files`)
 }
 
 async function mirrorSkills(destination: string) {

--- a/packages/virtuoso-skills/scripts/validate-codex-plugin.ts
+++ b/packages/virtuoso-skills/scripts/validate-codex-plugin.ts
@@ -2,7 +2,7 @@ import { access, readFile } from 'node:fs/promises'
 import { dirname, isAbsolute, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const expectedSkillNames = ['react-virtuoso', 'message-list', 'data-table'] as const
+const expectedSkillNames = ['react-virtuoso', 'message-list', 'data-table', 'reactive-engine'] as const
 const allowedTopLevelManifestFields = new Set<string>([
   'name',
   'version',

--- a/packages/virtuoso-skills/skills/data-table/SKILL.md
+++ b/packages/virtuoso-skills/skills/data-table/SKILL.md
@@ -1,8 +1,143 @@
 ---
 name: data-table
-description: Placeholder - content authoring pending. This skill will provide agent guidance for the @virtuoso.dev/data-table package.
+description: >-
+  Build virtualized data tables with @virtuoso.dev/data-table. Use this skill when (1) building a data grid with sorting, filtering,
+  or grouped rows, (2) installing the shadcn-styled or headless table, (3) connecting remote/paginated data sources, (4) adding sticky,
+  resizable, reorderable, or hideable columns, (5) persisting table state, (6) controlling a table from outside (scrolling, actions),
+  (7) migrating from TableVirtuoso, or any task involving VirtuosoDataTable, DataTable, DataTableColumn, localModel, remoteModel,
+  or engine refs like scrollToRow$ and dispatchModelAction$.
 ---
 
-# Data Table Skill
+# @virtuoso.dev/data-table
 
-TODO: Author skill body. See references/ for source docs.
+A virtualized React data table (rows and columns) with grouped rows, sticky columns, column resizing/reordering/visibility, state persistence, and remote data support. It is the successor to `TableVirtuoso` for table-shaped problems: instead of row renderers, you pass a data source (model) and declare columns as JSX.
+
+## Installation: two paths
+
+**Shadcn (pre-styled wrapper)** — for projects using shadcn/ui conventions:
+
+```bash
+npx shadcn@latest add https://virtuoso.dev/r/data-table.json
+```
+
+This installs a styled wrapper at `@/components/ui/data-table` exporting `DataTable`, `DataTableColumn`, `DataTableColumnHeader`, `DataTableCell`.
+
+**Headless** — for custom design systems:
+
+```bash
+npm install @virtuoso.dev/data-table
+```
+
+Import the structural styles (`@import '@virtuoso.dev/data-table/styles.css'`) and use the unstyled `VirtuosoDataTable`, `Column`, `ColumnHeader`, `Cell`. Ask which path fits the project before installing; the shadcn wrapper is the faster start in Tailwind/shadcn codebases.
+
+## Minimal example (shadcn wrapper)
+
+```tsx
+import { DataTable, DataTableCell, DataTableColumn, DataTableColumnHeader } from '@/components/ui/data-table'
+import { localModel } from '@virtuoso.dev/data-table'
+
+const model = localModel({ data: products })
+
+export default function App() {
+  return (
+    <DataTable className="rounded-xl" model={model} style={{ height: 360 }}>
+      <DataTableColumn field="name">
+        <DataTableColumnHeader>Product</DataTableColumnHeader>
+        <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
+      </DataTableColumn>
+    </DataTable>
+  )
+}
+```
+
+Columns are JSX, not config objects. `field` is both the row-data lookup key and the column's public identifier (used by visibility, reordering, persistence). The table needs a real height, like every Virtuoso component.
+
+## Choosing a data model
+
+| Situation                                                       | Model                                                                                                 |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Rows in memory; filter/sort/group client-side                   | `localModel({ data, pipeline?, actions?, groups? })`                                                  |
+| API-backed, known total count (placeholder rows while fetching) | `remoteModel` with offset mode (`defaultOffsetViewportHandler`); fetch returns `{ rows, totalCount }` |
+| API-backed, cursor pagination / infinite append                 | `remoteModel` with append mode (`defaultAppendViewportHandler`); fetch returns `{ rows }`             |
+
+Hold the model in `useState` with lazy init — `const [model] = useState(() => localModel({ data }))`. Do not use `useMemo`; React may discard memoized values, and the model instance must be retained. Module scope is fine for a static singleton table.
+
+Local filtering/sorting/grouping runs through a named-stage pipeline: declare `pipeline: ['filter', 'sort']` plus `actions`, then dispatch with `model.send({ action: 'filter', payload })`. See [local-data-model](references/2.data-model/01.local-data-model.md) and the [local-filter-sort-group example](references/8.examples/07.local-filter-sort-group.md).
+
+Provide `computeRowKey={({ data }) => data.id}` whenever rows can reorder (sort, filter, remote updates) — without it rows remount and lose local state.
+
+## Column features
+
+- **Sticky columns:** `<DataTableColumn field="name" sticky="left" />` (or `"right"`); multiple sticky columns stack.
+- **Visibility:** declaratively via `visible={false}`, or at runtime through `setColumnVisibility$` / `columnVisibilityState$` from `@virtuoso.dev/data-table/column-visibility`.
+- **Resizing:** mount `ResizeHandle` in the `HeaderEdge` slot; programmatic via `resizeColumn$` from `@virtuoso.dev/data-table/column-resize`.
+- **Reordering:** `ReorderGrip` in `HeaderStart` + `ReorderDropZone` in `HeaderOverlay`; programmatic via `reorderColumns$` from `@virtuoso.dev/data-table/column-reorder`.
+- **Header slots:** `HeaderStart` (before label), `HeaderEnd` (after label), `HeaderEdge` (pinned to the column boundary), `HeaderOverlay` (covers the header) — see [header-slots](references/7.customization/06.header-slots.md).
+- **Grouped rows:** pass `groups: [{ index, level }]` alongside `data` and render headers with `GroupHeaderCell` — see [grouped-rows](references/4.grouped-rows.md).
+
+State persistence: mount `<DataTableStatePersistence adapters={[...]} storageKey="my-table" />` with adapters from the feature subpaths (`columnVisibilityPersistenceAdapter()`, `columnOrderPersistenceAdapter()`, `columnWidthPersistenceAdapter()`, `modelStatePersistenceAdapter()`). See [state-persistence](references/5.state-persistence.md).
+
+## Controlling the table from outside
+
+The table's state lives in an internal reactive engine, and the package intentionally exports cells (readable state, `$`-suffixed) and streams (actions) for remote control — state is not lifted into props:
+
+```tsx
+import { scrollLocation$, scrollToRow$, useEngineRef, useRemoteCellValue, useRemotePublisher } from '@virtuoso.dev/data-table'
+
+const engineRef = useEngineRef()
+const scrollToRow = useRemotePublisher(scrollToRow$, engineRef)
+const location = useRemoteCellValue(scrollLocation$, engineRef)
+
+<DataTable engineRef={engineRef} model={model}>...</DataTable>
+<button onClick={() => scrollToRow({ index: 100, align: 'start' })}>Go to row 100</button>
+```
+
+For UI far from the table, pass `engineId="orders-table"` and use the same hooks with the string id. Useful nodes: `scrollToRow$`, `scrollIntoView$`, `setColumnVisibility$`, `dispatchModelAction$` (actions); `scrollLocation$`, `columns$`, `columnVisibilityState$`, `modelActionState$`, `loadingState$` (state). See [controlling-the-table](references/6.controlling-the-table.md).
+
+## Customization
+
+- Styling goes through `className` on the wrapper components and semantic data attributes — never use `data-testid` as a styling hook.
+- Replace internals via the `components` prop: `Row`, `StickyColumnContainer`, `LoadingPlaceholder`, `LoadingOverlay`, `LoadingFooter` (component overrides must forward refs). Top-level: `EmptyPlaceholder`, `ScrollElement`.
+- `context={{ ... }}` flows to `computeRowKey`, `EmptyPlaceholder`, loading slots, and component overrides — but not to cell/header renderers (use React context there). See [ambient-context](references/7.customization/05.ambient-context.md).
+- Scroll modes: default internal scroller, `useWindowScroll`, or `customScrollParent` — pick exactly one.
+
+## Migrating from TableVirtuoso
+
+| TableVirtuoso         | data-table                                                  |
+| --------------------- | ----------------------------------------------------------- |
+| `data` array          | `localModel({ data })` passed as `model`                    |
+| `itemContent`         | `DataTableColumn` + `DataTableCell`                         |
+| `fixedHeaderContent`  | `DataTableColumnHeader`                                     |
+| grouped rows          | `groups` + `GroupHeaderCell`                                |
+| fixed columns (CSS)   | `sticky="left"` / `sticky="right"`                          |
+| ref + `scrollToIndex` | `engineRef` + `scrollToRow$`                                |
+| `rangeChanged`        | `onRenderedDataChange`, `viewportRange$`, `scrollLocation$` |
+
+Full guide: [migrating-from-table-virtuoso](references/9.guides/04.migrating-from-table-virtuoso.md).
+
+## Troubleshooting
+
+| Symptom                                 | Fix                                                                                                 |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Blank table or header only              | Give the table a measurable height                                                                  |
+| Shadcn component imports fail           | Run the registry install, or import headless from `@virtuoso.dev/data-table`                        |
+| Page and table both scroll              | Use only one scroll mode                                                                            |
+| Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through |
+| Rows remount / lose state after sorting | Add `computeRowKey`                                                                                 |
+| Sticky columns clipped                  | Check parent `overflow` and column min-widths                                                       |
+| Empty cells flash on horizontal scroll  | Raise `columnOverscanCount`                                                                         |
+
+For tests, wrap in `VirtuosoDataTableTestingContext.Provider value={{ itemHeight, viewportHeight }}` (JSDOM has no layout) and assert behavior, not exact DOM row counts — overscan renders extra rows. Use real-browser tests for sticky columns, resizing, and drag interactions. See [testing](references/9.guides/01.testing.md).
+
+## References
+
+- [references/README.md](references/README.md) — overview
+- `references/1.installation/` — [shadcn](references/1.installation/01.shadcn.md), [headless](references/1.installation/02.headless.md)
+- `references/2.data-model/` — [local](references/2.data-model/01.local-data-model.md), [remote](references/2.data-model/02.remote-data-model.md), [row-keys](references/2.data-model/03.row-keys.md)
+- `references/3.columns/` — [defining-columns](references/3.columns/01.defining-columns.md), [cell-and-header-renderers](references/3.columns/02.cell-and-header-renderers.md), [column-groups](references/3.columns/03.column-groups.md), [sticky-columns](references/3.columns/04.sticky-columns.md), [visibility](references/3.columns/05.column-visibility.md), [resizing](references/3.columns/06.column-resizing.md), [reordering](references/3.columns/07.column-reordering.md), [runtime-columns](references/3.columns/08.runtime-columns.md)
+- Features: [grouped-rows](references/4.grouped-rows.md), [state-persistence](references/5.state-persistence.md), [controlling-the-table](references/6.controlling-the-table.md)
+- `references/7.customization/` — [styling](references/7.customization/01.styling.md), [replacing-internals](references/7.customization/02.replacing-internals.md), [empty-and-loading-states](references/7.customization/03.empty-and-loading-states.md), [scroll-containers](references/7.customization/04.scroll-containers.md), [ambient-context](references/7.customization/05.ambient-context.md), [header-slots](references/7.customization/06.header-slots.md), [shadcn-wrapper](references/7.customization/07.shadcn-wrapper.md)
+- `references/8.examples/` — worked examples from basic table to remote pagination, dashboards, and persistence
+- `references/9.guides/` — [testing](references/9.guides/01.testing.md), [performance](references/9.guides/02.performance.md), [troubleshooting](references/9.guides/03.troubleshooting.md), [migrating-from-table-virtuoso](references/9.guides/04.migrating-from-table-virtuoso.md), [debug-instrumentation](references/9.guides/05.debug-instrumentation.md)
+
+Full API reference: <https://virtuoso.dev/data-table/>

--- a/packages/virtuoso-skills/skills/message-list/SKILL.md
+++ b/packages/virtuoso-skills/skills/message-list/SKILL.md
@@ -1,8 +1,153 @@
 ---
 name: message-list
-description: Placeholder - content authoring pending. This skill will provide agent guidance for the @virtuoso.dev/message-list package.
+description: >-
+  Build chat, messaging, and AI conversation UIs with @virtuoso.dev/message-list. Use this skill when (1) building a chat or
+  messaging interface, (2) streaming AI assistant responses into a conversation, (3) loading older messages when scrolling up,
+  (4) adding scroll-to-bottom buttons or unseen-message indicators, (5) switching between channels/conversations, or (6) any task
+  involving VirtuosoMessageList, VirtuosoMessageListLicense, useVirtuosoMethods, useVirtuosoLocation, scrollModifier, or
+  data.append/prepend/map. The package is commercial and requires a license key.
 ---
 
-# Message List Skill
+# @virtuoso.dev/message-list
 
-TODO: Author skill body. See references/ for source docs.
+`VirtuosoMessageList` is a virtualized list purpose-built for human and AI chat: stick-to-bottom behavior, streaming responses that grow without scroll jumps, history prepending that preserves the visual position, and scroll position tracking. Use it instead of plain `Virtuoso` when building conversation UIs — these behaviors are built in rather than hand-assembled.
+
+## Licensing
+
+The package is commercial (annual, per-developer). Every instance must be wrapped in `VirtuosoMessageListLicense`:
+
+```tsx
+<VirtuosoMessageListLicense licenseKey={licenseKey}>
+  <VirtuosoMessageList ... />
+</VirtuosoMessageListLicense>
+```
+
+An empty `licenseKey=""` works as a 30-day non-production trial. Validation is local — no network requests. Surface this to the user when introducing the package into a project; keys come from <https://virtuoso.dev/pricing/>.
+
+## Core mental model: data updates carry scroll instructions
+
+Instead of separate imperative scroll calls, each data update includes a `scrollModifier` describing how the viewport should react:
+
+```tsx
+const [data, setData] = useState<VirtuosoMessageListProps<Message, null>['data']>(() => ({
+  data: initialMessages,
+  scrollModifier: { type: 'item-location', location: { index: 'LAST', align: 'end' } },
+}))
+
+<VirtuosoMessageList<Message, null> style={{ height: '100%' }} data={data} computeItemKey={({ data }) => data.key} ItemContent={ItemContent} />
+```
+
+`ItemContent` is a component receiving `{ data, index, context }` props (not positional arguments like react-virtuoso).
+
+### Scroll modifier reference
+
+| Modifier                                               | When to use                                                                                             |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- | ------ | -------------------------- |
+| `{ type: 'item-location', location, purgeItemSizes? }` | Initial load or channel switch; `purgeItemSizes: true` clears cached sizes when the items are different |
+| `{ type: 'auto-scroll-to-bottom', autoScroll }`        | New messages arrive; callback receives `{ atBottom, scrollInProgress, ... }` and returns `'smooth'      | 'auto' | false` or an item location |
+| `'prepend'`                                            | Older messages added to the top; keeps the current messages visually in place                           |
+| `{ type: 'items-change', behavior }`                   | Existing items changed size (streaming text, reactions); stays at bottom if already there               |
+| `'remove-from-start'` / `'remove-from-end'`            | Trimming data while preserving the visual position                                                      |
+| `null` / `undefined`                                   | Leave the scroll position alone                                                                         |
+
+## Common patterns
+
+### Receiving messages (auto-scroll when at bottom)
+
+```tsx
+setData((current) => ({
+  data: [...current.data, incoming],
+  scrollModifier: {
+    type: 'auto-scroll-to-bottom',
+    autoScroll: ({ atBottom, scrollInProgress }) => ({
+      index: 'LAST',
+      align: 'end',
+      behavior: atBottom || scrollInProgress ? 'smooth' : 'auto',
+    }),
+  },
+}))
+```
+
+Returning `false` from `autoScroll` when not at bottom is how you keep the viewport still and instead increment an unseen-messages counter.
+
+### Streaming an AI response
+
+Append an empty assistant message, then grow it as tokens arrive:
+
+```tsx
+setData((current) => ({
+  data: current.data.map((msg) => (msg.key === botKey ? { ...msg, text: msg.text + chunk } : msg)),
+  scrollModifier: { type: 'items-change', behavior: 'smooth' },
+}))
+```
+
+`items-change` keeps the view pinned to the bottom while the message grows, without jumping if the user scrolled up. See [ai-chatbot](references/3.examples/02.ai-chatbot.md) and [gemini](references/3.examples/03.gemini.md) (question pinned to top, answer streams below).
+
+### Loading older messages on scroll-up
+
+```tsx
+<VirtuosoMessageList
+  onScroll={(location) => {
+    if (location.listOffset > -100 && !loading) {
+      loadOlder().then((older) => setData((current) => ({ data: [...older, ...current.data], scrollModifier: 'prepend' })))
+    }
+  }}
+/>
+```
+
+No `firstItemIndex` bookkeeping is needed (unlike plain Virtuoso) — `'prepend'` preserves the position automatically.
+
+### Scroll-to-bottom button
+
+`StickyFooter` renders fixed at the bottom of the viewport; combine with the location hook:
+
+```tsx
+const StickyFooter = () => {
+  const location = useVirtuosoLocation()
+  const methods = useVirtuosoMethods()
+  if (location.bottomOffset <= 200) return null
+  return <button onClick={() => methods.scrollToItem({ index: 'LAST', align: 'end', behavior: 'auto' })}>▼</button>
+}
+```
+
+### Switching channels
+
+Keep one data object per channel and swap with `replace`/`item-location` + `purgeItemSizes: true`, so size caches from the previous channel don't distort the new one. See [multiple-channels](references/2.tutorial/07.multiple-channels.md).
+
+## Imperative API
+
+Via `ref={useRef<VirtuosoMessageListMethods<Message>>(null)}` from outside, or `useVirtuosoMethods()` from components rendered inside the list:
+
+- `data.append(items, scrollToBottom?)`, `data.prepend(items)`
+- `data.map(fn, autoscrollBehavior?)` — update items (reactions, edits, streaming)
+- `data.findAndDelete(predicate)`, `data.deleteRange(start, length)`, `data.replace(data, options?)`
+- `data.find(predicate)`, `data.findIndex(predicate)`, `data.get()`, `data.getCurrentlyRendered()`
+- `scrollToItem({ index: number | 'LAST', align, behavior })`
+
+The declarative `data` prop and the imperative `data.*` methods are alternative ways to drive the same list — pick one as the primary mechanism per component to avoid fighting updates.
+
+## Key props and hooks
+
+- `ItemContent: ({ data, index, context }) => JSX` — message renderer
+- `context` — shared state (current user, loading flags) available to `ItemContent` and all custom slots; avoids prop drilling
+- `computeItemKey({ data })` — stable message key; required for prepending/streaming to work without remounts
+- Slots: `Header`, `Footer` (scroll with content), `StickyHeader`, `StickyFooter` (fixed, measured to avoid overlap), `EmptyPlaceholder`
+- `initialLocation: { index: 'LAST', align: 'end' }` — start at the bottom
+- Hooks (inside the list): `useVirtuosoMethods()`, `useVirtuosoLocation()` (`atBottom`, `bottomOffset`, `listOffset`, `scrollInProgress`), `useCurrentlyRenderedData()`
+
+## Pitfalls
+
+- **No height → nothing renders.** The component needs a real height (`style={{ height: '100%' }}` with a sized parent).
+- **Missing `computeItemKey`** causes remounts and scroll jumps on prepend and streaming updates.
+- **Margins on message items** break height measurement (ResizeObserver excludes margins) — use padding.
+- **"ResizeObserver loop" errors are benign** — filter them in dev overlays and error tracking; see [resize-observer-errors](references/19.resize-observer-errors.md).
+- **JSDOM tests need mocked measurements** via `VirtuosoMessageListTestingContext.Provider value={{ itemHeight, viewportHeight }}` plus a ResizeObserver polyfill; prefer Playwright for scroll behavior. See [testing](references/11.testing.md).
+
+## References
+
+- [references/README.md](references/README.md) — overview and live example
+- `references/2.tutorial/` — step-by-step chat build: [intro](references/2.tutorial/01.intro.md), [message-list](references/2.tutorial/02.message-list.md), [loading-older-messages](references/2.tutorial/03.loading-older-messages.md), [scroll-to-bottom-button](references/2.tutorial/04.scroll-to-bottom-button.md), [receive-messages](references/2.tutorial/05.receive-messages.md), [send-messages](references/2.tutorial/06.send-messages.md), [multiple-channels](references/2.tutorial/07.multiple-channels.md)
+- `references/3.examples/` — [messaging](references/3.examples/01.messaging.md), [ai-chatbot](references/3.examples/02.ai-chatbot.md), [gemini](references/3.examples/03.gemini.md), [reactions](references/3.examples/04.reactions.md), [date-separators](references/3.examples/05.date-separators.md), [scroll-to-reply](references/3.examples/06.scroll-to-reply.md), [grouped-messages](references/3.examples/07.grouped-messages.md)
+- Feature guides: [headers-footers](references/4.headers-footers.md), [context](references/5.context.md), [item-keys](references/6.item-keys.md), [hooks](references/7.hooks.md), [custom-scrollbar](references/8.custom-scrollbar.md), [scrolling-to-item](references/9.scrolling-to-item.md), [smooth-scrolling](references/10.smooth-scrolling.md), [imperative-data-api](references/15.imperative-data-api.md), [scroll-modifier](references/20.scroll-modifier.md), [testing](references/11.testing.md), [licensing](references/80.licensing.md)
+
+Full API reference: <https://virtuoso.dev/message-list/>

--- a/packages/virtuoso-skills/skills/react-virtuoso/SKILL.md
+++ b/packages/virtuoso-skills/skills/react-virtuoso/SKILL.md
@@ -14,7 +14,6 @@ description: >-
 
 ```tsx
 import { Virtuoso } from 'react-virtuoso'
-
 ;<Virtuoso style={{ height: '100%' }} data={users} itemContent={(index, user) => <div>{user.name}</div>} />
 ```
 

--- a/packages/virtuoso-skills/skills/react-virtuoso/SKILL.md
+++ b/packages/virtuoso-skills/skills/react-virtuoso/SKILL.md
@@ -1,8 +1,179 @@
 ---
 name: react-virtuoso
-description: Placeholder - content authoring pending. This skill will provide agent guidance for the react-virtuoso package.
+description: >-
+  Build virtualized lists, grids, and tables with react-virtuoso. Use this skill when (1) rendering large or infinite lists,
+  (2) building grouped lists with sticky headers, (3) virtualizing HTML tables, (4) laying out same-sized items in a responsive grid,
+  (5) building feeds or logs that follow new items at the bottom, (6) diagnosing virtualization symptoms such as jumpy scrolling,
+  a list that does not scroll to the bottom, items overlapping, blank items, or "zero-sized element" errors, or (7) any task involving
+  Virtuoso, GroupedVirtuoso, VirtuosoGrid, TableVirtuoso, VirtuosoHandle, itemContent, followOutput, or firstItemIndex.
 ---
 
-# React Virtuoso Skill
+# react-virtuoso
 
-TODO: Author skill body. See references/ for source docs.
+`react-virtuoso` renders only the visible portion of large lists, grids, and tables. It measures item sizes automatically with ResizeObserver — variable item heights work out of the box, with no size configuration.
+
+```tsx
+import { Virtuoso } from 'react-virtuoso'
+
+;<Virtuoso style={{ height: '100%' }} data={users} itemContent={(index, user) => <div>{user.name}</div>} />
+```
+
+## Picking the right component
+
+| Need                                                                    | Use                                                                 |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Flat list, variable or fixed item heights                               | `Virtuoso`                                                          |
+| Groups with sticky group headers                                        | `GroupedVirtuoso`                                                   |
+| HTML table with virtualized rows                                        | `TableVirtuoso`                                                     |
+| Table with grouped rows and sticky group headers                        | `GroupedTableVirtuoso`                                              |
+| Same-sized items in a responsive multi-column grid                      | `VirtuosoGrid`                                                      |
+| Chat / AI conversation UI (streaming, stick-to-bottom, prepend history) | `@virtuoso.dev/message-list` — use the `message-list` skill instead |
+| Data grid with columns, sorting, filtering, column features             | `@virtuoso.dev/data-table` — use the `data-table` skill instead     |
+
+All components share the same core props (`data`/`totalCount`, `itemContent`, `components`, scroll callbacks, ref methods).
+
+## What you do NOT need to do
+
+Unlike TanStack Virtual or react-window, react-virtuoso measures items itself. Do not carry those libraries' patterns over:
+
+- No `estimateSize`, no `measureElement`, no `data-index` wiring — measurement is automatic.
+- No absolute positioning or `transform: translateY` on items — the library positions items.
+- No fixed `itemSize` requirement — variable heights are the default. If items genuinely have one uniform height, pass `fixedItemHeight` as a performance optimization only.
+- No windowing math — pass `data` (or `totalCount`) and render the item in `itemContent`.
+
+## Core rules
+
+- **The component needs a height.** Set `style={{ height: '100%' }}` (with a sized parent) or a fixed height. A zero-height container renders nothing.
+- **Never put CSS margins on items.** ResizeObserver reports `contentRect`, which excludes margins, so the computed total height comes up short — the classic symptom is a list that cannot scroll all the way to the bottom. Use padding instead. Watch for default margins on `<p>`, headings, `<ul>`, `<blockquote>`, `<pre>`.
+- **Use `data`, not `totalCount`, when you have the items.** With `data`, `itemContent={(index, item) => ...}` receives the item. Use `totalCount` only when items are derived from the index. Updates must produce a new array reference.
+- **Provide `computeItemKey={(index, item) => item.id}`** whenever the list can be prepended, reordered, or filtered. The default key is the index, which remounts items (losing state) when positions shift.
+- **Define `components` overrides outside the render function.** Inline definitions create a new component type each render, remounting the subtree on every scroll. `Scroller` and `List` overrides must forward `ref` to their DOM element.
+- **Item content must not render zero-height elements.** The error "zero-sized element, this should not happen" means an item measured 0px — filter empty items out of the data instead.
+
+## Common patterns
+
+### Infinite scrolling
+
+```tsx
+<Virtuoso data={items} endReached={() => loadMore()} itemContent={(index, item) => <Item item={item} />} />
+```
+
+`endReached` fires at the bottom; render a spinner via `components.Footer`. For "load more" on click, put the button in `Footer`.
+
+### Prepending items (reverse infinite scroll)
+
+Prepending naively makes the list jump. Instead, keep a `firstItemIndex` that you decrease by the number of prepended items:
+
+```tsx
+const [firstItemIndex, setFirstItemIndex] = useState(START)
+
+const prepend = (older: Item[]) => {
+  setFirstItemIndex((i) => i - older.length)
+  setItems((current) => [...older, ...current])
+}
+
+<Virtuoso firstItemIndex={firstItemIndex} initialTopMostItemIndex={START} data={items} startReached={prepend} ... />
+```
+
+`firstItemIndex` must stay a positive number, so start it large (e.g. `100000`). For `GroupedVirtuoso`, decrease it by the number of new items only, excluding the group headers. See [endless-scrolling](references/1.virtuoso/endless-scrolling.md).
+
+### Following new items (logs, feeds)
+
+```tsx
+<Virtuoso followOutput="smooth" data={messages} ... />
+```
+
+`followOutput` scrolls to new bottom items only when the user is already at the bottom. It accepts `'auto' | 'smooth' | false` or a function `(isAtBottom) => ...` for custom logic. For full chat UIs prefer `@virtuoso.dev/message-list`.
+
+### Scrolling programmatically
+
+```tsx
+const ref = useRef<VirtuosoHandle>(null)
+ref.current?.scrollToIndex({ index: 500, align: 'center', behavior: 'smooth' })
+```
+
+Also on the handle: `scrollIntoView` (only scrolls if not visible — right for keyboard navigation), `scrollTo`/`scrollBy` (pixel-based), and `getState` (snapshot for `restoreStateFrom` when remounting, e.g. back navigation).
+
+To start at an item, use `initialTopMostItemIndex={{ index, align: 'start' }}` — not `initialScrollTop`, which first renders at the top and then jumps.
+
+### Grouped lists
+
+```tsx
+<GroupedVirtuoso
+  groupCounts={[20, 30]} // items per group, in order
+  groupContent={(groupIndex) => <Header group={groups[groupIndex]} />}
+  itemContent={(index, groupIndex) => <Item item={items[index]} />} // index is absolute across all items
+/>
+```
+
+You provide flat data plus `groupCounts`; map indexes back to your data yourself.
+
+### Tables
+
+```tsx
+<TableVirtuoso
+  data={rows}
+  fixedHeaderContent={() => (
+    <tr>
+      <th>Name</th>
+    </tr>
+  )}
+  itemContent={(index, row) => (
+    <>
+      <td>{row.name}</td>
+    </>
+  )} // <td> cells only — the row <tr> is rendered for you
+/>
+```
+
+Do not set `border-collapse: collapse` on the table — the sticky header's borders scroll away with the body. Use `border-collapse: separate` with explicit cell borders. Customize structure via `components` (`Table`, `TableRow`, `TableHead`, `TableBody`).
+
+### Grid
+
+`VirtuosoGrid` virtualizes same-sized items in columns. You control column count with CSS — give `components.Item` a percentage width (`33%` for three columns, changed via media queries) and `components.List` `display: flex; flex-wrap: wrap`. See [grid-responsive-columns](references/3.virtuoso-grid/grid-responsive-columns.md).
+
+### Page-level scrolling
+
+Use `useWindowScroll` to drive the list from the document scroll, or `customScrollParent={element}` to attach to an existing scrollable ancestor. Pick exactly one scroll mode — combining them makes both containers scroll.
+
+### Testing
+
+JSDOM has no layout, so items will not render in Jest/Vitest without mocked measurements:
+
+```tsx
+render(<Virtuoso data={data} />, {
+  wrapper: ({ children }) => (
+    <VirtuosoMockContext.Provider value={{ viewportHeight: 300, itemHeight: 100 }}>{children}</VirtuosoMockContext.Provider>
+  ),
+})
+```
+
+Use `VirtuosoGridMockContext` (adds `viewportWidth`, `itemWidth`) for grids. Prefer real-browser tests (Playwright) for scroll behavior.
+
+## Troubleshooting
+
+| Symptom                                                                       | Likely cause                                                     | Fix                                                                                          |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Nothing renders                                                               | Container has zero height                                        | Give the component or its parent a real height                                               |
+| Cannot scroll to the last items / jumps near the bottom                       | Margins on item content                                          | Replace margins with padding                                                                 |
+| Items flicker or lose state while scrolling                                   | Inline `components` definitions or index-based keys              | Hoist components; add `computeItemKey`                                                       |
+| List jumps on prepend                                                         | Items added without `firstItemIndex` adjustment                  | Use the `firstItemIndex` prepend pattern                                                     |
+| "zero-sized element, this should not happen"                                  | An item rendered with zero height                                | Filter empty items from the data                                                             |
+| "ResizeObserver loop completed with undelivered notifications" overlay in dev | Benign ResizeObserver timing, surfaced by the dev-server overlay | Disable `runtimeErrors` in the webpack/vite overlay config; safe to filter in error tracking |
+| Hard-to-explain size behavior                                                 | —                                                                | Set `logLevel={LogLevel.DEBUG}` and watch the console with all levels enabled                |
+
+Tuning: `increaseViewportBy` renders extra pixels outside the viewport (smoother, more DOM); `defaultItemHeight` skips the initial probe render; `fixedItemHeight` skips measurement entirely (uniform items only); `scrollSeekConfiguration` swaps items for placeholders during fast scrolling.
+
+## References
+
+Detailed guides with full code in [references/](references/):
+
+- [references/README.md](references/README.md) — package overview and full feature list
+- `references/1.virtuoso/` — flat list guides: [basic-usage](references/1.virtuoso/basic-usage.md), [endless-scrolling](references/1.virtuoso/endless-scrolling.md), [press-to-load-more](references/1.virtuoso/press-to-load-more.md), [initial-index](references/1.virtuoso/initial-index.md), [scroll-to-index](references/1.virtuoso/scroll-to-index.md), [keyboard-navigation](references/1.virtuoso/keyboard-navigation.md), [customize-rendering](references/1.virtuoso/customize-rendering.md), [footer](references/1.virtuoso/footer.md), [top-items](references/1.virtuoso/top-items.md), [scroll-handling](references/1.virtuoso/scroll-handling.md), [range-change-callback](references/1.virtuoso/range-change-callback.md), [scroll-seek-placeholders](references/1.virtuoso/scroll-seek-placeholders.md), [auto-resizing](references/1.virtuoso/auto-resizing.md), [window-scrolling](references/1.virtuoso/window-scrolling.md), [custom-scroll-container](references/1.virtuoso/custom-scroll-container.md), [horizontal-mode](references/1.virtuoso/horizontal-mode.md)
+- `references/2.grouped-virtuoso/` — grouped lists: [grouped-numbers](references/2.grouped-virtuoso/grouped-numbers.md), [grouped-by-first-letter](references/2.grouped-virtuoso/grouped-by-first-letter.md), [scroll-to-group](references/2.grouped-virtuoso/scroll-to-group.md), [grouped-with-load-on-demand](references/2.grouped-virtuoso/grouped-with-load-on-demand.md)
+- `references/3.virtuoso-grid/` — [grid-responsive-columns](references/3.virtuoso-grid/grid-responsive-columns.md)
+- `references/4.table-virtuoso/` — tables: [basic-table](references/4.table-virtuoso/basic-table.md), [table-fixed-headers](references/4.table-virtuoso/table-fixed-headers.md), [table-fixed-columns](references/4.table-virtuoso/table-fixed-columns.md), [table-grouped](references/4.table-virtuoso/table-grouped.md)
+- `references/5.third-party-integration/` — [mocking-in-tests](references/5.third-party-integration/mocking-in-tests.md), [tanstack-table-integration](references/5.third-party-integration/tanstack-table-integration.md), [mui-table-virtual-scroll](references/5.third-party-integration/mui-table-virtual-scroll.md), [material-ui-endless-scrolling](references/5.third-party-integration/material-ui-endless-scrolling.md)
+- [references/6.troubleshooting.md](references/6.troubleshooting.md) — full troubleshooting guide
+
+Full API reference: <https://virtuoso.dev/react-virtuoso/>

--- a/packages/virtuoso-skills/skills/react-virtuoso/references/README.md
+++ b/packages/virtuoso-skills/skills/react-virtuoso/references/README.md
@@ -29,6 +29,12 @@ React components for efficiently rendering large lists, grids, and tables with v
 npm install react-virtuoso
 ```
 
+If you work with a coding agent (Claude Code, Codex, Cursor), install the [Virtuoso agent skills](https://virtuoso.dev/skills/) so it knows the component selection rules, measurement constraints, and common pitfalls:
+
+```bash
+npx skills add virtuoso-dev/skills --skill react-virtuoso
+```
+
 ## Quick Start
 
 ### Virtuoso

--- a/packages/virtuoso-skills/skills/reactive-engine/SKILL.md
+++ b/packages/virtuoso-skills/skills/reactive-engine/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: reactive-engine
+description: >-
+  Manage application state with the @virtuoso.dev/reactive-engine-* package family. Use this skill when (1) defining reactive state
+  with Cell, Stream, Trigger, or Resource nodes, (2) wiring React components through EngineProvider, useCellValue, useCellValues, or
+  usePublisher, (3) fetching data with Query and Mutation from reactive-engine-query, (4) routing with Route, Layout, and Guard from
+  reactive-engine-router, (5) persisting cells with linkCellToStorage, (6) architecting a component or library on top of the engine,
+  or (7) any task involving Engine, pub, sub, getValue, combine, pipe, link, changeWith, the e namespace, or the error
+  "No active engine found".
+---
+
+# Reactive Engine
+
+A reactive state system built on a graph of typed nodes. Five packages compose:
+
+| Package                                 | Provides                                                                                                            |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `@virtuoso.dev/reactive-engine-core`    | Nodes (`Cell`, `Stream`, `Trigger`, `Resource`, `DerivedCell`), `Engine`, operators, combinators, the `e` namespace |
+| `@virtuoso.dev/reactive-engine-react`   | `EngineProvider`, hooks (`useCellValue`, `usePublisher`, remote hooks)                                              |
+| `@virtuoso.dev/reactive-engine-query`   | `Query` and `Mutation` data fetching on top of nodes                                                                |
+| `@virtuoso.dev/reactive-engine-router`  | `Route`, `Layout`, `Guard`, `Router` — routes are nodes                                                             |
+| `@virtuoso.dev/reactive-engine-storage` | `linkCellToStorage` (localStorage / sessionStorage / cookie)                                                        |
+
+It also powers `@virtuoso.dev/data-table` internally — the same concepts apply when remote-controlling the table, and data-table's architecture is the reference for building on the engine ([building-on-the-engine](references/core/05.building-on-the-engine.md)).
+
+## Mental model: nodes are definitions, engines hold state
+
+Node constructors return inert references (symbols at runtime), defined at module scope with a `$` suffix. They hold no state. An `Engine` instance activates nodes lazily on first use and owns their values — two engines using the same node have independent state. This is what makes engine-based libraries reusable: one module-scope graph, one engine per component instance.
+
+```ts
+import { Cell, Stream, Engine, e } from '@virtuoso.dev/reactive-engine-core'
+
+const count$ = Cell(0)
+const engine = new Engine()
+engine.sub(count$, (value) => console.log('count:', value))
+engine.pub(count$, 1) // logs 'count: 1'
+```
+
+Node types — pick by statefulness:
+
+| Node                            | State                          | Use for                                       |
+| ------------------------------- | ------------------------------ | --------------------------------------------- |
+| `Cell(initial, distinct?)`      | Stateful, has a current value  | App state, settings                           |
+| `DerivedCell(initial, source$)` | Stateful, tracks a source      | Read-only computed state                      |
+| `Stream<T>(distinct?)`          | Stateless, emits values        | Events, commands                              |
+| `Trigger()`                     | Stateless, valueless           | "Something happened" signals (refetch, reset) |
+| `Resource(factory)`             | Factory-initialized per engine | Objects needing setup/disposal                |
+
+Nodes are distinct by default using **reference equality** (`===`): publishing the same reference (or an equal primitive) does not re-emit. Always publish new references from updates (`new Map(old)`, spread). Pass `false` to always emit, or a comparator `(prev, next) => boolean` (true = equal = suppress); `prev` is `undefined` on first emission.
+
+## The three API flavors (most important distinction)
+
+The same verbs exist in three forms — using the wrong one is the main source of errors:
+
+| Flavor                   | Examples                                               | Where                                             | Effect                                                           |
+| ------------------------ | ------------------------------------------------------ | ------------------------------------------------- | ---------------------------------------------------------------- |
+| Module-scope combinators | `link`, `pipe`, `sub`, `changeWith`, `combine` / `e.*` | Anywhere, incl. module top level                  | Deferred wiring, applied once per engine when the nodes activate |
+| Engine instance methods  | `engine.pub`, `engine.sub`, `engine.getValue`          | Wherever you hold an engine                       | Immediate, on that engine                                        |
+| Context-bound utilities  | standalone `pub`, `getValue`, `pubIn` / `e.pub`, ...   | Only inside subscription callbacks and node inits | Acts on the currently executing engine                           |
+
+Calling a context-bound utility elsewhere throws `No active engine found. You can use getValue only in the context of node subscription callbacks.` — fix by using `engine.*` methods, React hooks, or moving the code into a subscription. Note the asymmetry: standalone `sub`/`link`/`changeWith` are safe at module scope (they defer); standalone `pub`/`getValue` are not.
+
+The `e` export bundles all combinators, operators, and context utilities into one namespace — idiomatic for wiring blocks:
+
+```ts
+e.link(
+  e.pipe(
+    toggleTheme$,
+    e.withLatestFrom(theme$),
+    e.map(([, t]) => (t === 'light' ? 'dark' : 'light'))
+  ),
+  theme$
+)
+```
+
+## Wiring the graph
+
+- `link(source$, sink$)` — forward emissions; `pipe(source$, ...ops)` — derive a new node
+- `combine(a$, b$, ...)` — emit `[a, b, ...]` when ANY source emits; `withLatestFrom(...)` (operator) — read other nodes passively, emit only when the source emits
+- `changeWith(cell$, source$, (cell, value) => next)` — reducer-style cell update from a stream (return a new reference)
+- `sub`, `subMultiple`, `singletonSub` (replaces the previous singleton subscription — use for callbacks driven by React renders)
+- Operators: `map(fn, distinct?)`, `filter` (supports type guards), `mapTo`, `scan`, `once`, `throttleTime`, `debounceTime`, `delayWithMicrotask`, `onNext`, `handlePromise`
+
+Publishing is transactional: `engine.pubIn({ [a$]: 1, [b$]: 2 })` batches into one cycle; the graph executes in topological order, so diamond dependencies emit downstream exactly once with consistent inputs. Emissions are synchronous; there are no error/completion channels (exceptions abort the cycle — handle errors at the edges). Subscribing never replays a current value; read cells with `getValue` when needed. See [transactions](references/core/03.transactions.md).
+
+## React integration
+
+```tsx
+import { EngineProvider, useCellValue, usePublisher } from '@virtuoso.dev/reactive-engine-react'
+
+const Counter = () => {
+  const count = useCellValue(count$)
+  const setCount = usePublisher(count$)
+  return <button onClick={() => setCount(count + 1)}>{count}</button>
+}
+```
+
+- `useCellValue(cell$)` subscribes and re-renders; `useCellValues(a$, b$, ...)` returns a tuple with a single combined subscription (prefer it for cells that change together); `useCell` is the `useState` shape; `usePublisher(node$)` returns a stable publish function
+- `EngineProvider` props: `initFn(engine)` (one-time setup: register nodes, seed with `pubIn`, attach bridges), `initWith` (initial cell values), `updateFn`/`updateDeps` (re-publish changed props; use `singletonSub` for callback props so re-renders replace instead of stack), `engineId`, `engineRef`
+- Remote hooks (`useRemoteCellValue`, `useRemotePublisher`, `useRemoteCell`, `useRemoteCellValues`) reach another provider's engine via `useEngineRef()` or a string `engineId` — they return `undefined` until that engine mounts; guard for it
+- Components stay projection-only: read cells, publish actions. Logic lives in module-scope wiring, testable with a bare `Engine` and no React
+
+## Data fetching (reactive-engine-query)
+
+```ts
+export const tasksQuery = Query<{ listId: string }, Task[]>({
+  queryFn: async ({ listId }, signal) => {
+    const res = await fetch(`/api/tasks?listId=${listId}`, { signal })
+    if (!res.ok) throw new Error('Failed to fetch tasks')
+    return res.json()
+  },
+  initialParams: { listId: '' },
+})
+```
+
+`Query` returns nodes: `data$` (cell with `{ type: 'pending' | 'success' | 'error', data, error, isLoading, isFetching, ... }`), `params$` (publish to refetch with new params), `refetch$`, `invalidate$` (keep showing stale data, `isFetching: true`, re-execute), `unload$` (abort and clear), `enabled$`. Queries auto-execute on activation and param changes; each execution aborts the previous via the `signal`. Options: `retry` (default 3, exponential backoff), `refetchInterval`, `initialData`, `enabled`.
+
+`Mutation({ mutationFn, onSuccess?, onError? })` returns `data$`, `mutate$`, `reset$`. Mutations never auto-execute — publish params to `mutate$`. Wire mutations to refetch queries in the graph, not in components:
+
+```ts
+e.link(
+  e.pipe(
+    e.merge(createTask.data$, deleteTask.data$),
+    e.filter((r) => r.type === 'success'),
+    e.map(() => undefined, false) // distinct=false so consecutive successes each fire
+  ),
+  tasksQuery.refetch$
+)
+```
+
+## Routing (reactive-engine-router)
+
+```tsx
+export const user$ = Route('/users/{id:number}', UserPage) // params typed from the path
+const root = Layout('/', ({ children }) => <main>{children}</main>)
+
+<Router routes={[user$]} layouts={[root]} guards={[authGuard]} />
+```
+
+Route nodes emit typed params when matched, `null` otherwise. Navigate by publishing params to the route node (`usePublisher(user$)({ id: 42 })`). Pipe route params into query params to fetch on navigation. `Guard(pattern, fn)` runs on matching navigations — its context offers `continue()`, `navigate()`, `redirect()`; async guards render the route inside `Suspense`. Layouts match by URL prefix and nest by specificity; `LayoutSlotPortal`/`LayoutSlot`/`LayoutSlotFill` let pages fill layout regions. `Router` syncs with browser history by default.
+
+## Persistence (reactive-engine-storage)
+
+```ts
+linkCellToStorage(theme$, { storageType: 'localStorage', key: 'app-theme', debounceMs: 300 })
+```
+
+`storageType: 'localStorage' | 'sessionStorage' | 'cookie'` (cookie adds `cookieOptions`). Reads happen lazily, once per engine, when the engine first activates the cell; writes are debounced; localStorage links sync across tabs. The engine's `id` namespaces keys (`my-app:app-theme`) so multiple instances persist independently. SSR-safe (no-op without `window`).
+
+## Building a component or library on the engine
+
+Follow the data-table architecture ([full patterns](references/core/05.building-on-the-engine.md)):
+
+- Module-scope node graph + one engine per component instance (via `EngineProvider`)
+- Public API = action streams in (`setX$`, `resetX$`), state cells out (`xState$`, often `DerivedCell`); wiring stays internal
+- Props flow into cells via `pubIn` in `initFn`/`updateFn`; callback props via `singletonSub`
+- Optional features as separate modules (subpath exports) that attach wiring to core nodes — unused features cost nothing because inits are lazy
+- External control via `engineRef`/`engineId` + remote hooks against the exported nodes
+- Bridge imperative subsystems with subscribe-both-ways functions whose cleanup reaches `engine.onDispose`
+
+## Common mistakes
+
+- Calling standalone `pub`/`getValue`/`pubIn` outside a subscription callback — use `engine.*` methods or React hooks.
+- Mutating and republishing the same object — distinct is reference equality; nothing emits. Publish new references.
+- Expecting a node to hold state by itself — values live in an engine; the same `Cell` in two engines has two values.
+- Expecting `Stream` subscriptions to fire on subscribe with a current value — streams are stateless; only `Cell` has a value.
+- Piping into a trigger through `map` without `distinct: false` — consecutive identical mapped values get filtered.
+- Triggering a `Mutation` by changing params — mutations only run when params are published to `mutate$`.
+- Plain `sub` in code that re-runs with React renders — subscriptions accumulate; use `singletonSub`.
+- Creating cycles in the graph — cycles hang or loop; break one direction with an action stream or `delayWithMicrotask`.
+
+## References
+
+Guides in [references/](references/), per package:
+
+- `references/core/` — [core-concepts](references/core/01.core-concepts.md) (node types, distinct, the `e` namespace), [engine-and-lifecycle](references/core/02.engine-and-lifecycle.md) (activation, API flavors, child engines, disposal), [transactions](references/core/03.transactions.md) (cycles, topological execution, RxJS differences), [operators-and-combinators](references/core/04.operators-and-combinators.md) (full reference), [building-on-the-engine](references/core/05.building-on-the-engine.md) (architecture patterns from data-table), [README](references/core/README.md)
+- `references/react/` — [react-integration](references/react/01.react-integration.md) (EngineProvider lifecycle, hooks, remote hooks, SSR), [README](references/react/README.md)
+- `references/query/` — [queries-and-mutations](references/query/01.queries-and-mutations.md) (result states, lifecycle, wiring patterns), [README](references/query/README.md)
+- `references/router/` — [routing](references/router/01.routing.md) (path syntax, navigation, layouts, guards), [README](references/router/README.md)
+- `references/storage/` — [storage-links](references/storage/01.storage-links.md) (timing, namespacing, cross-tab sync), [README](references/storage/README.md)
+
+The JSDoc on the exported symbols in `@virtuoso.dev/reactive-engine-core` is extensive — when in doubt about a signature, read the type definitions shipped with the package.

--- a/packages/virtuoso-skills/skills/reactive-engine/references/core/01.core-concepts.md
+++ b/packages/virtuoso-skills/skills/reactive-engine/references/core/01.core-concepts.md
@@ -1,0 +1,113 @@
+---
+title: Core Concepts
+description: Nodes, engines, and the separation between graph definitions and runtime state.
+---
+
+The reactive engine models application logic as a graph of typed nodes. Two ideas carry everything else:
+
+1. **Nodes are definitions, not state.** A node constructor returns an inert reference — at runtime it is literally a `Symbol`. Creating a node records its definition (type, initial value, distinct behavior) in a global registry, but holds no value.
+2. **Engines hold state.** An `Engine` instance activates nodes on first use and owns their values. The same node used by two engines has two independent values.
+
+```ts
+import { Cell, Engine } from '@virtuoso.dev/reactive-engine-core'
+
+const count$ = Cell(0) // a definition, usually at module scope
+
+const a = new Engine()
+const b = new Engine()
+a.pub(count$, 5)
+a.getValue(count$) // 5
+b.getValue(count$) // 0 — independent state
+```
+
+This split is what makes the engine suitable for building reusable components: a library defines its node graph once at module scope, and every component instance gets its own engine — its own state — without re-declaring anything.
+
+## Node types
+
+| Node                            | State          | Emits                  | Use for                                            |
+| ------------------------------- | -------------- | ---------------------- | -------------------------------------------------- |
+| `Cell(initial, distinct?)`      | Current value  | On value change        | App state, configuration, derived values           |
+| `Stream<T>(distinct?)`          | None           | On publish             | Events, commands, transient data                   |
+| `Trigger()`                     | None           | On publish (valueless) | "Something happened" signals                       |
+| `Resource(factory)`             | Factory result | —                      | Per-engine objects with setup/teardown             |
+| `DerivedCell(initial, source$)` | Current value  | When the source emits  | Read-only computed state                           |
+| `Pipe<T>(...operators)`         | —              | —                      | An input/output node pair with a transform between |
+
+```ts
+import { Cell, Stream, Trigger, Resource } from '@virtuoso.dev/reactive-engine-core'
+
+const theme$ = Cell<'light' | 'dark'>('light')
+const keyPressed$ = Stream<string>()
+const reset$ = Trigger()
+const cache$ = Resource(() => ({
+  data: new Map<string, unknown>(),
+  dispose() {
+    this.data.clear()
+  },
+}))
+```
+
+A `Resource` factory runs once per engine, the first time the engine touches the node. On `engine.dispose()` the engine calls the instance's `[Symbol.dispose]()` if present, falling back to `dispose()`.
+
+`DerivedCell` is a cell whose value tracks a source expression:
+
+```ts
+import { DerivedCell, e } from '@virtuoso.dev/reactive-engine-core'
+
+const fahrenheit$ = DerivedCell(
+  32,
+  e.pipe(
+    celsius$,
+    e.map((c) => c * 1.8 + 32)
+  )
+)
+```
+
+Components read it like any cell; nothing can publish into it directly without going through the source.
+
+## Distinct semantics
+
+Every Cell and Stream filters duplicate emissions by default:
+
+- `true` (default) — compare with `===` (the `defaultComparator`; reference equality, not deep equality)
+- `false` — never filter; every publish emits
+- `(prev, next) => boolean` — custom comparator returning `true` when values are equal (suppress emission)
+
+```ts
+const user$ = Cell<User | null>(null, (prev, next) => prev?.id === next?.id)
+```
+
+Two consequences worth internalizing:
+
+- Because the default is reference equality, publishing a mutated object does not emit. Always publish new references (`new Map(old)`, spread), the same discipline React state requires.
+- The comparator receives `undefined` as `prev` on the first emission — write comparators with optional chaining.
+
+Triggers never filter; every publish fires.
+
+## The `e` namespace
+
+The package exports each operator and combinator individually, and also bundles them in a single `e` object — convenient when wiring many connections:
+
+```ts
+import { e } from '@virtuoso.dev/reactive-engine-core'
+
+e.link(
+  e.pipe(
+    toggleTheme$,
+    e.withLatestFrom(theme$),
+    e.map(([, current]) => (current === 'light' ? 'dark' : 'light'))
+  ),
+  theme$
+)
+```
+
+`e` contains the combinators (`link`, `pipe`, `combine`, `merge`, `sub`, `changeWith`, ...), the operators (`map`, `filter`, `scan`, ...), and the context-bound utilities (`pub`, `getValue`, `pubIn` — see [Engine and Lifecycle](./02.engine-and-lifecycle.md) for where those are allowed).
+
+## Naming conventions
+
+- Node references take a `$` suffix: `count$`, `setColumnVisibility$`.
+- Input streams that represent user actions read as commands: `resizeColumn$`, `toggleTheme$`.
+- State cells read as nouns: `theme$`, `scrollLocation$`.
+- Plain helper functions take no suffix.
+
+These conventions come from the packages built on the engine (data-table follows them throughout) and make the input/output boundary of a module visible at a glance.

--- a/packages/virtuoso-skills/skills/reactive-engine/references/core/02.engine-and-lifecycle.md
+++ b/packages/virtuoso-skills/skills/reactive-engine/references/core/02.engine-and-lifecycle.md
@@ -1,0 +1,108 @@
+---
+title: Engine and Lifecycle
+description: How engines activate nodes, the three API flavors, engine context, child engines, and disposal.
+---
+
+## Activation: how a node comes alive in an engine
+
+Nodes register lazily. The first time an engine touches a node — through `pub`, `sub`, `getValue`, `link`, or an explicit `engine.register(node$)` — the engine:
+
+1. Looks up the node's definition in the global registry and creates its state slot (or runs the `Resource` factory).
+2. Runs every **node init** attached to the node, once per engine, inside engine context.
+
+Node inits are the deferred-wiring mechanism. `addNodeInit(fn, ...nodes$)` attaches a function that runs when any of the listed nodes first activates in an engine:
+
+```ts
+import { addNodeInit } from '@virtuoso.dev/reactive-engine-core'
+
+addNodeInit((engine) => {
+  engine.link(source$, sink$)
+}, source$)
+```
+
+You rarely call `addNodeInit` directly — the module-scope combinators do it for you (next section). But understanding it explains the engine's central trick: _wiring declared at module scope applies to every engine that ever uses those nodes, paid for only when used._
+
+## The three API flavors
+
+The same verbs exist in three forms. Choosing the right one is most of the learning curve:
+
+| Flavor                   | Examples                                                        | Where it works                                    | What it does                                                                          |
+| ------------------------ | --------------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Module-scope combinators | `link`, `pipe`, `sub`, `changeWith`, `combine` (also via `e.*`) | Anywhere, including module top level              | Registers a node init — deferred wiring for **every** engine that activates the nodes |
+| Engine instance methods  | `engine.pub`, `engine.sub`, `engine.link`, `engine.getValue`    | Anywhere you hold an engine                       | Acts immediately on **that** engine                                                   |
+| Context-bound utilities  | `pub`, `getValue`, `pubIn` (standalone or via `e.*`)            | Only inside subscription callbacks and node inits | Acts on the currently executing engine                                                |
+
+```ts
+import { Cell, Stream, Engine, e } from '@virtuoso.dev/reactive-engine-core'
+
+const saveRequested$ = Stream<void>()
+const draft$ = Cell('')
+const save$ = Stream<string>()
+
+// Module scope: wiring for all engines, applied lazily
+e.sub(saveRequested$, () => {
+  // Context-bound: we are inside a subscription, an engine is active
+  e.pub(save$, e.getValue(draft$))
+})
+
+// Imperative code with an engine in hand
+const engine = new Engine()
+engine.pub(draft$, 'hello')
+engine.pub(saveRequested$)
+```
+
+Calling a context-bound utility outside engine context throws:
+
+```text
+No active engine found. You can use getValue only in the context of node subscription callbacks.
+```
+
+When you hit this error, the fix is one of: use the engine instance method, use a React hook (`useCellValue`, `usePublisher`), or move the code into a subscription/init where context exists.
+
+Note the asymmetry: standalone `sub`/`link`/`changeWith` are safe at module scope (they defer), but standalone `pub`/`getValue`/`pubIn` are not (they need a live engine). The subscription callback also receives the engine as a second argument — `sub(node$, (value, engine) => ...)` — when you prefer being explicit.
+
+## Engine construction
+
+```ts
+new Engine(initialValues?: Record<symbol, unknown>, id?: string, parentEngine?: Engine)
+```
+
+- `initialValues` — seed cell values, keyed by node: `new Engine({ [theme$]: 'dark' })`.
+- `id` — names the engine; used for storage key namespacing and the React engine registry.
+- `parentEngine` — creates a child engine (below).
+
+Key instance methods beyond the verbs already covered: `pubIn(values)` (batch several publishes into one transaction — see [Transactions](./03.transactions.md)), `subMultiple(nodes, cb)`, `singletonSub(node$, cb)`, `combineCells(cells)` (cached combination used by the React bindings), `register(node$)`, `onDispose(cb)`, `dispose()`, and the low-level `connect({ sources, pulls, sink, map })` that all operators reduce to.
+
+## singletonSub: subscriptions that replace themselves
+
+`engine.singletonSub(node$, callback)` keeps at most one subscription per node, replacing the previous one on each call. Regular `sub` subscriptions accumulate — calling `sub` in code that re-runs (React renders, update functions) leaks duplicate callbacks. `singletonSub` exists precisely for "the latest callback wins" situations, such as forwarding a node to a React prop:
+
+```ts
+// In an EngineProvider initFn AND updateFn — safe, replaces rather than stacks
+engine.singletonSub(onScroll$, onScroll)
+```
+
+`engine.resetSingletonSubs()` clears them all.
+
+## Child engines
+
+```ts
+const parent = new Engine()
+const child = new Engine({}, 'child-id', parent)
+```
+
+A child engine delegates operations on nodes the parent has registered: publishing or subscribing to a parent-owned node from the child reaches the parent's state, and parent emissions propagate into child subscriptions. Nodes the parent does not own activate locally in the child. Use child engines to scope a feature's state while still seeing shared application state.
+
+## Disposal
+
+`engine.dispose()`:
+
+- runs callbacks registered with `engine.onDispose(cb)`
+- disposes `Resource` instances (`[Symbol.dispose]()` or `dispose()`)
+- clears subscriptions and state; `engine.isDisposed` becomes `true`
+
+Anything that bridges the engine to the outside world (DOM listeners, timers, external stores) should register cleanup with `onDispose` at the point where the bridge is created. The React `EngineProvider` disposes its engine on unmount.
+
+## Debugging
+
+`debug(node$, 'label')` logs every emission of a node with the given label. Subscriptions also receive the engine, so ad-hoc inspection from a callback is `console.log(engine.getValue(other$))`.

--- a/packages/virtuoso-skills/skills/reactive-engine/references/core/03.transactions.md
+++ b/packages/virtuoso-skills/skills/reactive-engine/references/core/03.transactions.md
@@ -1,0 +1,56 @@
+---
+title: Transactions and Execution
+description: How publishing works - transactional cycles, topological ordering, and how the engine differs from RxJS.
+---
+
+## One publish, one cycle
+
+Every `engine.pub(node$, value)` runs a complete computation cycle, synchronously:
+
+1. The engine computes the **execution map**: a topological sort of every node reachable from the published node through the graph.
+2. It walks the map sources-before-sinks, computing each node's new value from the latest values of its inputs.
+3. Each node's distinct comparator decides whether it actually emits; nodes that don't emit prune their downstream.
+4. Subscriptions fire for every node that emitted, inside engine context.
+
+By the time `pub` returns, the whole graph is consistent and all subscriptions have run.
+
+## pubIn: batching into a single transaction
+
+`engine.pubIn({ [a$]: 1, [b$]: 2 })` publishes several nodes in **one** cycle. Derived nodes that depend on both inputs compute once, seeing both new values — instead of twice with an inconsistent intermediate state. Whenever you publish more than one related value, use `pubIn`:
+
+```ts
+engine.pubIn({
+  [data$]: rows,
+  [groupIndices$]: groups,
+})
+```
+
+## Diamond dependencies emit once
+
+Given `a$ → b$`, `a$ → c$`, and `(b$, c$) → d$`, publishing to `a$` makes `d$` emit exactly once per cycle, after both `b$` and `c$` computed. This is the property that makes derived state composable — you never observe a "glitch" where `d$` fires with one fresh and one stale input.
+
+## When distinct is checked
+
+The comparator runs during node computation, comparing against the node's current value. It is not a pre-publish check on the caller's side. Implications:
+
+- A `Cell` that receives the same value emits nothing downstream — derived nodes and subscriptions stay quiet.
+- `map(fn, distinct?)` takes its own distinct parameter; a derived node can filter duplicates even when its source always emits.
+- The comparator sees `prev === undefined` on a node's first computation.
+
+## Re-entrancy
+
+Publishing from inside a subscription starts a **nested cycle** — cycles are not queued or merged. This is allowed and common (a subscription reacting to one node by publishing another), but recursive publishes to the same node must terminate, or you have an infinite loop. To defer work to after the current cycle, route it through `delayWithMicrotask()`:
+
+```ts
+e.link(e.pipe(burst$, e.delayWithMicrotask()), settled$)
+```
+
+## Differences from RxJS
+
+If you come from RxJS (or urx), recalibrate on these points:
+
+- **No completion, no error channel.** Nodes never complete; exceptions in operators or subscriptions propagate to the publisher and abort the cycle. Handle errors at the edges — inside `queryFn`-style async work or subscription bodies — not in the graph.
+- **Synchronous by default.** Emissions happen during `pub`, not on a scheduler. Only `throttleTime`, `debounceTime`, `delayWithMicrotask`, and `handlePromise` introduce asynchrony.
+- **Subscribing does not replay.** Subscribing to a `Cell` does not invoke the callback with the current value — read it with `getValue` if needed at subscribe time. (The React hooks do this for you.) Streams have no current value at all; `getValue` on a stream returns `undefined`.
+- **No per-subscription operator chains.** Operators transform nodes into new nodes (`pipe` returns a `NodeRef`); they are part of the shared graph, not private to a subscriber.
+- **Promises resolve out of order.** `handlePromise` emits results as promises settle; a slow earlier request can emit after a fast later one. Abort or sequence-guard async work where ordering matters (the `Query` package does this for you).

--- a/packages/virtuoso-skills/skills/reactive-engine/references/core/04.operators-and-combinators.md
+++ b/packages/virtuoso-skills/skills/reactive-engine/references/core/04.operators-and-combinators.md
@@ -1,0 +1,68 @@
+---
+title: Operators and Combinators
+description: Reference for transforming and connecting nodes.
+---
+
+Combinators connect nodes; operators transform values inside a `pipe`. All are available as named exports and on the `e` namespace object. The module-scope forms register deferred wiring (applied per engine on activation); the `Engine` instance methods of the same names act immediately on one engine.
+
+## Combinators
+
+| Combinator                                                    | Purpose                                                                  |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `link(source$, sink$)`                                        | Forward every emission from source to sink                               |
+| `pipe(source$, ...operators)`                                 | Derive a new node by running emissions through operators                 |
+| `combine(a$, b$, ...)`                                        | Node emitting `[a, b, ...]` whenever any source emits (up to 22 sources) |
+| `merge(a$, b$, ...)`                                          | Node emitting each source's values individually                          |
+| `sub(node$, cb)`                                              | Subscribe; `cb(value, engine)`                                           |
+| `singletonSub(node$, cb)`                                     | Exclusive subscription — replaces the previous singleton on the node     |
+| `subMultiple([a$, b$], cb)`                                   | One callback over several nodes                                          |
+| `changeWith(cell$, source$, (cell, value) => next)`           | Update a cell from a stream, reducer-style                               |
+| `withResource(source$, resource$, (value, resource) => void)` | Side effect pairing emissions with a resource instance                   |
+
+`changeWith` is the workhorse for "action stream updates state cell":
+
+```ts
+e.changeWith(columnWidths$, resizeColumn$, (widths, { key, width }) => {
+  const next = new Map(widths)
+  next.set(key, width)
+  return next
+})
+```
+
+Return a **new** reference from the reducer — cells are distinct by reference equality, so mutating and returning the same Map emits nothing.
+
+## Operators
+
+| Operator                                    | Behavior                                                                                          |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `map(fn, distinct?)`                        | Transform each value; optional distinct filter on the output                                      |
+| `filter(predicate)`                         | Drop values failing the predicate; supports type-guard predicates for narrowing                   |
+| `mapTo(value)`                              | Replace every emission with a constant                                                            |
+| `scan((acc, value) => acc, seed)`           | Running accumulation                                                                              |
+| `once()`                                    | Pass only the first emission                                                                      |
+| `withLatestFrom(...nodes$)`                 | Append the latest values of other nodes to each source emission; emits only when the source emits |
+| `throttleTime(ms)`                          | Rate-limit emissions                                                                              |
+| `debounceTime(ms)`                          | Emit only after the source goes quiet for the duration                                            |
+| `delayWithMicrotask()`                      | Re-emit in a microtask, after the current cycle                                                   |
+| `onNext(buf$)`                              | Buffer the source value, emit `[buffered, value]` when `buf$` next emits                          |
+| `handlePromise(onLoad, onSuccess, onError)` | Expand a promise-emitting node into loading/success/error emissions                               |
+
+Two distinctions that prevent common mistakes:
+
+- `combine` vs `withLatestFrom`: `combine` emits when _any_ input changes; `withLatestFrom` only when the _source_ emits, with the other nodes read passively. Use `withLatestFrom` for "when the user clicks, read the current settings", `combine` for "recompute whenever anything changes".
+- `map(..., distinct)` vs node distinct: pass `false` as map's distinct when piping into a Trigger-like sink that must fire every time — for example mapping mutation successes to `undefined` for a refetch trigger:
+
+```ts
+e.link(
+  e.pipe(
+    e.merge(create.data$, remove.data$),
+    e.filter((r) => r.type === 'success'),
+    e.map(() => undefined, false) // without false, the second success would be filtered as a duplicate undefined
+  ),
+  tasksQuery.refetch$
+)
+```
+
+## The low-level primitive: connect
+
+Every operator and combinator reduces to `engine.connect({ sources, pulls, sink, map })`: when any node in `sources` emits, call `map(done)(...sourceValues, ...pullValues)`; calling `done(value)` proposes an emission on `sink` (still subject to the sink's distinct check). `pulls` are read passively without triggering. Reach for `connect` only when no operator combination expresses the dependency shape — it is the engine's assembly language.

--- a/packages/virtuoso-skills/skills/reactive-engine/references/core/05.building-on-the-engine.md
+++ b/packages/virtuoso-skills/skills/reactive-engine/references/core/05.building-on-the-engine.md
@@ -1,0 +1,142 @@
+---
+title: Building on the Engine
+description: Architecture patterns for components and libraries built on the reactive engine, extracted from @virtuoso.dev/data-table.
+---
+
+`@virtuoso.dev/data-table` is the largest production system built on the engine. Its architecture demonstrates the patterns that make engine-based components scale. Each pattern below is generic; data-table serves as the worked example.
+
+## Module-scope graph, per-instance engine
+
+Define the entire node graph and its wiring at module scope. Instantiate one engine per component instance. Because module-scope combinators register deferred inits, the wiring applies automatically to every engine that activates the nodes — and each instance's state stays isolated.
+
+```ts
+// feature module, module scope — runs once per import, applies to every engine
+export const setColumnVisibility$ = Stream<SetColumnVisibilityPayload>()
+export const resetColumnVisibility$ = Trigger()
+
+e.changeWith(
+  columnVisibilityOverrides$,
+  e.pipe(setColumnVisibility$, e.withLatestFrom(columns$)),
+  (overrides, [{ key, visible }, columns]) => {
+    /* return a new Map */
+  }
+)
+```
+
+Two tables on one page (`engineId="orders"` / `engineId="invoices"`) share this wiring but never share state.
+
+## Action streams in, state cells out
+
+Design a module's public API as a boundary of nodes:
+
+- **Inputs**: streams and triggers named as commands — `setColumnVisibility$`, `resizeColumn$`, `resetColumnOrder$`. The outside world publishes; it never writes state directly.
+- **Outputs**: cells (often `DerivedCell`) named as state — `columnVisibilityState$`, `scrollLocation$`. The outside world reads and subscribes; it cannot publish into a derived cell.
+
+The wiring between inputs and outputs is internal. This gives the module the same encapsulation a reducer gives a store: all state transitions are enumerable, and every consumer (React component, persistence adapter, test) goes through the same two node kinds.
+
+## Derived cells for computed state
+
+Represent any state computable from other state as a `DerivedCell` over `combine`:
+
+```ts
+export const columnVisibilityState$ = DerivedCell(
+  new Map<string, boolean>(),
+  e.pipe(
+    e.combine(columns$, columnVisibilityOverrides$),
+    e.map(([columns, overrides]) => new Map([...columns].map(([key, c]) => [key, overrides.get(key) ?? c.visible !== false])))
+  )
+)
+```
+
+Store only the minimal independent state (the overrides) and derive the rest. The transaction system guarantees derived cells never observe partially-updated inputs.
+
+## React props flow in through initFn/updateFn; callbacks flow out through singletonSub
+
+The component shell is thin: an `EngineProvider` that pushes props into cells and forwards node emissions to callback props.
+
+```tsx
+<EngineProvider
+  initFn={(e) => {
+    e.register(columns$) // activate nodes whose inits must run eagerly
+    e.pubIn({ [context$]: context, [computeRowKey$]: computeRowKey })
+    e.singletonSub(onScroll$, onScroll)
+  }}
+  updateFn={(e) => {
+    e.pubIn({ [context$]: context, [computeRowKey$]: computeRowKey })
+    e.singletonSub(onScroll$, onScroll) // replaces, never stacks
+  }}
+  updateDeps={[context, computeRowKey, onScroll]}
+  engineId={engineId}
+  engineRef={engineRef}
+>
+```
+
+- `initFn` runs once at engine creation: register nodes, seed cells with `pubIn`, attach bridges.
+- `updateFn` runs whenever `updateDeps` change: re-publish the changed props. Distinct cells make redundant publishes free.
+- Callback props always go through `singletonSub` so re-renders replace the subscription instead of accumulating duplicates.
+
+Inside the component tree, rendering is just `useCellValue(cell$)` and event handlers are just `usePublisher(action$)` — components contain no logic, only projection.
+
+## Batch related publishes with pubIn
+
+When several cells change together (a data result and its group indices; a set of props), publish them in one `pubIn` transaction so derived nodes compute once with a consistent view.
+
+## Feature modules as opt-in subpath exports
+
+Each optional feature lives in its own module exporting its action streams, state cells, pure helper converters, and UI fragments — published as a package subpath (`@virtuoso.dev/data-table/column-visibility`). The core never imports features; features import core nodes and attach wiring. Because wiring is deferred inits, an unused feature costs nothing: its inits never run in engines that never touch its nodes.
+
+## Remote control: engineRef and engineId
+
+Because state lives in an engine rather than React state, external UI does not need prop drilling or lifted state. The component accepts an identity (`engineRef` from `useEngineRef()` for nearby UI, string `engineId` for distant UI), and external components use remote hooks against the exported nodes:
+
+```tsx
+const scrollToRow = useRemotePublisher(scrollToRow$, engineRef)
+const location = useRemoteCellValue(scrollLocation$, engineRef)
+```
+
+The public node set defines exactly what external control is possible. Remote hooks return `undefined` until the target engine mounts — design consumers to tolerate that.
+
+## Bridging imperative systems
+
+Non-reactive subsystems (data sources, network layers) connect through a bridge: a function that subscribes both directions and returns a cleanup, registered with `engine.onDispose`.
+
+```ts
+function bridgeModelToEngine(model: DataModelHandle, engine: Engine): () => void {
+  const unsubModel = model.subscribe((msg) => {
+    engine.pubIn({ [data$]: msg.rows, [groupIndices$]: msg.groups })
+  })
+  const unsubViewport = engine.sub(viewportRange$, (range) => {
+    model.send({ action: 'viewportChange', payload: range })
+  })
+  return () => {
+    unsubModel()
+    unsubViewport()
+  }
+}
+```
+
+The engine side stays declarative (cells and streams); the imperative side keeps its own protocol. data-table uses this to keep its data models (`localModel`, `remoteModel`) engine-free and independently testable.
+
+## Persistence adapters
+
+Persisting feature state generalizes into an adapter interface that each feature implements with its own pure serializers:
+
+```ts
+interface PersistenceAdapter<State> {
+  key: string
+  capture(context, previous: State | null): State // engine state -> storable shape
+  restore(context, state: State | null): void // storable shape -> publishes into the engine
+  subscribe(context, onChange): () => void // watch the nodes that mean "state changed, save it"
+  subscribeRestore?(context, onChange): () => void // watch the nodes that mean "re-apply saved state"
+}
+```
+
+An orchestrator component owns the storage, debounces writes, restores on mount, and knows nothing about any feature. Note the two subscription channels: `subscribe` watches user actions (save triggers), `subscribeRestore` watches structural changes like the column set (re-apply triggers). For simple cases — one cell, one storage key — skip the adapter machinery and use `linkCellToStorage` from `@virtuoso.dev/reactive-engine-storage`.
+
+## Invariants to respect
+
+- **Register dependency nodes before attaching bridges** in `initFn` — wiring inits must be in place before data starts flowing.
+- **Always return new references from reducers** (`changeWith`, `map`) — distinct is reference equality.
+- **Every bridge returns a cleanup**, and every cleanup reaches `engine.onDispose` (or the provider's unmount path).
+- **Keep the graph acyclic.** If two cells must influence each other, route one direction through an action stream or `delayWithMicrotask`.
+- **`singletonSub` for anything driven by React renders**; plain `sub` only in module wiring and inits.

--- a/packages/virtuoso-skills/skills/reactive-engine/references/core/README.md
+++ b/packages/virtuoso-skills/skills/reactive-engine/references/core/README.md
@@ -1,0 +1,46 @@
+# Reactive Engine Core
+
+`@virtuoso.dev/reactive-engine-core` is a framework-agnostic reactive state engine. State is modeled as a graph of typed nodes — stateful cells, stateless streams, and valueless triggers — connected through operators and combinators. An `Engine` instance activates the graph, propagates values, and manages subscriptions.
+
+The package is part of the Reactive Engine family:
+
+- [`@virtuoso.dev/reactive-engine-react`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-react) - React bindings (provider and hooks)
+- [`@virtuoso.dev/reactive-engine-query`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-query) - data fetching with queries and mutations
+- [`@virtuoso.dev/reactive-engine-router`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-router) - routing with routes, layouts, and guards
+- [`@virtuoso.dev/reactive-engine-storage`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-storage) - cell persistence in local/session storage or cookies
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core
+```
+
+## Quick Example
+
+```ts
+import { Cell, Engine } from '@virtuoso.dev/reactive-engine-core'
+
+const count$ = Cell(0)
+const engine = new Engine()
+
+engine.sub(count$, (value) => {
+  console.log('count is now', value)
+})
+
+engine.pub(count$, 1)
+engine.getValue(count$) // 1
+```
+
+## Concepts
+
+- **Cells** are stateful nodes that always hold a current value.
+- **Streams** are stateless nodes that emit values to their subscribers.
+- **Triggers** are valueless streams used to signal events.
+- **Resources** are cells with factory initialization and automatic disposal.
+- **Operators** (`map`, `filter`, `scan`, `debounceTime`, `throttleTime`, `withLatestFrom`, and more) transform values as they flow between nodes.
+- **Combinators** (`link`, `pipe`, `combine`, `merge`) wire nodes into a graph.
+- **Engine** instances activate node definitions, propagate published values, and manage subscriptions.
+
+## License
+
+MIT

--- a/packages/virtuoso-skills/skills/reactive-engine/references/query/01.queries-and-mutations.md
+++ b/packages/virtuoso-skills/skills/reactive-engine/references/query/01.queries-and-mutations.md
@@ -1,0 +1,124 @@
+---
+title: Queries and Mutations
+description: Data fetching as nodes - lifecycle, result states, retries, and wiring patterns.
+---
+
+`@virtuoso.dev/reactive-engine-query` expresses data fetching as engine nodes, so queries compose with the rest of the graph: route params can drive query params, mutation successes can trigger refetches, and components consume results with `useCellValue` like any other state.
+
+## Query
+
+```ts
+export const tasksQuery = Query<{ listId: string }, Task[]>({
+  queryFn: async ({ listId }, signal) => {
+    const res = await fetch(`/api/tasks?listId=${listId}`, { signal })
+    if (!res.ok) throw new Error('Failed to fetch tasks')
+    return res.json()
+  },
+  initialParams: { listId: '' },
+})
+```
+
+`Query()` returns a bundle of nodes:
+
+| Node          | Kind    | Role                                                        |
+| ------------- | ------- | ----------------------------------------------------------- |
+| `data$`       | Cell    | The query result (discriminated union below)                |
+| `params$`     | Cell    | Publishing new params re-executes the query                 |
+| `refetch$`    | Trigger | Re-execute with current params                              |
+| `invalidate$` | Trigger | Mark stale: keep showing data, set `isFetching`, re-execute |
+| `unload$`     | Trigger | Abort, clear data, return to pending                        |
+| `enabled$`    | Cell    | Gate execution; toggling to `true` executes                 |
+
+Options: `enabled` (default `true`), `retry` (default `3`; `retry: 3` means up to 4 attempts), `retryDelay` (default exponential backoff capped at 30s), `refetchInterval` (polling, starts after a successful fetch), `initialData`.
+
+### Result shape
+
+`data$` emits one of three states, discriminated on `type`:
+
+```ts
+{ type: 'pending', data: null,  isLoading: true,  isFetching: true,  isSuccess: false, isError: false, error: null }
+{ type: 'success', data: T,     isLoading: false, isFetching: boolean, isSuccess: true,  isError: false, error: null, dataUpdatedAt: number }
+{ type: 'error',   data: null,  isLoading: false, isFetching: false, isSuccess: false, isError: true,  error: unknown }
+```
+
+`isFetching: true` inside the success state means a background refresh is in flight while stale data stays visible — that is what `invalidate$` produces, versus `unload$` which drops to pending.
+
+### Lifecycle rules
+
+- A query executes when its `data$` first activates in an engine (if enabled), whenever `params$` emits (if enabled), on `refetch$`/`invalidate$`, and when `enabled$` flips to `true`.
+- Each execution aborts the previous in-flight request — the `signal` passed to `queryFn` must reach the actual fetch.
+- Disabling aborts in-flight work and stops polling.
+- Query state is per engine, like all node state; the same query in two engines fetches independently.
+
+## Mutation
+
+```ts
+export const createTask = Mutation<{ listId: string; title: string }, Task>({
+  mutationFn: async (params) => {
+    /* POST */
+  },
+})
+```
+
+Returns `data$` (states `idle | pending | success | error`, with `isPending`/`isSuccess`/`isError` flags), `mutate$` (publish params to execute), and `reset$` (back to idle). Mutations never auto-execute and don't retry by default. `onSuccess(data)`/`onError(error)` callbacks fire after the state publish.
+
+```tsx
+const create = usePublisher(createTask.mutate$)
+const result = useCellValue(createTask.data$)
+
+<button disabled={result.isPending} onClick={() => create({ listId, title })}>Add</button>
+```
+
+## Wiring patterns
+
+**Mutations trigger refetches in the graph, not in components.** Declare the relationship once at module scope:
+
+```ts
+e.link(
+  e.pipe(
+    e.merge(createTask.data$, updateTask.data$, deleteTask.data$),
+    e.filter((r) => r.type === 'success'),
+    e.map(() => undefined, false) // distinct=false: consecutive successes must each fire
+  ),
+  tasksQuery.refetch$
+)
+```
+
+**Routes drive query params.** A route node emits its params when matched; pipe it into `params$`:
+
+```ts
+e.link(
+  e.pipe(
+    tasks$, // Route('/lists/{id:string}', TasksPage)
+    e.filter((params) => params !== null),
+    e.map((params) => ({ listId: params.id }))
+  ),
+  tasksQuery.params$
+)
+```
+
+Navigation then transparently refetches — no effect hooks, no param threading through components.
+
+**Dependent queries** gate on their prerequisite:
+
+```ts
+e.link(
+  e.pipe(
+    userQuery.data$,
+    e.map((r) => r.type === 'success')
+  ),
+  ordersQuery.enabled$
+)
+```
+
+## Rendering results
+
+Branch on the discriminated union:
+
+```tsx
+const result = useCellValue(tasksQuery.data$)
+
+if (result.isLoading) return <Spinner />
+if (result.isError) return <ErrorView error={result.error} />
+return <TaskList tasks={result.data} refreshing={result.isFetching} />
+```

--- a/packages/virtuoso-skills/skills/reactive-engine/references/query/README.md
+++ b/packages/virtuoso-skills/skills/reactive-engine/references/query/README.md
@@ -1,0 +1,41 @@
+# Reactive Engine Query
+
+`@virtuoso.dev/reactive-engine-query` adds data fetching to [`@virtuoso.dev/reactive-engine-core`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-core). Queries and mutations are reactive nodes: parameters flow in, and pending/success/error results flow out to the rest of the graph.
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core @virtuoso.dev/reactive-engine-query
+```
+
+## Quick Example
+
+```ts
+import { Query } from '@virtuoso.dev/reactive-engine-query'
+
+interface Task {
+  id: string
+  title: string
+}
+
+export const tasksQuery = Query<{ listId: string }, Task[]>({
+  queryFn: async ({ listId }, signal) => {
+    const res = await fetch(`/api/tasks?listId=${listId}`, { signal })
+    if (!res.ok) {
+      throw new Error('Failed to fetch tasks')
+    }
+    return res.json()
+  },
+  initialParams: { listId: '' },
+})
+```
+
+## Features
+
+- `Query` - parameterized async reads with abort signal support, retries, and typed pending/success/error results
+- `Mutation` - async writes with typed idle/pending/success/error results
+- `executeWithRetry` / `defaultRetryDelay` - retry utilities used by both
+
+## License
+
+MIT

--- a/packages/virtuoso-skills/skills/reactive-engine/references/react/01.react-integration.md
+++ b/packages/virtuoso-skills/skills/reactive-engine/references/react/01.react-integration.md
@@ -1,0 +1,93 @@
+---
+title: React Integration
+description: EngineProvider lifecycle, hooks, and remote engine access.
+---
+
+## EngineProvider
+
+`EngineProvider` creates an engine when it mounts, provides it through context, and disposes it on unmount. While the provider is mounted, the engine is the source of truth; React components project its state.
+
+```tsx
+<EngineProvider
+  initWith={{ [theme$]: 'dark' }} // seed cell values at construction
+  initFn={(engine) => {
+    /* one-time setup: register nodes, bridges, singleton subs */
+  }}
+  updateFn={(engine) => {
+    /* re-publish changed props */
+  }}
+  updateDeps={[propA, propB]}
+  engineId="my-feature" // optional: global registry + storage namespacing
+  engineRef={engineRef} // optional: handle for remote hooks
+>
+  {children}
+</EngineProvider>
+```
+
+Lifecycle details that matter:
+
+- The engine is created in a `useState` initializer and `initFn` runs synchronously right after — before the first render of children.
+- `updateFn` runs in a layout effect whenever `updateDeps` change (including once after mount). It is independent of `initFn`; both should be written idempotently. Use `pubIn` for prop values (distinct cells absorb no-op republishes) and `singletonSub` for callback props.
+- On unmount the engine is disposed and (if set) removed from the registry/ref.
+- Nesting providers shadows the engine context — `useEngine()` returns the nearest provider's engine. Providers do not automatically parent-link; coordinate separate engines through remote hooks or construct child engines yourself.
+
+## Hooks
+
+| Hook                         | Returns                             | Notes                                                                                |
+| ---------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------ |
+| `useCellValue(cell$)`        | Current value, re-renders on change | Backed by `useSyncExternalStore`; SSR-safe                                           |
+| `useCellValues(a$, b$, ...)` | Tuple of values                     | Single subscription via a combined cell — one re-render when several change together |
+| `useCell(cell$)`             | `[value, publish]`                  | The `useState` shape                                                                 |
+| `usePublisher(node$)`        | Stable `(value) => void`            | Safe in effect dependency arrays                                                     |
+| `useEngine()`                | The provider's engine               | For imperative escape hatches                                                        |
+| `useEngineRef()`             | A stable `EngineRef`                | Pass to a provider's `engineRef` and to remote hooks                                 |
+
+Prefer `useCellValues` over several `useCellValue` calls when a component reads multiple cells that change in the same transaction — it collapses them into one re-render.
+
+## Remote hooks: reaching an engine from outside its tree
+
+Remote hooks accept an `EngineSource` — an `EngineRef` or a string `engineId` — and resolve the engine through the ref or a global registry:
+
+```tsx
+const value = useRemoteCellValue(scrollLocation$, engineRef)
+const publish = useRemotePublisher(scrollToRow$, 'orders-table')
+const [v, setV] = useRemoteCell(theme$, engineRef)
+const values = useRemoteCellValues({ cells: [a$, b$], engineSource: engineRef })
+```
+
+The defining behavior: **remote hooks return `undefined` until the target engine exists**. They subscribe to the ref/registry and start delivering values as soon as the provider mounts. Guard accordingly:
+
+```tsx
+const location = useRemoteCellValue(scrollLocation$, engineRef)
+if (location === undefined) return null // table not mounted yet
+```
+
+Use an `engineRef` when the controlling UI and the provider share a component (a toolbar next to its table); use an `engineId` when they are far apart and threading a ref is impractical. The id registry is global to the page — namespace ids if several independent features use them.
+
+## SSR
+
+`useCellValue` provides a server snapshot through `useSyncExternalStore`, so server rendering reads the engine's initial values. Reading a cell during render must stay side-effect free. Effect-timing hooks use a layout effect in the browser and a regular effect on the server (`useIsomorphicLayoutEffect`).
+
+## Component patterns
+
+Keep components projection-only:
+
+```tsx
+const VisibilityMenu = () => {
+  const visibility = useCellValue(columnVisibilityState$)
+  const setVisibility = usePublisher(setColumnVisibility$)
+
+  return (
+    <>
+      {[...visibility].map(([key, visible]) => (
+        <label key={key}>
+          <input type="checkbox" checked={visible} onChange={(ev) => setVisibility({ key, visible: ev.target.checked })} />
+          {key}
+        </label>
+      ))}
+    </>
+  )
+}
+```
+
+Logic — what a visibility change means, how it composes with declarations — lives in the module-scope wiring, where it is shared by every instance and testable with a bare `Engine` and no React at all.

--- a/packages/virtuoso-skills/skills/reactive-engine/references/react/README.md
+++ b/packages/virtuoso-skills/skills/reactive-engine/references/react/README.md
@@ -1,0 +1,45 @@
+# Reactive Engine React
+
+`@virtuoso.dev/reactive-engine-react` provides React bindings for [`@virtuoso.dev/reactive-engine-core`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-core): an `EngineProvider` component and hooks for reading cell values and publishing into nodes from components.
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core @virtuoso.dev/reactive-engine-react
+```
+
+## Quick Example
+
+```tsx
+import { Cell } from '@virtuoso.dev/reactive-engine-core'
+import { EngineProvider, useCellValue, usePublisher } from '@virtuoso.dev/reactive-engine-react'
+
+const count$ = Cell(0)
+
+function Counter() {
+  const count = useCellValue(count$)
+  const setCount = usePublisher(count$)
+
+  return <button onClick={() => setCount(count + 1)}>{count}</button>
+}
+
+export function App() {
+  return (
+    <EngineProvider>
+      <Counter />
+    </EngineProvider>
+  )
+}
+```
+
+## Hooks
+
+- `useCellValue` / `useCellValues` - subscribe to one or several cells
+- `useCell` - read a cell value and get a publisher for it
+- `usePublisher` - get a publisher function for a node
+- `useEngine` / `useEngineRef` - access the engine instance from context
+- `useRemoteCell`, `useRemoteCellValue`, `useRemoteCellValues`, `useRemotePublisher` - work with cells from another engine instance
+
+## License
+
+MIT

--- a/packages/virtuoso-skills/skills/reactive-engine/references/router/01.routing.md
+++ b/packages/virtuoso-skills/skills/reactive-engine/references/router/01.routing.md
@@ -68,7 +68,7 @@ Layouts match by URL prefix and nest by specificity — `Layout('/')` wraps ever
 ## Guards
 
 ```tsx
-const authGuard = Guard('/admin/*', (context) => {
+const authGuard = Guard('/admin', (context) => {
   const user = context.engine.getValue(currentUser$)
   if (!user) {
     return context.redirect(login$, {})

--- a/packages/virtuoso-skills/skills/reactive-engine/references/router/01.routing.md
+++ b/packages/virtuoso-skills/skills/reactive-engine/references/router/01.routing.md
@@ -1,0 +1,99 @@
+---
+title: Routing
+description: Typed routes as nodes, navigation, layouts, guards, and browser history.
+---
+
+`@virtuoso.dev/reactive-engine-router` represents each route as a node. A route node emits its parsed params when the route is active and `null` when it is not — which makes routing composable with the rest of the graph (drive query params from routes, gate features on the active route).
+
+## Defining routes
+
+```tsx
+import { Route } from '@virtuoso.dev/reactive-engine-router'
+
+export const home$ = Route('/', HomePage)
+export const user$ = Route('/users/{id:number}', UserPage)
+export const blog$ = Route('/blog/{slug}/?category={category?}&tag={tag?}', BlogPage)
+export const files$ = Route('/files/{*rest}', FilesPage)
+```
+
+The path syntax is parsed at the type level — params arrive typed:
+
+- `{id:number}` → `{ id: number }`; `{slug}` defaults to string
+- `?q={query}&limit={limit?:number}` → optional search params under `$search`
+- `{*rest}` → catch-all, `string[]`
+
+The route component receives the params as props, typed as `RouteParams<'/users/{id:number}'>`:
+
+```tsx
+export const UserPage: React.ComponentType<RouteParams<'/users/{id:number}'>> = ({ id }) => <h1>User {id}</h1>
+```
+
+## Mounting and navigating
+
+```tsx
+<EngineProvider>
+  <Router routes={[home$, user$, blog$]} layouts={[rootLayout]} guards={[authGuard]} />
+</EngineProvider>
+```
+
+`Router` needs an engine (mount it inside an `EngineProvider`). Props: `routes`, `layouts`, `guards`, `basePath`, `useBrowserHistory` (default `true` — syncs with the address bar and back/forward buttons).
+
+Navigation is publishing params to a route node:
+
+```tsx
+const goToUser = usePublisher(user$)
+goToUser({ id: 42 }) // navigates to /users/42
+```
+
+Since route nodes are also outputs, the same node tells you whether the route is active:
+
+```tsx
+const userParams = useCellValue(user$) // null when not on /users/...
+```
+
+## Layouts
+
+```tsx
+const rootLayout = Layout('/', ({ children }) => (
+  <main>
+    <Nav />
+    {children}
+  </main>
+))
+const blogLayout = Layout('/blog', ({ children }) => <BlogShell>{children}</BlogShell>)
+```
+
+Layouts match by URL prefix and nest by specificity — `Layout('/')` wraps everything, `Layout('/blog')` wraps inside it for blog routes. For regions a route fills inside a layout (a context-dependent sidebar), create a slot cell with `LayoutSlotPortal()`, render it in the layout with `<LayoutSlot slotPortal={...}>`, and provide content from a page with `<LayoutSlotFill slotPortal={...}>`.
+
+## Guards
+
+```tsx
+const authGuard = Guard('/admin/*', (context) => {
+  const user = context.engine.getValue(currentUser$)
+  if (!user) {
+    return context.redirect(login$, {})
+  }
+  return context.continue()
+})
+```
+
+- A guard's pattern uses route syntax; all guards matching the target URL run in order (priority option, then specificity, then registration order).
+- The context offers `continue()`, `navigate(urlOrRoute, params?)` (retarget and keep evaluating guards against the new URL), `redirect(urlOrRoute, params?)` (abort and navigate), plus `params`, `location`, and `engine`.
+- Guards may be async — the route renders inside `Suspense` while pending, so provide a Suspense boundary above the `Router`.
+
+## Wiring routes into the graph
+
+The canonical pattern — route activation drives data fetching:
+
+```ts
+e.link(
+  e.pipe(
+    user$,
+    e.filter((params) => params !== null),
+    e.map((params) => ({ userId: params.id }))
+  ),
+  userQuery.params$
+)
+```
+
+Pages then need no fetch logic at all: navigating publishes params, params trigger the query, the page reads `userQuery.data$`.

--- a/packages/virtuoso-skills/skills/reactive-engine/references/router/README.md
+++ b/packages/virtuoso-skills/skills/reactive-engine/references/router/README.md
@@ -1,0 +1,51 @@
+# Reactive Engine Router
+
+`@virtuoso.dev/reactive-engine-router` is a router built on [`@virtuoso.dev/reactive-engine-core`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-core). Routes are reactive nodes - navigation is publishing into a route node, and the current route flows through the graph like any other value.
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core @virtuoso.dev/reactive-engine-react @virtuoso.dev/reactive-engine-router
+```
+
+## Quick Example
+
+```tsx
+import { usePublisher } from '@virtuoso.dev/reactive-engine-react'
+import { Layout, Router } from '@virtuoso.dev/reactive-engine-router'
+
+import { about$, home$ } from './routes'
+
+const rootLayout = Layout('/', ({ children }) => (
+  <div>
+    <Navigation />
+    <main>{children}</main>
+  </div>
+))
+
+function Navigation() {
+  const goHome = usePublisher(home$)
+  const goToAbout = usePublisher(about$)
+
+  return (
+    <nav>
+      <button onClick={() => goHome({})}>Home</button>
+      <button onClick={() => goToAbout({})}>About</button>
+    </nav>
+  )
+}
+
+export function App() {
+  return <Router layouts={[rootLayout]} routes={[home$, about$]} />
+}
+```
+
+## Features
+
+- **Routes** - typed route definitions with parameters
+- **Layouts** - nested layout components matched by path, with slot/fill composition (`LayoutSlot`, `LayoutSlotFill`)
+- **Guards** - sync or async navigation guards that can continue, redirect, or navigate elsewhere
+
+## License
+
+MIT

--- a/packages/virtuoso-skills/skills/reactive-engine/references/storage/01.storage-links.md
+++ b/packages/virtuoso-skills/skills/reactive-engine/references/storage/01.storage-links.md
@@ -1,0 +1,47 @@
+---
+title: Storage Links
+description: Persisting cells to localStorage, sessionStorage, and cookies.
+---
+
+`linkCellToStorage` keeps a cell in sync with browser storage. Declare it at module scope next to the cell:
+
+```ts
+import { Cell } from '@virtuoso.dev/reactive-engine-core'
+import { linkCellToStorage } from '@virtuoso.dev/reactive-engine-storage'
+
+export const theme$ = Cell<'light' | 'dark'>('light')
+
+linkCellToStorage(theme$, {
+  storageType: 'localStorage',
+  key: 'app-theme',
+  debounceMs: 300,
+})
+```
+
+Options form a union on `storageType`:
+
+- `'localStorage'` / `'sessionStorage'` — `{ key, debounceMs?, serialize?, deserialize? }`
+- `'cookie'` — additionally `cookieOptions`: `{ expires?: Date | '7d' | '1h' | '30m', path?, domain?, sameSite?, secure? }`
+
+Serialization defaults to `JSON.stringify`/`JSON.parse`; failures in either direction are swallowed (the cell keeps its in-memory value).
+
+## Timing semantics
+
+The link is implemented as a node init, so everything is lazy and per engine:
+
+- **Read** happens once per engine, when the engine first activates the cell. The stored value (if any) is published into the cell at that moment — before components subscribe through the provider. Reading the cell before any engine activates it yields the constructor's initial value.
+- **Write** happens on cell changes, debounced (default 500ms for localStorage, 0 otherwise). Pending writes are flushed/cleared on engine disposal.
+- **Cross-tab sync** applies to localStorage only: changes from other tabs publish into the cell; the link ignores echoes of its own writes.
+
+## Key namespacing
+
+If the engine has an id (`new Engine({}, 'my-app')` or `<EngineProvider engineId="my-app">`), localStorage/sessionStorage keys become `my-app:app-theme`. This is how multiple instances of the same engine-based component (for example two data tables) persist independently while sharing node definitions. Cookies are not namespaced.
+
+## Server-side rendering
+
+The link is a no-op when `window` is unavailable or the storage type is inaccessible — cells keep their initial values on the server, and storage hydrates them on the client when the engine activates the cell. Expect a possible flash of the initial value before client hydration, and avoid branching server-rendered markup on persisted state.
+
+## When to use what
+
+- One cell, one key: `linkCellToStorage`.
+- Composite, versioned feature state (like a table's column layout): a persistence adapter orchestrator — see "Building on the Engine" in the core docs for the pattern data-table uses.

--- a/packages/virtuoso-skills/skills/reactive-engine/references/storage/README.md
+++ b/packages/virtuoso-skills/skills/reactive-engine/references/storage/README.md
@@ -1,0 +1,27 @@
+# Reactive Engine Storage
+
+`@virtuoso.dev/reactive-engine-storage` persists [`@virtuoso.dev/reactive-engine-core`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-core) cells in `localStorage`, `sessionStorage`, or cookies. A storage link hydrates the cell on engine startup and writes changes back as the cell updates.
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core @virtuoso.dev/reactive-engine-storage
+```
+
+## Quick Example
+
+```ts
+import { Cell } from '@virtuoso.dev/reactive-engine-core'
+import { linkCellToStorage } from '@virtuoso.dev/reactive-engine-storage'
+
+const theme$ = Cell<'light' | 'dark'>('light')
+
+linkCellToStorage(theme$, {
+  key: 'app-theme',
+  storageType: 'localStorage',
+})
+```
+
+## License
+
+MIT

--- a/plugins/virtuoso-skills/.codex-plugin/plugin.json
+++ b/plugins/virtuoso-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "virtuoso-skills",
-  "description": "Agent skills for react-virtuoso, message-list, and data-table",
+  "description": "Agent skills for react-virtuoso, message-list, data-table, and the reactive engine",
   "version": "0.1.0",
   "author": {
     "name": "Virtuoso.dev",
@@ -10,12 +10,12 @@
   "homepage": "https://virtuoso.dev",
   "repository": "https://github.com/petyosi/react-virtuoso",
   "license": "MIT",
-  "keywords": ["react-virtuoso", "virtualization", "table", "chat", "data-table"],
+  "keywords": ["react-virtuoso", "virtualization", "table", "chat", "data-table", "reactive-engine"],
   "skills": "./skills/",
   "interface": {
     "displayName": "Virtuoso Skills",
     "shortDescription": "Use Virtuoso React virtualization libraries correctly.",
-    "longDescription": "Agent guidance for react-virtuoso, message-list, and data-table, generated from the official package docs.",
+    "longDescription": "Agent guidance for react-virtuoso, message-list, data-table, and the reactive engine, generated from the official package docs.",
     "developerName": "Virtuoso.dev",
     "category": "Coding",
     "capabilities": ["Write"],

--- a/plugins/virtuoso-skills/skills/data-table/SKILL.md
+++ b/plugins/virtuoso-skills/skills/data-table/SKILL.md
@@ -1,8 +1,143 @@
 ---
 name: data-table
-description: Placeholder - content authoring pending. This skill will provide agent guidance for the @virtuoso.dev/data-table package.
+description: >-
+  Build virtualized data tables with @virtuoso.dev/data-table. Use this skill when (1) building a data grid with sorting, filtering,
+  or grouped rows, (2) installing the shadcn-styled or headless table, (3) connecting remote/paginated data sources, (4) adding sticky,
+  resizable, reorderable, or hideable columns, (5) persisting table state, (6) controlling a table from outside (scrolling, actions),
+  (7) migrating from TableVirtuoso, or any task involving VirtuosoDataTable, DataTable, DataTableColumn, localModel, remoteModel,
+  or engine refs like scrollToRow$ and dispatchModelAction$.
 ---
 
-# Data Table Skill
+# @virtuoso.dev/data-table
 
-TODO: Author skill body. See references/ for source docs.
+A virtualized React data table (rows and columns) with grouped rows, sticky columns, column resizing/reordering/visibility, state persistence, and remote data support. It is the successor to `TableVirtuoso` for table-shaped problems: instead of row renderers, you pass a data source (model) and declare columns as JSX.
+
+## Installation: two paths
+
+**Shadcn (pre-styled wrapper)** — for projects using shadcn/ui conventions:
+
+```bash
+npx shadcn@latest add https://virtuoso.dev/r/data-table.json
+```
+
+This installs a styled wrapper at `@/components/ui/data-table` exporting `DataTable`, `DataTableColumn`, `DataTableColumnHeader`, `DataTableCell`.
+
+**Headless** — for custom design systems:
+
+```bash
+npm install @virtuoso.dev/data-table
+```
+
+Import the structural styles (`@import '@virtuoso.dev/data-table/styles.css'`) and use the unstyled `VirtuosoDataTable`, `Column`, `ColumnHeader`, `Cell`. Ask which path fits the project before installing; the shadcn wrapper is the faster start in Tailwind/shadcn codebases.
+
+## Minimal example (shadcn wrapper)
+
+```tsx
+import { DataTable, DataTableCell, DataTableColumn, DataTableColumnHeader } from '@/components/ui/data-table'
+import { localModel } from '@virtuoso.dev/data-table'
+
+const model = localModel({ data: products })
+
+export default function App() {
+  return (
+    <DataTable className="rounded-xl" model={model} style={{ height: 360 }}>
+      <DataTableColumn field="name">
+        <DataTableColumnHeader>Product</DataTableColumnHeader>
+        <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
+      </DataTableColumn>
+    </DataTable>
+  )
+}
+```
+
+Columns are JSX, not config objects. `field` is both the row-data lookup key and the column's public identifier (used by visibility, reordering, persistence). The table needs a real height, like every Virtuoso component.
+
+## Choosing a data model
+
+| Situation                                                       | Model                                                                                                 |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Rows in memory; filter/sort/group client-side                   | `localModel({ data, pipeline?, actions?, groups? })`                                                  |
+| API-backed, known total count (placeholder rows while fetching) | `remoteModel` with offset mode (`defaultOffsetViewportHandler`); fetch returns `{ rows, totalCount }` |
+| API-backed, cursor pagination / infinite append                 | `remoteModel` with append mode (`defaultAppendViewportHandler`); fetch returns `{ rows }`             |
+
+Hold the model in `useState` with lazy init — `const [model] = useState(() => localModel({ data }))`. Do not use `useMemo`; React may discard memoized values, and the model instance must be retained. Module scope is fine for a static singleton table.
+
+Local filtering/sorting/grouping runs through a named-stage pipeline: declare `pipeline: ['filter', 'sort']` plus `actions`, then dispatch with `model.send({ action: 'filter', payload })`. See [local-data-model](references/2.data-model/01.local-data-model.md) and the [local-filter-sort-group example](references/8.examples/07.local-filter-sort-group.md).
+
+Provide `computeRowKey={({ data }) => data.id}` whenever rows can reorder (sort, filter, remote updates) — without it rows remount and lose local state.
+
+## Column features
+
+- **Sticky columns:** `<DataTableColumn field="name" sticky="left" />` (or `"right"`); multiple sticky columns stack.
+- **Visibility:** declaratively via `visible={false}`, or at runtime through `setColumnVisibility$` / `columnVisibilityState$` from `@virtuoso.dev/data-table/column-visibility`.
+- **Resizing:** mount `ResizeHandle` in the `HeaderEdge` slot; programmatic via `resizeColumn$` from `@virtuoso.dev/data-table/column-resize`.
+- **Reordering:** `ReorderGrip` in `HeaderStart` + `ReorderDropZone` in `HeaderOverlay`; programmatic via `reorderColumns$` from `@virtuoso.dev/data-table/column-reorder`.
+- **Header slots:** `HeaderStart` (before label), `HeaderEnd` (after label), `HeaderEdge` (pinned to the column boundary), `HeaderOverlay` (covers the header) — see [header-slots](references/7.customization/06.header-slots.md).
+- **Grouped rows:** pass `groups: [{ index, level }]` alongside `data` and render headers with `GroupHeaderCell` — see [grouped-rows](references/4.grouped-rows.md).
+
+State persistence: mount `<DataTableStatePersistence adapters={[...]} storageKey="my-table" />` with adapters from the feature subpaths (`columnVisibilityPersistenceAdapter()`, `columnOrderPersistenceAdapter()`, `columnWidthPersistenceAdapter()`, `modelStatePersistenceAdapter()`). See [state-persistence](references/5.state-persistence.md).
+
+## Controlling the table from outside
+
+The table's state lives in an internal reactive engine, and the package intentionally exports cells (readable state, `$`-suffixed) and streams (actions) for remote control — state is not lifted into props:
+
+```tsx
+import { scrollLocation$, scrollToRow$, useEngineRef, useRemoteCellValue, useRemotePublisher } from '@virtuoso.dev/data-table'
+
+const engineRef = useEngineRef()
+const scrollToRow = useRemotePublisher(scrollToRow$, engineRef)
+const location = useRemoteCellValue(scrollLocation$, engineRef)
+
+<DataTable engineRef={engineRef} model={model}>...</DataTable>
+<button onClick={() => scrollToRow({ index: 100, align: 'start' })}>Go to row 100</button>
+```
+
+For UI far from the table, pass `engineId="orders-table"` and use the same hooks with the string id. Useful nodes: `scrollToRow$`, `scrollIntoView$`, `setColumnVisibility$`, `dispatchModelAction$` (actions); `scrollLocation$`, `columns$`, `columnVisibilityState$`, `modelActionState$`, `loadingState$` (state). See [controlling-the-table](references/6.controlling-the-table.md).
+
+## Customization
+
+- Styling goes through `className` on the wrapper components and semantic data attributes — never use `data-testid` as a styling hook.
+- Replace internals via the `components` prop: `Row`, `StickyColumnContainer`, `LoadingPlaceholder`, `LoadingOverlay`, `LoadingFooter` (component overrides must forward refs). Top-level: `EmptyPlaceholder`, `ScrollElement`.
+- `context={{ ... }}` flows to `computeRowKey`, `EmptyPlaceholder`, loading slots, and component overrides — but not to cell/header renderers (use React context there). See [ambient-context](references/7.customization/05.ambient-context.md).
+- Scroll modes: default internal scroller, `useWindowScroll`, or `customScrollParent` — pick exactly one.
+
+## Migrating from TableVirtuoso
+
+| TableVirtuoso         | data-table                                                  |
+| --------------------- | ----------------------------------------------------------- |
+| `data` array          | `localModel({ data })` passed as `model`                    |
+| `itemContent`         | `DataTableColumn` + `DataTableCell`                         |
+| `fixedHeaderContent`  | `DataTableColumnHeader`                                     |
+| grouped rows          | `groups` + `GroupHeaderCell`                                |
+| fixed columns (CSS)   | `sticky="left"` / `sticky="right"`                          |
+| ref + `scrollToIndex` | `engineRef` + `scrollToRow$`                                |
+| `rangeChanged`        | `onRenderedDataChange`, `viewportRange$`, `scrollLocation$` |
+
+Full guide: [migrating-from-table-virtuoso](references/9.guides/04.migrating-from-table-virtuoso.md).
+
+## Troubleshooting
+
+| Symptom                                 | Fix                                                                                                 |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Blank table or header only              | Give the table a measurable height                                                                  |
+| Shadcn component imports fail           | Run the registry install, or import headless from `@virtuoso.dev/data-table`                        |
+| Page and table both scroll              | Use only one scroll mode                                                                            |
+| Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through |
+| Rows remount / lose state after sorting | Add `computeRowKey`                                                                                 |
+| Sticky columns clipped                  | Check parent `overflow` and column min-widths                                                       |
+| Empty cells flash on horizontal scroll  | Raise `columnOverscanCount`                                                                         |
+
+For tests, wrap in `VirtuosoDataTableTestingContext.Provider value={{ itemHeight, viewportHeight }}` (JSDOM has no layout) and assert behavior, not exact DOM row counts — overscan renders extra rows. Use real-browser tests for sticky columns, resizing, and drag interactions. See [testing](references/9.guides/01.testing.md).
+
+## References
+
+- [references/README.md](references/README.md) — overview
+- `references/1.installation/` — [shadcn](references/1.installation/01.shadcn.md), [headless](references/1.installation/02.headless.md)
+- `references/2.data-model/` — [local](references/2.data-model/01.local-data-model.md), [remote](references/2.data-model/02.remote-data-model.md), [row-keys](references/2.data-model/03.row-keys.md)
+- `references/3.columns/` — [defining-columns](references/3.columns/01.defining-columns.md), [cell-and-header-renderers](references/3.columns/02.cell-and-header-renderers.md), [column-groups](references/3.columns/03.column-groups.md), [sticky-columns](references/3.columns/04.sticky-columns.md), [visibility](references/3.columns/05.column-visibility.md), [resizing](references/3.columns/06.column-resizing.md), [reordering](references/3.columns/07.column-reordering.md), [runtime-columns](references/3.columns/08.runtime-columns.md)
+- Features: [grouped-rows](references/4.grouped-rows.md), [state-persistence](references/5.state-persistence.md), [controlling-the-table](references/6.controlling-the-table.md)
+- `references/7.customization/` — [styling](references/7.customization/01.styling.md), [replacing-internals](references/7.customization/02.replacing-internals.md), [empty-and-loading-states](references/7.customization/03.empty-and-loading-states.md), [scroll-containers](references/7.customization/04.scroll-containers.md), [ambient-context](references/7.customization/05.ambient-context.md), [header-slots](references/7.customization/06.header-slots.md), [shadcn-wrapper](references/7.customization/07.shadcn-wrapper.md)
+- `references/8.examples/` — worked examples from basic table to remote pagination, dashboards, and persistence
+- `references/9.guides/` — [testing](references/9.guides/01.testing.md), [performance](references/9.guides/02.performance.md), [troubleshooting](references/9.guides/03.troubleshooting.md), [migrating-from-table-virtuoso](references/9.guides/04.migrating-from-table-virtuoso.md), [debug-instrumentation](references/9.guides/05.debug-instrumentation.md)
+
+Full API reference: <https://virtuoso.dev/data-table/>

--- a/plugins/virtuoso-skills/skills/message-list/SKILL.md
+++ b/plugins/virtuoso-skills/skills/message-list/SKILL.md
@@ -1,8 +1,153 @@
 ---
 name: message-list
-description: Placeholder - content authoring pending. This skill will provide agent guidance for the @virtuoso.dev/message-list package.
+description: >-
+  Build chat, messaging, and AI conversation UIs with @virtuoso.dev/message-list. Use this skill when (1) building a chat or
+  messaging interface, (2) streaming AI assistant responses into a conversation, (3) loading older messages when scrolling up,
+  (4) adding scroll-to-bottom buttons or unseen-message indicators, (5) switching between channels/conversations, or (6) any task
+  involving VirtuosoMessageList, VirtuosoMessageListLicense, useVirtuosoMethods, useVirtuosoLocation, scrollModifier, or
+  data.append/prepend/map. The package is commercial and requires a license key.
 ---
 
-# Message List Skill
+# @virtuoso.dev/message-list
 
-TODO: Author skill body. See references/ for source docs.
+`VirtuosoMessageList` is a virtualized list purpose-built for human and AI chat: stick-to-bottom behavior, streaming responses that grow without scroll jumps, history prepending that preserves the visual position, and scroll position tracking. Use it instead of plain `Virtuoso` when building conversation UIs — these behaviors are built in rather than hand-assembled.
+
+## Licensing
+
+The package is commercial (annual, per-developer). Every instance must be wrapped in `VirtuosoMessageListLicense`:
+
+```tsx
+<VirtuosoMessageListLicense licenseKey={licenseKey}>
+  <VirtuosoMessageList ... />
+</VirtuosoMessageListLicense>
+```
+
+An empty `licenseKey=""` works as a 30-day non-production trial. Validation is local — no network requests. Surface this to the user when introducing the package into a project; keys come from <https://virtuoso.dev/pricing/>.
+
+## Core mental model: data updates carry scroll instructions
+
+Instead of separate imperative scroll calls, each data update includes a `scrollModifier` describing how the viewport should react:
+
+```tsx
+const [data, setData] = useState<VirtuosoMessageListProps<Message, null>['data']>(() => ({
+  data: initialMessages,
+  scrollModifier: { type: 'item-location', location: { index: 'LAST', align: 'end' } },
+}))
+
+<VirtuosoMessageList<Message, null> style={{ height: '100%' }} data={data} computeItemKey={({ data }) => data.key} ItemContent={ItemContent} />
+```
+
+`ItemContent` is a component receiving `{ data, index, context }` props (not positional arguments like react-virtuoso).
+
+### Scroll modifier reference
+
+| Modifier                                               | When to use                                                                                             |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- | ------ | -------------------------- |
+| `{ type: 'item-location', location, purgeItemSizes? }` | Initial load or channel switch; `purgeItemSizes: true` clears cached sizes when the items are different |
+| `{ type: 'auto-scroll-to-bottom', autoScroll }`        | New messages arrive; callback receives `{ atBottom, scrollInProgress, ... }` and returns `'smooth'      | 'auto' | false` or an item location |
+| `'prepend'`                                            | Older messages added to the top; keeps the current messages visually in place                           |
+| `{ type: 'items-change', behavior }`                   | Existing items changed size (streaming text, reactions); stays at bottom if already there               |
+| `'remove-from-start'` / `'remove-from-end'`            | Trimming data while preserving the visual position                                                      |
+| `null` / `undefined`                                   | Leave the scroll position alone                                                                         |
+
+## Common patterns
+
+### Receiving messages (auto-scroll when at bottom)
+
+```tsx
+setData((current) => ({
+  data: [...current.data, incoming],
+  scrollModifier: {
+    type: 'auto-scroll-to-bottom',
+    autoScroll: ({ atBottom, scrollInProgress }) => ({
+      index: 'LAST',
+      align: 'end',
+      behavior: atBottom || scrollInProgress ? 'smooth' : 'auto',
+    }),
+  },
+}))
+```
+
+Returning `false` from `autoScroll` when not at bottom is how you keep the viewport still and instead increment an unseen-messages counter.
+
+### Streaming an AI response
+
+Append an empty assistant message, then grow it as tokens arrive:
+
+```tsx
+setData((current) => ({
+  data: current.data.map((msg) => (msg.key === botKey ? { ...msg, text: msg.text + chunk } : msg)),
+  scrollModifier: { type: 'items-change', behavior: 'smooth' },
+}))
+```
+
+`items-change` keeps the view pinned to the bottom while the message grows, without jumping if the user scrolled up. See [ai-chatbot](references/3.examples/02.ai-chatbot.md) and [gemini](references/3.examples/03.gemini.md) (question pinned to top, answer streams below).
+
+### Loading older messages on scroll-up
+
+```tsx
+<VirtuosoMessageList
+  onScroll={(location) => {
+    if (location.listOffset > -100 && !loading) {
+      loadOlder().then((older) => setData((current) => ({ data: [...older, ...current.data], scrollModifier: 'prepend' })))
+    }
+  }}
+/>
+```
+
+No `firstItemIndex` bookkeeping is needed (unlike plain Virtuoso) — `'prepend'` preserves the position automatically.
+
+### Scroll-to-bottom button
+
+`StickyFooter` renders fixed at the bottom of the viewport; combine with the location hook:
+
+```tsx
+const StickyFooter = () => {
+  const location = useVirtuosoLocation()
+  const methods = useVirtuosoMethods()
+  if (location.bottomOffset <= 200) return null
+  return <button onClick={() => methods.scrollToItem({ index: 'LAST', align: 'end', behavior: 'auto' })}>▼</button>
+}
+```
+
+### Switching channels
+
+Keep one data object per channel and swap with `replace`/`item-location` + `purgeItemSizes: true`, so size caches from the previous channel don't distort the new one. See [multiple-channels](references/2.tutorial/07.multiple-channels.md).
+
+## Imperative API
+
+Via `ref={useRef<VirtuosoMessageListMethods<Message>>(null)}` from outside, or `useVirtuosoMethods()` from components rendered inside the list:
+
+- `data.append(items, scrollToBottom?)`, `data.prepend(items)`
+- `data.map(fn, autoscrollBehavior?)` — update items (reactions, edits, streaming)
+- `data.findAndDelete(predicate)`, `data.deleteRange(start, length)`, `data.replace(data, options?)`
+- `data.find(predicate)`, `data.findIndex(predicate)`, `data.get()`, `data.getCurrentlyRendered()`
+- `scrollToItem({ index: number | 'LAST', align, behavior })`
+
+The declarative `data` prop and the imperative `data.*` methods are alternative ways to drive the same list — pick one as the primary mechanism per component to avoid fighting updates.
+
+## Key props and hooks
+
+- `ItemContent: ({ data, index, context }) => JSX` — message renderer
+- `context` — shared state (current user, loading flags) available to `ItemContent` and all custom slots; avoids prop drilling
+- `computeItemKey({ data })` — stable message key; required for prepending/streaming to work without remounts
+- Slots: `Header`, `Footer` (scroll with content), `StickyHeader`, `StickyFooter` (fixed, measured to avoid overlap), `EmptyPlaceholder`
+- `initialLocation: { index: 'LAST', align: 'end' }` — start at the bottom
+- Hooks (inside the list): `useVirtuosoMethods()`, `useVirtuosoLocation()` (`atBottom`, `bottomOffset`, `listOffset`, `scrollInProgress`), `useCurrentlyRenderedData()`
+
+## Pitfalls
+
+- **No height → nothing renders.** The component needs a real height (`style={{ height: '100%' }}` with a sized parent).
+- **Missing `computeItemKey`** causes remounts and scroll jumps on prepend and streaming updates.
+- **Margins on message items** break height measurement (ResizeObserver excludes margins) — use padding.
+- **"ResizeObserver loop" errors are benign** — filter them in dev overlays and error tracking; see [resize-observer-errors](references/19.resize-observer-errors.md).
+- **JSDOM tests need mocked measurements** via `VirtuosoMessageListTestingContext.Provider value={{ itemHeight, viewportHeight }}` plus a ResizeObserver polyfill; prefer Playwright for scroll behavior. See [testing](references/11.testing.md).
+
+## References
+
+- [references/README.md](references/README.md) — overview and live example
+- `references/2.tutorial/` — step-by-step chat build: [intro](references/2.tutorial/01.intro.md), [message-list](references/2.tutorial/02.message-list.md), [loading-older-messages](references/2.tutorial/03.loading-older-messages.md), [scroll-to-bottom-button](references/2.tutorial/04.scroll-to-bottom-button.md), [receive-messages](references/2.tutorial/05.receive-messages.md), [send-messages](references/2.tutorial/06.send-messages.md), [multiple-channels](references/2.tutorial/07.multiple-channels.md)
+- `references/3.examples/` — [messaging](references/3.examples/01.messaging.md), [ai-chatbot](references/3.examples/02.ai-chatbot.md), [gemini](references/3.examples/03.gemini.md), [reactions](references/3.examples/04.reactions.md), [date-separators](references/3.examples/05.date-separators.md), [scroll-to-reply](references/3.examples/06.scroll-to-reply.md), [grouped-messages](references/3.examples/07.grouped-messages.md)
+- Feature guides: [headers-footers](references/4.headers-footers.md), [context](references/5.context.md), [item-keys](references/6.item-keys.md), [hooks](references/7.hooks.md), [custom-scrollbar](references/8.custom-scrollbar.md), [scrolling-to-item](references/9.scrolling-to-item.md), [smooth-scrolling](references/10.smooth-scrolling.md), [imperative-data-api](references/15.imperative-data-api.md), [scroll-modifier](references/20.scroll-modifier.md), [testing](references/11.testing.md), [licensing](references/80.licensing.md)
+
+Full API reference: <https://virtuoso.dev/message-list/>

--- a/plugins/virtuoso-skills/skills/react-virtuoso/SKILL.md
+++ b/plugins/virtuoso-skills/skills/react-virtuoso/SKILL.md
@@ -14,7 +14,6 @@ description: >-
 
 ```tsx
 import { Virtuoso } from 'react-virtuoso'
-
 ;<Virtuoso style={{ height: '100%' }} data={users} itemContent={(index, user) => <div>{user.name}</div>} />
 ```
 

--- a/plugins/virtuoso-skills/skills/react-virtuoso/SKILL.md
+++ b/plugins/virtuoso-skills/skills/react-virtuoso/SKILL.md
@@ -1,8 +1,179 @@
 ---
 name: react-virtuoso
-description: Placeholder - content authoring pending. This skill will provide agent guidance for the react-virtuoso package.
+description: >-
+  Build virtualized lists, grids, and tables with react-virtuoso. Use this skill when (1) rendering large or infinite lists,
+  (2) building grouped lists with sticky headers, (3) virtualizing HTML tables, (4) laying out same-sized items in a responsive grid,
+  (5) building feeds or logs that follow new items at the bottom, (6) diagnosing virtualization symptoms such as jumpy scrolling,
+  a list that does not scroll to the bottom, items overlapping, blank items, or "zero-sized element" errors, or (7) any task involving
+  Virtuoso, GroupedVirtuoso, VirtuosoGrid, TableVirtuoso, VirtuosoHandle, itemContent, followOutput, or firstItemIndex.
 ---
 
-# React Virtuoso Skill
+# react-virtuoso
 
-TODO: Author skill body. See references/ for source docs.
+`react-virtuoso` renders only the visible portion of large lists, grids, and tables. It measures item sizes automatically with ResizeObserver — variable item heights work out of the box, with no size configuration.
+
+```tsx
+import { Virtuoso } from 'react-virtuoso'
+
+;<Virtuoso style={{ height: '100%' }} data={users} itemContent={(index, user) => <div>{user.name}</div>} />
+```
+
+## Picking the right component
+
+| Need                                                                    | Use                                                                 |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Flat list, variable or fixed item heights                               | `Virtuoso`                                                          |
+| Groups with sticky group headers                                        | `GroupedVirtuoso`                                                   |
+| HTML table with virtualized rows                                        | `TableVirtuoso`                                                     |
+| Table with grouped rows and sticky group headers                        | `GroupedTableVirtuoso`                                              |
+| Same-sized items in a responsive multi-column grid                      | `VirtuosoGrid`                                                      |
+| Chat / AI conversation UI (streaming, stick-to-bottom, prepend history) | `@virtuoso.dev/message-list` — use the `message-list` skill instead |
+| Data grid with columns, sorting, filtering, column features             | `@virtuoso.dev/data-table` — use the `data-table` skill instead     |
+
+All components share the same core props (`data`/`totalCount`, `itemContent`, `components`, scroll callbacks, ref methods).
+
+## What you do NOT need to do
+
+Unlike TanStack Virtual or react-window, react-virtuoso measures items itself. Do not carry those libraries' patterns over:
+
+- No `estimateSize`, no `measureElement`, no `data-index` wiring — measurement is automatic.
+- No absolute positioning or `transform: translateY` on items — the library positions items.
+- No fixed `itemSize` requirement — variable heights are the default. If items genuinely have one uniform height, pass `fixedItemHeight` as a performance optimization only.
+- No windowing math — pass `data` (or `totalCount`) and render the item in `itemContent`.
+
+## Core rules
+
+- **The component needs a height.** Set `style={{ height: '100%' }}` (with a sized parent) or a fixed height. A zero-height container renders nothing.
+- **Never put CSS margins on items.** ResizeObserver reports `contentRect`, which excludes margins, so the computed total height comes up short — the classic symptom is a list that cannot scroll all the way to the bottom. Use padding instead. Watch for default margins on `<p>`, headings, `<ul>`, `<blockquote>`, `<pre>`.
+- **Use `data`, not `totalCount`, when you have the items.** With `data`, `itemContent={(index, item) => ...}` receives the item. Use `totalCount` only when items are derived from the index. Updates must produce a new array reference.
+- **Provide `computeItemKey={(index, item) => item.id}`** whenever the list can be prepended, reordered, or filtered. The default key is the index, which remounts items (losing state) when positions shift.
+- **Define `components` overrides outside the render function.** Inline definitions create a new component type each render, remounting the subtree on every scroll. `Scroller` and `List` overrides must forward `ref` to their DOM element.
+- **Item content must not render zero-height elements.** The error "zero-sized element, this should not happen" means an item measured 0px — filter empty items out of the data instead.
+
+## Common patterns
+
+### Infinite scrolling
+
+```tsx
+<Virtuoso data={items} endReached={() => loadMore()} itemContent={(index, item) => <Item item={item} />} />
+```
+
+`endReached` fires at the bottom; render a spinner via `components.Footer`. For "load more" on click, put the button in `Footer`.
+
+### Prepending items (reverse infinite scroll)
+
+Prepending naively makes the list jump. Instead, keep a `firstItemIndex` that you decrease by the number of prepended items:
+
+```tsx
+const [firstItemIndex, setFirstItemIndex] = useState(START)
+
+const prepend = (older: Item[]) => {
+  setFirstItemIndex((i) => i - older.length)
+  setItems((current) => [...older, ...current])
+}
+
+<Virtuoso firstItemIndex={firstItemIndex} initialTopMostItemIndex={START} data={items} startReached={prepend} ... />
+```
+
+`firstItemIndex` must stay a positive number, so start it large (e.g. `100000`). For `GroupedVirtuoso`, decrease it by the number of new items only, excluding the group headers. See [endless-scrolling](references/1.virtuoso/endless-scrolling.md).
+
+### Following new items (logs, feeds)
+
+```tsx
+<Virtuoso followOutput="smooth" data={messages} ... />
+```
+
+`followOutput` scrolls to new bottom items only when the user is already at the bottom. It accepts `'auto' | 'smooth' | false` or a function `(isAtBottom) => ...` for custom logic. For full chat UIs prefer `@virtuoso.dev/message-list`.
+
+### Scrolling programmatically
+
+```tsx
+const ref = useRef<VirtuosoHandle>(null)
+ref.current?.scrollToIndex({ index: 500, align: 'center', behavior: 'smooth' })
+```
+
+Also on the handle: `scrollIntoView` (only scrolls if not visible — right for keyboard navigation), `scrollTo`/`scrollBy` (pixel-based), and `getState` (snapshot for `restoreStateFrom` when remounting, e.g. back navigation).
+
+To start at an item, use `initialTopMostItemIndex={{ index, align: 'start' }}` — not `initialScrollTop`, which first renders at the top and then jumps.
+
+### Grouped lists
+
+```tsx
+<GroupedVirtuoso
+  groupCounts={[20, 30]} // items per group, in order
+  groupContent={(groupIndex) => <Header group={groups[groupIndex]} />}
+  itemContent={(index, groupIndex) => <Item item={items[index]} />} // index is absolute across all items
+/>
+```
+
+You provide flat data plus `groupCounts`; map indexes back to your data yourself.
+
+### Tables
+
+```tsx
+<TableVirtuoso
+  data={rows}
+  fixedHeaderContent={() => (
+    <tr>
+      <th>Name</th>
+    </tr>
+  )}
+  itemContent={(index, row) => (
+    <>
+      <td>{row.name}</td>
+    </>
+  )} // <td> cells only — the row <tr> is rendered for you
+/>
+```
+
+Do not set `border-collapse: collapse` on the table — the sticky header's borders scroll away with the body. Use `border-collapse: separate` with explicit cell borders. Customize structure via `components` (`Table`, `TableRow`, `TableHead`, `TableBody`).
+
+### Grid
+
+`VirtuosoGrid` virtualizes same-sized items in columns. You control column count with CSS — give `components.Item` a percentage width (`33%` for three columns, changed via media queries) and `components.List` `display: flex; flex-wrap: wrap`. See [grid-responsive-columns](references/3.virtuoso-grid/grid-responsive-columns.md).
+
+### Page-level scrolling
+
+Use `useWindowScroll` to drive the list from the document scroll, or `customScrollParent={element}` to attach to an existing scrollable ancestor. Pick exactly one scroll mode — combining them makes both containers scroll.
+
+### Testing
+
+JSDOM has no layout, so items will not render in Jest/Vitest without mocked measurements:
+
+```tsx
+render(<Virtuoso data={data} />, {
+  wrapper: ({ children }) => (
+    <VirtuosoMockContext.Provider value={{ viewportHeight: 300, itemHeight: 100 }}>{children}</VirtuosoMockContext.Provider>
+  ),
+})
+```
+
+Use `VirtuosoGridMockContext` (adds `viewportWidth`, `itemWidth`) for grids. Prefer real-browser tests (Playwright) for scroll behavior.
+
+## Troubleshooting
+
+| Symptom                                                                       | Likely cause                                                     | Fix                                                                                          |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Nothing renders                                                               | Container has zero height                                        | Give the component or its parent a real height                                               |
+| Cannot scroll to the last items / jumps near the bottom                       | Margins on item content                                          | Replace margins with padding                                                                 |
+| Items flicker or lose state while scrolling                                   | Inline `components` definitions or index-based keys              | Hoist components; add `computeItemKey`                                                       |
+| List jumps on prepend                                                         | Items added without `firstItemIndex` adjustment                  | Use the `firstItemIndex` prepend pattern                                                     |
+| "zero-sized element, this should not happen"                                  | An item rendered with zero height                                | Filter empty items from the data                                                             |
+| "ResizeObserver loop completed with undelivered notifications" overlay in dev | Benign ResizeObserver timing, surfaced by the dev-server overlay | Disable `runtimeErrors` in the webpack/vite overlay config; safe to filter in error tracking |
+| Hard-to-explain size behavior                                                 | —                                                                | Set `logLevel={LogLevel.DEBUG}` and watch the console with all levels enabled                |
+
+Tuning: `increaseViewportBy` renders extra pixels outside the viewport (smoother, more DOM); `defaultItemHeight` skips the initial probe render; `fixedItemHeight` skips measurement entirely (uniform items only); `scrollSeekConfiguration` swaps items for placeholders during fast scrolling.
+
+## References
+
+Detailed guides with full code in [references/](references/):
+
+- [references/README.md](references/README.md) — package overview and full feature list
+- `references/1.virtuoso/` — flat list guides: [basic-usage](references/1.virtuoso/basic-usage.md), [endless-scrolling](references/1.virtuoso/endless-scrolling.md), [press-to-load-more](references/1.virtuoso/press-to-load-more.md), [initial-index](references/1.virtuoso/initial-index.md), [scroll-to-index](references/1.virtuoso/scroll-to-index.md), [keyboard-navigation](references/1.virtuoso/keyboard-navigation.md), [customize-rendering](references/1.virtuoso/customize-rendering.md), [footer](references/1.virtuoso/footer.md), [top-items](references/1.virtuoso/top-items.md), [scroll-handling](references/1.virtuoso/scroll-handling.md), [range-change-callback](references/1.virtuoso/range-change-callback.md), [scroll-seek-placeholders](references/1.virtuoso/scroll-seek-placeholders.md), [auto-resizing](references/1.virtuoso/auto-resizing.md), [window-scrolling](references/1.virtuoso/window-scrolling.md), [custom-scroll-container](references/1.virtuoso/custom-scroll-container.md), [horizontal-mode](references/1.virtuoso/horizontal-mode.md)
+- `references/2.grouped-virtuoso/` — grouped lists: [grouped-numbers](references/2.grouped-virtuoso/grouped-numbers.md), [grouped-by-first-letter](references/2.grouped-virtuoso/grouped-by-first-letter.md), [scroll-to-group](references/2.grouped-virtuoso/scroll-to-group.md), [grouped-with-load-on-demand](references/2.grouped-virtuoso/grouped-with-load-on-demand.md)
+- `references/3.virtuoso-grid/` — [grid-responsive-columns](references/3.virtuoso-grid/grid-responsive-columns.md)
+- `references/4.table-virtuoso/` — tables: [basic-table](references/4.table-virtuoso/basic-table.md), [table-fixed-headers](references/4.table-virtuoso/table-fixed-headers.md), [table-fixed-columns](references/4.table-virtuoso/table-fixed-columns.md), [table-grouped](references/4.table-virtuoso/table-grouped.md)
+- `references/5.third-party-integration/` — [mocking-in-tests](references/5.third-party-integration/mocking-in-tests.md), [tanstack-table-integration](references/5.third-party-integration/tanstack-table-integration.md), [mui-table-virtual-scroll](references/5.third-party-integration/mui-table-virtual-scroll.md), [material-ui-endless-scrolling](references/5.third-party-integration/material-ui-endless-scrolling.md)
+- [references/6.troubleshooting.md](references/6.troubleshooting.md) — full troubleshooting guide
+
+Full API reference: <https://virtuoso.dev/react-virtuoso/>

--- a/plugins/virtuoso-skills/skills/react-virtuoso/references/README.md
+++ b/plugins/virtuoso-skills/skills/react-virtuoso/references/README.md
@@ -29,6 +29,12 @@ React components for efficiently rendering large lists, grids, and tables with v
 npm install react-virtuoso
 ```
 
+If you work with a coding agent (Claude Code, Codex, Cursor), install the [Virtuoso agent skills](https://virtuoso.dev/skills/) so it knows the component selection rules, measurement constraints, and common pitfalls:
+
+```bash
+npx skills add virtuoso-dev/skills --skill react-virtuoso
+```
+
 ## Quick Start
 
 ### Virtuoso

--- a/plugins/virtuoso-skills/skills/reactive-engine/SKILL.md
+++ b/plugins/virtuoso-skills/skills/reactive-engine/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: reactive-engine
+description: >-
+  Manage application state with the @virtuoso.dev/reactive-engine-* package family. Use this skill when (1) defining reactive state
+  with Cell, Stream, Trigger, or Resource nodes, (2) wiring React components through EngineProvider, useCellValue, useCellValues, or
+  usePublisher, (3) fetching data with Query and Mutation from reactive-engine-query, (4) routing with Route, Layout, and Guard from
+  reactive-engine-router, (5) persisting cells with linkCellToStorage, (6) architecting a component or library on top of the engine,
+  or (7) any task involving Engine, pub, sub, getValue, combine, pipe, link, changeWith, the e namespace, or the error
+  "No active engine found".
+---
+
+# Reactive Engine
+
+A reactive state system built on a graph of typed nodes. Five packages compose:
+
+| Package                                 | Provides                                                                                                            |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `@virtuoso.dev/reactive-engine-core`    | Nodes (`Cell`, `Stream`, `Trigger`, `Resource`, `DerivedCell`), `Engine`, operators, combinators, the `e` namespace |
+| `@virtuoso.dev/reactive-engine-react`   | `EngineProvider`, hooks (`useCellValue`, `usePublisher`, remote hooks)                                              |
+| `@virtuoso.dev/reactive-engine-query`   | `Query` and `Mutation` data fetching on top of nodes                                                                |
+| `@virtuoso.dev/reactive-engine-router`  | `Route`, `Layout`, `Guard`, `Router` — routes are nodes                                                             |
+| `@virtuoso.dev/reactive-engine-storage` | `linkCellToStorage` (localStorage / sessionStorage / cookie)                                                        |
+
+It also powers `@virtuoso.dev/data-table` internally — the same concepts apply when remote-controlling the table, and data-table's architecture is the reference for building on the engine ([building-on-the-engine](references/core/05.building-on-the-engine.md)).
+
+## Mental model: nodes are definitions, engines hold state
+
+Node constructors return inert references (symbols at runtime), defined at module scope with a `$` suffix. They hold no state. An `Engine` instance activates nodes lazily on first use and owns their values — two engines using the same node have independent state. This is what makes engine-based libraries reusable: one module-scope graph, one engine per component instance.
+
+```ts
+import { Cell, Stream, Engine, e } from '@virtuoso.dev/reactive-engine-core'
+
+const count$ = Cell(0)
+const engine = new Engine()
+engine.sub(count$, (value) => console.log('count:', value))
+engine.pub(count$, 1) // logs 'count: 1'
+```
+
+Node types — pick by statefulness:
+
+| Node                            | State                          | Use for                                       |
+| ------------------------------- | ------------------------------ | --------------------------------------------- |
+| `Cell(initial, distinct?)`      | Stateful, has a current value  | App state, settings                           |
+| `DerivedCell(initial, source$)` | Stateful, tracks a source      | Read-only computed state                      |
+| `Stream<T>(distinct?)`          | Stateless, emits values        | Events, commands                              |
+| `Trigger()`                     | Stateless, valueless           | "Something happened" signals (refetch, reset) |
+| `Resource(factory)`             | Factory-initialized per engine | Objects needing setup/disposal                |
+
+Nodes are distinct by default using **reference equality** (`===`): publishing the same reference (or an equal primitive) does not re-emit. Always publish new references from updates (`new Map(old)`, spread). Pass `false` to always emit, or a comparator `(prev, next) => boolean` (true = equal = suppress); `prev` is `undefined` on first emission.
+
+## The three API flavors (most important distinction)
+
+The same verbs exist in three forms — using the wrong one is the main source of errors:
+
+| Flavor                   | Examples                                               | Where                                             | Effect                                                           |
+| ------------------------ | ------------------------------------------------------ | ------------------------------------------------- | ---------------------------------------------------------------- |
+| Module-scope combinators | `link`, `pipe`, `sub`, `changeWith`, `combine` / `e.*` | Anywhere, incl. module top level                  | Deferred wiring, applied once per engine when the nodes activate |
+| Engine instance methods  | `engine.pub`, `engine.sub`, `engine.getValue`          | Wherever you hold an engine                       | Immediate, on that engine                                        |
+| Context-bound utilities  | standalone `pub`, `getValue`, `pubIn` / `e.pub`, ...   | Only inside subscription callbacks and node inits | Acts on the currently executing engine                           |
+
+Calling a context-bound utility elsewhere throws `No active engine found. You can use getValue only in the context of node subscription callbacks.` — fix by using `engine.*` methods, React hooks, or moving the code into a subscription. Note the asymmetry: standalone `sub`/`link`/`changeWith` are safe at module scope (they defer); standalone `pub`/`getValue` are not.
+
+The `e` export bundles all combinators, operators, and context utilities into one namespace — idiomatic for wiring blocks:
+
+```ts
+e.link(
+  e.pipe(
+    toggleTheme$,
+    e.withLatestFrom(theme$),
+    e.map(([, t]) => (t === 'light' ? 'dark' : 'light'))
+  ),
+  theme$
+)
+```
+
+## Wiring the graph
+
+- `link(source$, sink$)` — forward emissions; `pipe(source$, ...ops)` — derive a new node
+- `combine(a$, b$, ...)` — emit `[a, b, ...]` when ANY source emits; `withLatestFrom(...)` (operator) — read other nodes passively, emit only when the source emits
+- `changeWith(cell$, source$, (cell, value) => next)` — reducer-style cell update from a stream (return a new reference)
+- `sub`, `subMultiple`, `singletonSub` (replaces the previous singleton subscription — use for callbacks driven by React renders)
+- Operators: `map(fn, distinct?)`, `filter` (supports type guards), `mapTo`, `scan`, `once`, `throttleTime`, `debounceTime`, `delayWithMicrotask`, `onNext`, `handlePromise`
+
+Publishing is transactional: `engine.pubIn({ [a$]: 1, [b$]: 2 })` batches into one cycle; the graph executes in topological order, so diamond dependencies emit downstream exactly once with consistent inputs. Emissions are synchronous; there are no error/completion channels (exceptions abort the cycle — handle errors at the edges). Subscribing never replays a current value; read cells with `getValue` when needed. See [transactions](references/core/03.transactions.md).
+
+## React integration
+
+```tsx
+import { EngineProvider, useCellValue, usePublisher } from '@virtuoso.dev/reactive-engine-react'
+
+const Counter = () => {
+  const count = useCellValue(count$)
+  const setCount = usePublisher(count$)
+  return <button onClick={() => setCount(count + 1)}>{count}</button>
+}
+```
+
+- `useCellValue(cell$)` subscribes and re-renders; `useCellValues(a$, b$, ...)` returns a tuple with a single combined subscription (prefer it for cells that change together); `useCell` is the `useState` shape; `usePublisher(node$)` returns a stable publish function
+- `EngineProvider` props: `initFn(engine)` (one-time setup: register nodes, seed with `pubIn`, attach bridges), `initWith` (initial cell values), `updateFn`/`updateDeps` (re-publish changed props; use `singletonSub` for callback props so re-renders replace instead of stack), `engineId`, `engineRef`
+- Remote hooks (`useRemoteCellValue`, `useRemotePublisher`, `useRemoteCell`, `useRemoteCellValues`) reach another provider's engine via `useEngineRef()` or a string `engineId` — they return `undefined` until that engine mounts; guard for it
+- Components stay projection-only: read cells, publish actions. Logic lives in module-scope wiring, testable with a bare `Engine` and no React
+
+## Data fetching (reactive-engine-query)
+
+```ts
+export const tasksQuery = Query<{ listId: string }, Task[]>({
+  queryFn: async ({ listId }, signal) => {
+    const res = await fetch(`/api/tasks?listId=${listId}`, { signal })
+    if (!res.ok) throw new Error('Failed to fetch tasks')
+    return res.json()
+  },
+  initialParams: { listId: '' },
+})
+```
+
+`Query` returns nodes: `data$` (cell with `{ type: 'pending' | 'success' | 'error', data, error, isLoading, isFetching, ... }`), `params$` (publish to refetch with new params), `refetch$`, `invalidate$` (keep showing stale data, `isFetching: true`, re-execute), `unload$` (abort and clear), `enabled$`. Queries auto-execute on activation and param changes; each execution aborts the previous via the `signal`. Options: `retry` (default 3, exponential backoff), `refetchInterval`, `initialData`, `enabled`.
+
+`Mutation({ mutationFn, onSuccess?, onError? })` returns `data$`, `mutate$`, `reset$`. Mutations never auto-execute — publish params to `mutate$`. Wire mutations to refetch queries in the graph, not in components:
+
+```ts
+e.link(
+  e.pipe(
+    e.merge(createTask.data$, deleteTask.data$),
+    e.filter((r) => r.type === 'success'),
+    e.map(() => undefined, false) // distinct=false so consecutive successes each fire
+  ),
+  tasksQuery.refetch$
+)
+```
+
+## Routing (reactive-engine-router)
+
+```tsx
+export const user$ = Route('/users/{id:number}', UserPage) // params typed from the path
+const root = Layout('/', ({ children }) => <main>{children}</main>)
+
+<Router routes={[user$]} layouts={[root]} guards={[authGuard]} />
+```
+
+Route nodes emit typed params when matched, `null` otherwise. Navigate by publishing params to the route node (`usePublisher(user$)({ id: 42 })`). Pipe route params into query params to fetch on navigation. `Guard(pattern, fn)` runs on matching navigations — its context offers `continue()`, `navigate()`, `redirect()`; async guards render the route inside `Suspense`. Layouts match by URL prefix and nest by specificity; `LayoutSlotPortal`/`LayoutSlot`/`LayoutSlotFill` let pages fill layout regions. `Router` syncs with browser history by default.
+
+## Persistence (reactive-engine-storage)
+
+```ts
+linkCellToStorage(theme$, { storageType: 'localStorage', key: 'app-theme', debounceMs: 300 })
+```
+
+`storageType: 'localStorage' | 'sessionStorage' | 'cookie'` (cookie adds `cookieOptions`). Reads happen lazily, once per engine, when the engine first activates the cell; writes are debounced; localStorage links sync across tabs. The engine's `id` namespaces keys (`my-app:app-theme`) so multiple instances persist independently. SSR-safe (no-op without `window`).
+
+## Building a component or library on the engine
+
+Follow the data-table architecture ([full patterns](references/core/05.building-on-the-engine.md)):
+
+- Module-scope node graph + one engine per component instance (via `EngineProvider`)
+- Public API = action streams in (`setX$`, `resetX$`), state cells out (`xState$`, often `DerivedCell`); wiring stays internal
+- Props flow into cells via `pubIn` in `initFn`/`updateFn`; callback props via `singletonSub`
+- Optional features as separate modules (subpath exports) that attach wiring to core nodes — unused features cost nothing because inits are lazy
+- External control via `engineRef`/`engineId` + remote hooks against the exported nodes
+- Bridge imperative subsystems with subscribe-both-ways functions whose cleanup reaches `engine.onDispose`
+
+## Common mistakes
+
+- Calling standalone `pub`/`getValue`/`pubIn` outside a subscription callback — use `engine.*` methods or React hooks.
+- Mutating and republishing the same object — distinct is reference equality; nothing emits. Publish new references.
+- Expecting a node to hold state by itself — values live in an engine; the same `Cell` in two engines has two values.
+- Expecting `Stream` subscriptions to fire on subscribe with a current value — streams are stateless; only `Cell` has a value.
+- Piping into a trigger through `map` without `distinct: false` — consecutive identical mapped values get filtered.
+- Triggering a `Mutation` by changing params — mutations only run when params are published to `mutate$`.
+- Plain `sub` in code that re-runs with React renders — subscriptions accumulate; use `singletonSub`.
+- Creating cycles in the graph — cycles hang or loop; break one direction with an action stream or `delayWithMicrotask`.
+
+## References
+
+Guides in [references/](references/), per package:
+
+- `references/core/` — [core-concepts](references/core/01.core-concepts.md) (node types, distinct, the `e` namespace), [engine-and-lifecycle](references/core/02.engine-and-lifecycle.md) (activation, API flavors, child engines, disposal), [transactions](references/core/03.transactions.md) (cycles, topological execution, RxJS differences), [operators-and-combinators](references/core/04.operators-and-combinators.md) (full reference), [building-on-the-engine](references/core/05.building-on-the-engine.md) (architecture patterns from data-table), [README](references/core/README.md)
+- `references/react/` — [react-integration](references/react/01.react-integration.md) (EngineProvider lifecycle, hooks, remote hooks, SSR), [README](references/react/README.md)
+- `references/query/` — [queries-and-mutations](references/query/01.queries-and-mutations.md) (result states, lifecycle, wiring patterns), [README](references/query/README.md)
+- `references/router/` — [routing](references/router/01.routing.md) (path syntax, navigation, layouts, guards), [README](references/router/README.md)
+- `references/storage/` — [storage-links](references/storage/01.storage-links.md) (timing, namespacing, cross-tab sync), [README](references/storage/README.md)
+
+The JSDoc on the exported symbols in `@virtuoso.dev/reactive-engine-core` is extensive — when in doubt about a signature, read the type definitions shipped with the package.

--- a/plugins/virtuoso-skills/skills/reactive-engine/references/core/01.core-concepts.md
+++ b/plugins/virtuoso-skills/skills/reactive-engine/references/core/01.core-concepts.md
@@ -1,0 +1,113 @@
+---
+title: Core Concepts
+description: Nodes, engines, and the separation between graph definitions and runtime state.
+---
+
+The reactive engine models application logic as a graph of typed nodes. Two ideas carry everything else:
+
+1. **Nodes are definitions, not state.** A node constructor returns an inert reference — at runtime it is literally a `Symbol`. Creating a node records its definition (type, initial value, distinct behavior) in a global registry, but holds no value.
+2. **Engines hold state.** An `Engine` instance activates nodes on first use and owns their values. The same node used by two engines has two independent values.
+
+```ts
+import { Cell, Engine } from '@virtuoso.dev/reactive-engine-core'
+
+const count$ = Cell(0) // a definition, usually at module scope
+
+const a = new Engine()
+const b = new Engine()
+a.pub(count$, 5)
+a.getValue(count$) // 5
+b.getValue(count$) // 0 — independent state
+```
+
+This split is what makes the engine suitable for building reusable components: a library defines its node graph once at module scope, and every component instance gets its own engine — its own state — without re-declaring anything.
+
+## Node types
+
+| Node                            | State          | Emits                  | Use for                                            |
+| ------------------------------- | -------------- | ---------------------- | -------------------------------------------------- |
+| `Cell(initial, distinct?)`      | Current value  | On value change        | App state, configuration, derived values           |
+| `Stream<T>(distinct?)`          | None           | On publish             | Events, commands, transient data                   |
+| `Trigger()`                     | None           | On publish (valueless) | "Something happened" signals                       |
+| `Resource(factory)`             | Factory result | —                      | Per-engine objects with setup/teardown             |
+| `DerivedCell(initial, source$)` | Current value  | When the source emits  | Read-only computed state                           |
+| `Pipe<T>(...operators)`         | —              | —                      | An input/output node pair with a transform between |
+
+```ts
+import { Cell, Stream, Trigger, Resource } from '@virtuoso.dev/reactive-engine-core'
+
+const theme$ = Cell<'light' | 'dark'>('light')
+const keyPressed$ = Stream<string>()
+const reset$ = Trigger()
+const cache$ = Resource(() => ({
+  data: new Map<string, unknown>(),
+  dispose() {
+    this.data.clear()
+  },
+}))
+```
+
+A `Resource` factory runs once per engine, the first time the engine touches the node. On `engine.dispose()` the engine calls the instance's `[Symbol.dispose]()` if present, falling back to `dispose()`.
+
+`DerivedCell` is a cell whose value tracks a source expression:
+
+```ts
+import { DerivedCell, e } from '@virtuoso.dev/reactive-engine-core'
+
+const fahrenheit$ = DerivedCell(
+  32,
+  e.pipe(
+    celsius$,
+    e.map((c) => c * 1.8 + 32)
+  )
+)
+```
+
+Components read it like any cell; nothing can publish into it directly without going through the source.
+
+## Distinct semantics
+
+Every Cell and Stream filters duplicate emissions by default:
+
+- `true` (default) — compare with `===` (the `defaultComparator`; reference equality, not deep equality)
+- `false` — never filter; every publish emits
+- `(prev, next) => boolean` — custom comparator returning `true` when values are equal (suppress emission)
+
+```ts
+const user$ = Cell<User | null>(null, (prev, next) => prev?.id === next?.id)
+```
+
+Two consequences worth internalizing:
+
+- Because the default is reference equality, publishing a mutated object does not emit. Always publish new references (`new Map(old)`, spread), the same discipline React state requires.
+- The comparator receives `undefined` as `prev` on the first emission — write comparators with optional chaining.
+
+Triggers never filter; every publish fires.
+
+## The `e` namespace
+
+The package exports each operator and combinator individually, and also bundles them in a single `e` object — convenient when wiring many connections:
+
+```ts
+import { e } from '@virtuoso.dev/reactive-engine-core'
+
+e.link(
+  e.pipe(
+    toggleTheme$,
+    e.withLatestFrom(theme$),
+    e.map(([, current]) => (current === 'light' ? 'dark' : 'light'))
+  ),
+  theme$
+)
+```
+
+`e` contains the combinators (`link`, `pipe`, `combine`, `merge`, `sub`, `changeWith`, ...), the operators (`map`, `filter`, `scan`, ...), and the context-bound utilities (`pub`, `getValue`, `pubIn` — see [Engine and Lifecycle](./02.engine-and-lifecycle.md) for where those are allowed).
+
+## Naming conventions
+
+- Node references take a `$` suffix: `count$`, `setColumnVisibility$`.
+- Input streams that represent user actions read as commands: `resizeColumn$`, `toggleTheme$`.
+- State cells read as nouns: `theme$`, `scrollLocation$`.
+- Plain helper functions take no suffix.
+
+These conventions come from the packages built on the engine (data-table follows them throughout) and make the input/output boundary of a module visible at a glance.

--- a/plugins/virtuoso-skills/skills/reactive-engine/references/core/02.engine-and-lifecycle.md
+++ b/plugins/virtuoso-skills/skills/reactive-engine/references/core/02.engine-and-lifecycle.md
@@ -1,0 +1,108 @@
+---
+title: Engine and Lifecycle
+description: How engines activate nodes, the three API flavors, engine context, child engines, and disposal.
+---
+
+## Activation: how a node comes alive in an engine
+
+Nodes register lazily. The first time an engine touches a node — through `pub`, `sub`, `getValue`, `link`, or an explicit `engine.register(node$)` — the engine:
+
+1. Looks up the node's definition in the global registry and creates its state slot (or runs the `Resource` factory).
+2. Runs every **node init** attached to the node, once per engine, inside engine context.
+
+Node inits are the deferred-wiring mechanism. `addNodeInit(fn, ...nodes$)` attaches a function that runs when any of the listed nodes first activates in an engine:
+
+```ts
+import { addNodeInit } from '@virtuoso.dev/reactive-engine-core'
+
+addNodeInit((engine) => {
+  engine.link(source$, sink$)
+}, source$)
+```
+
+You rarely call `addNodeInit` directly — the module-scope combinators do it for you (next section). But understanding it explains the engine's central trick: _wiring declared at module scope applies to every engine that ever uses those nodes, paid for only when used._
+
+## The three API flavors
+
+The same verbs exist in three forms. Choosing the right one is most of the learning curve:
+
+| Flavor                   | Examples                                                        | Where it works                                    | What it does                                                                          |
+| ------------------------ | --------------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Module-scope combinators | `link`, `pipe`, `sub`, `changeWith`, `combine` (also via `e.*`) | Anywhere, including module top level              | Registers a node init — deferred wiring for **every** engine that activates the nodes |
+| Engine instance methods  | `engine.pub`, `engine.sub`, `engine.link`, `engine.getValue`    | Anywhere you hold an engine                       | Acts immediately on **that** engine                                                   |
+| Context-bound utilities  | `pub`, `getValue`, `pubIn` (standalone or via `e.*`)            | Only inside subscription callbacks and node inits | Acts on the currently executing engine                                                |
+
+```ts
+import { Cell, Stream, Engine, e } from '@virtuoso.dev/reactive-engine-core'
+
+const saveRequested$ = Stream<void>()
+const draft$ = Cell('')
+const save$ = Stream<string>()
+
+// Module scope: wiring for all engines, applied lazily
+e.sub(saveRequested$, () => {
+  // Context-bound: we are inside a subscription, an engine is active
+  e.pub(save$, e.getValue(draft$))
+})
+
+// Imperative code with an engine in hand
+const engine = new Engine()
+engine.pub(draft$, 'hello')
+engine.pub(saveRequested$)
+```
+
+Calling a context-bound utility outside engine context throws:
+
+```text
+No active engine found. You can use getValue only in the context of node subscription callbacks.
+```
+
+When you hit this error, the fix is one of: use the engine instance method, use a React hook (`useCellValue`, `usePublisher`), or move the code into a subscription/init where context exists.
+
+Note the asymmetry: standalone `sub`/`link`/`changeWith` are safe at module scope (they defer), but standalone `pub`/`getValue`/`pubIn` are not (they need a live engine). The subscription callback also receives the engine as a second argument — `sub(node$, (value, engine) => ...)` — when you prefer being explicit.
+
+## Engine construction
+
+```ts
+new Engine(initialValues?: Record<symbol, unknown>, id?: string, parentEngine?: Engine)
+```
+
+- `initialValues` — seed cell values, keyed by node: `new Engine({ [theme$]: 'dark' })`.
+- `id` — names the engine; used for storage key namespacing and the React engine registry.
+- `parentEngine` — creates a child engine (below).
+
+Key instance methods beyond the verbs already covered: `pubIn(values)` (batch several publishes into one transaction — see [Transactions](./03.transactions.md)), `subMultiple(nodes, cb)`, `singletonSub(node$, cb)`, `combineCells(cells)` (cached combination used by the React bindings), `register(node$)`, `onDispose(cb)`, `dispose()`, and the low-level `connect({ sources, pulls, sink, map })` that all operators reduce to.
+
+## singletonSub: subscriptions that replace themselves
+
+`engine.singletonSub(node$, callback)` keeps at most one subscription per node, replacing the previous one on each call. Regular `sub` subscriptions accumulate — calling `sub` in code that re-runs (React renders, update functions) leaks duplicate callbacks. `singletonSub` exists precisely for "the latest callback wins" situations, such as forwarding a node to a React prop:
+
+```ts
+// In an EngineProvider initFn AND updateFn — safe, replaces rather than stacks
+engine.singletonSub(onScroll$, onScroll)
+```
+
+`engine.resetSingletonSubs()` clears them all.
+
+## Child engines
+
+```ts
+const parent = new Engine()
+const child = new Engine({}, 'child-id', parent)
+```
+
+A child engine delegates operations on nodes the parent has registered: publishing or subscribing to a parent-owned node from the child reaches the parent's state, and parent emissions propagate into child subscriptions. Nodes the parent does not own activate locally in the child. Use child engines to scope a feature's state while still seeing shared application state.
+
+## Disposal
+
+`engine.dispose()`:
+
+- runs callbacks registered with `engine.onDispose(cb)`
+- disposes `Resource` instances (`[Symbol.dispose]()` or `dispose()`)
+- clears subscriptions and state; `engine.isDisposed` becomes `true`
+
+Anything that bridges the engine to the outside world (DOM listeners, timers, external stores) should register cleanup with `onDispose` at the point where the bridge is created. The React `EngineProvider` disposes its engine on unmount.
+
+## Debugging
+
+`debug(node$, 'label')` logs every emission of a node with the given label. Subscriptions also receive the engine, so ad-hoc inspection from a callback is `console.log(engine.getValue(other$))`.

--- a/plugins/virtuoso-skills/skills/reactive-engine/references/core/03.transactions.md
+++ b/plugins/virtuoso-skills/skills/reactive-engine/references/core/03.transactions.md
@@ -1,0 +1,56 @@
+---
+title: Transactions and Execution
+description: How publishing works - transactional cycles, topological ordering, and how the engine differs from RxJS.
+---
+
+## One publish, one cycle
+
+Every `engine.pub(node$, value)` runs a complete computation cycle, synchronously:
+
+1. The engine computes the **execution map**: a topological sort of every node reachable from the published node through the graph.
+2. It walks the map sources-before-sinks, computing each node's new value from the latest values of its inputs.
+3. Each node's distinct comparator decides whether it actually emits; nodes that don't emit prune their downstream.
+4. Subscriptions fire for every node that emitted, inside engine context.
+
+By the time `pub` returns, the whole graph is consistent and all subscriptions have run.
+
+## pubIn: batching into a single transaction
+
+`engine.pubIn({ [a$]: 1, [b$]: 2 })` publishes several nodes in **one** cycle. Derived nodes that depend on both inputs compute once, seeing both new values — instead of twice with an inconsistent intermediate state. Whenever you publish more than one related value, use `pubIn`:
+
+```ts
+engine.pubIn({
+  [data$]: rows,
+  [groupIndices$]: groups,
+})
+```
+
+## Diamond dependencies emit once
+
+Given `a$ → b$`, `a$ → c$`, and `(b$, c$) → d$`, publishing to `a$` makes `d$` emit exactly once per cycle, after both `b$` and `c$` computed. This is the property that makes derived state composable — you never observe a "glitch" where `d$` fires with one fresh and one stale input.
+
+## When distinct is checked
+
+The comparator runs during node computation, comparing against the node's current value. It is not a pre-publish check on the caller's side. Implications:
+
+- A `Cell` that receives the same value emits nothing downstream — derived nodes and subscriptions stay quiet.
+- `map(fn, distinct?)` takes its own distinct parameter; a derived node can filter duplicates even when its source always emits.
+- The comparator sees `prev === undefined` on a node's first computation.
+
+## Re-entrancy
+
+Publishing from inside a subscription starts a **nested cycle** — cycles are not queued or merged. This is allowed and common (a subscription reacting to one node by publishing another), but recursive publishes to the same node must terminate, or you have an infinite loop. To defer work to after the current cycle, route it through `delayWithMicrotask()`:
+
+```ts
+e.link(e.pipe(burst$, e.delayWithMicrotask()), settled$)
+```
+
+## Differences from RxJS
+
+If you come from RxJS (or urx), recalibrate on these points:
+
+- **No completion, no error channel.** Nodes never complete; exceptions in operators or subscriptions propagate to the publisher and abort the cycle. Handle errors at the edges — inside `queryFn`-style async work or subscription bodies — not in the graph.
+- **Synchronous by default.** Emissions happen during `pub`, not on a scheduler. Only `throttleTime`, `debounceTime`, `delayWithMicrotask`, and `handlePromise` introduce asynchrony.
+- **Subscribing does not replay.** Subscribing to a `Cell` does not invoke the callback with the current value — read it with `getValue` if needed at subscribe time. (The React hooks do this for you.) Streams have no current value at all; `getValue` on a stream returns `undefined`.
+- **No per-subscription operator chains.** Operators transform nodes into new nodes (`pipe` returns a `NodeRef`); they are part of the shared graph, not private to a subscriber.
+- **Promises resolve out of order.** `handlePromise` emits results as promises settle; a slow earlier request can emit after a fast later one. Abort or sequence-guard async work where ordering matters (the `Query` package does this for you).

--- a/plugins/virtuoso-skills/skills/reactive-engine/references/core/04.operators-and-combinators.md
+++ b/plugins/virtuoso-skills/skills/reactive-engine/references/core/04.operators-and-combinators.md
@@ -1,0 +1,68 @@
+---
+title: Operators and Combinators
+description: Reference for transforming and connecting nodes.
+---
+
+Combinators connect nodes; operators transform values inside a `pipe`. All are available as named exports and on the `e` namespace object. The module-scope forms register deferred wiring (applied per engine on activation); the `Engine` instance methods of the same names act immediately on one engine.
+
+## Combinators
+
+| Combinator                                                    | Purpose                                                                  |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `link(source$, sink$)`                                        | Forward every emission from source to sink                               |
+| `pipe(source$, ...operators)`                                 | Derive a new node by running emissions through operators                 |
+| `combine(a$, b$, ...)`                                        | Node emitting `[a, b, ...]` whenever any source emits (up to 22 sources) |
+| `merge(a$, b$, ...)`                                          | Node emitting each source's values individually                          |
+| `sub(node$, cb)`                                              | Subscribe; `cb(value, engine)`                                           |
+| `singletonSub(node$, cb)`                                     | Exclusive subscription — replaces the previous singleton on the node     |
+| `subMultiple([a$, b$], cb)`                                   | One callback over several nodes                                          |
+| `changeWith(cell$, source$, (cell, value) => next)`           | Update a cell from a stream, reducer-style                               |
+| `withResource(source$, resource$, (value, resource) => void)` | Side effect pairing emissions with a resource instance                   |
+
+`changeWith` is the workhorse for "action stream updates state cell":
+
+```ts
+e.changeWith(columnWidths$, resizeColumn$, (widths, { key, width }) => {
+  const next = new Map(widths)
+  next.set(key, width)
+  return next
+})
+```
+
+Return a **new** reference from the reducer — cells are distinct by reference equality, so mutating and returning the same Map emits nothing.
+
+## Operators
+
+| Operator                                    | Behavior                                                                                          |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `map(fn, distinct?)`                        | Transform each value; optional distinct filter on the output                                      |
+| `filter(predicate)`                         | Drop values failing the predicate; supports type-guard predicates for narrowing                   |
+| `mapTo(value)`                              | Replace every emission with a constant                                                            |
+| `scan((acc, value) => acc, seed)`           | Running accumulation                                                                              |
+| `once()`                                    | Pass only the first emission                                                                      |
+| `withLatestFrom(...nodes$)`                 | Append the latest values of other nodes to each source emission; emits only when the source emits |
+| `throttleTime(ms)`                          | Rate-limit emissions                                                                              |
+| `debounceTime(ms)`                          | Emit only after the source goes quiet for the duration                                            |
+| `delayWithMicrotask()`                      | Re-emit in a microtask, after the current cycle                                                   |
+| `onNext(buf$)`                              | Buffer the source value, emit `[buffered, value]` when `buf$` next emits                          |
+| `handlePromise(onLoad, onSuccess, onError)` | Expand a promise-emitting node into loading/success/error emissions                               |
+
+Two distinctions that prevent common mistakes:
+
+- `combine` vs `withLatestFrom`: `combine` emits when _any_ input changes; `withLatestFrom` only when the _source_ emits, with the other nodes read passively. Use `withLatestFrom` for "when the user clicks, read the current settings", `combine` for "recompute whenever anything changes".
+- `map(..., distinct)` vs node distinct: pass `false` as map's distinct when piping into a Trigger-like sink that must fire every time — for example mapping mutation successes to `undefined` for a refetch trigger:
+
+```ts
+e.link(
+  e.pipe(
+    e.merge(create.data$, remove.data$),
+    e.filter((r) => r.type === 'success'),
+    e.map(() => undefined, false) // without false, the second success would be filtered as a duplicate undefined
+  ),
+  tasksQuery.refetch$
+)
+```
+
+## The low-level primitive: connect
+
+Every operator and combinator reduces to `engine.connect({ sources, pulls, sink, map })`: when any node in `sources` emits, call `map(done)(...sourceValues, ...pullValues)`; calling `done(value)` proposes an emission on `sink` (still subject to the sink's distinct check). `pulls` are read passively without triggering. Reach for `connect` only when no operator combination expresses the dependency shape — it is the engine's assembly language.

--- a/plugins/virtuoso-skills/skills/reactive-engine/references/core/05.building-on-the-engine.md
+++ b/plugins/virtuoso-skills/skills/reactive-engine/references/core/05.building-on-the-engine.md
@@ -1,0 +1,142 @@
+---
+title: Building on the Engine
+description: Architecture patterns for components and libraries built on the reactive engine, extracted from @virtuoso.dev/data-table.
+---
+
+`@virtuoso.dev/data-table` is the largest production system built on the engine. Its architecture demonstrates the patterns that make engine-based components scale. Each pattern below is generic; data-table serves as the worked example.
+
+## Module-scope graph, per-instance engine
+
+Define the entire node graph and its wiring at module scope. Instantiate one engine per component instance. Because module-scope combinators register deferred inits, the wiring applies automatically to every engine that activates the nodes — and each instance's state stays isolated.
+
+```ts
+// feature module, module scope — runs once per import, applies to every engine
+export const setColumnVisibility$ = Stream<SetColumnVisibilityPayload>()
+export const resetColumnVisibility$ = Trigger()
+
+e.changeWith(
+  columnVisibilityOverrides$,
+  e.pipe(setColumnVisibility$, e.withLatestFrom(columns$)),
+  (overrides, [{ key, visible }, columns]) => {
+    /* return a new Map */
+  }
+)
+```
+
+Two tables on one page (`engineId="orders"` / `engineId="invoices"`) share this wiring but never share state.
+
+## Action streams in, state cells out
+
+Design a module's public API as a boundary of nodes:
+
+- **Inputs**: streams and triggers named as commands — `setColumnVisibility$`, `resizeColumn$`, `resetColumnOrder$`. The outside world publishes; it never writes state directly.
+- **Outputs**: cells (often `DerivedCell`) named as state — `columnVisibilityState$`, `scrollLocation$`. The outside world reads and subscribes; it cannot publish into a derived cell.
+
+The wiring between inputs and outputs is internal. This gives the module the same encapsulation a reducer gives a store: all state transitions are enumerable, and every consumer (React component, persistence adapter, test) goes through the same two node kinds.
+
+## Derived cells for computed state
+
+Represent any state computable from other state as a `DerivedCell` over `combine`:
+
+```ts
+export const columnVisibilityState$ = DerivedCell(
+  new Map<string, boolean>(),
+  e.pipe(
+    e.combine(columns$, columnVisibilityOverrides$),
+    e.map(([columns, overrides]) => new Map([...columns].map(([key, c]) => [key, overrides.get(key) ?? c.visible !== false])))
+  )
+)
+```
+
+Store only the minimal independent state (the overrides) and derive the rest. The transaction system guarantees derived cells never observe partially-updated inputs.
+
+## React props flow in through initFn/updateFn; callbacks flow out through singletonSub
+
+The component shell is thin: an `EngineProvider` that pushes props into cells and forwards node emissions to callback props.
+
+```tsx
+<EngineProvider
+  initFn={(e) => {
+    e.register(columns$) // activate nodes whose inits must run eagerly
+    e.pubIn({ [context$]: context, [computeRowKey$]: computeRowKey })
+    e.singletonSub(onScroll$, onScroll)
+  }}
+  updateFn={(e) => {
+    e.pubIn({ [context$]: context, [computeRowKey$]: computeRowKey })
+    e.singletonSub(onScroll$, onScroll) // replaces, never stacks
+  }}
+  updateDeps={[context, computeRowKey, onScroll]}
+  engineId={engineId}
+  engineRef={engineRef}
+>
+```
+
+- `initFn` runs once at engine creation: register nodes, seed cells with `pubIn`, attach bridges.
+- `updateFn` runs whenever `updateDeps` change: re-publish the changed props. Distinct cells make redundant publishes free.
+- Callback props always go through `singletonSub` so re-renders replace the subscription instead of accumulating duplicates.
+
+Inside the component tree, rendering is just `useCellValue(cell$)` and event handlers are just `usePublisher(action$)` — components contain no logic, only projection.
+
+## Batch related publishes with pubIn
+
+When several cells change together (a data result and its group indices; a set of props), publish them in one `pubIn` transaction so derived nodes compute once with a consistent view.
+
+## Feature modules as opt-in subpath exports
+
+Each optional feature lives in its own module exporting its action streams, state cells, pure helper converters, and UI fragments — published as a package subpath (`@virtuoso.dev/data-table/column-visibility`). The core never imports features; features import core nodes and attach wiring. Because wiring is deferred inits, an unused feature costs nothing: its inits never run in engines that never touch its nodes.
+
+## Remote control: engineRef and engineId
+
+Because state lives in an engine rather than React state, external UI does not need prop drilling or lifted state. The component accepts an identity (`engineRef` from `useEngineRef()` for nearby UI, string `engineId` for distant UI), and external components use remote hooks against the exported nodes:
+
+```tsx
+const scrollToRow = useRemotePublisher(scrollToRow$, engineRef)
+const location = useRemoteCellValue(scrollLocation$, engineRef)
+```
+
+The public node set defines exactly what external control is possible. Remote hooks return `undefined` until the target engine mounts — design consumers to tolerate that.
+
+## Bridging imperative systems
+
+Non-reactive subsystems (data sources, network layers) connect through a bridge: a function that subscribes both directions and returns a cleanup, registered with `engine.onDispose`.
+
+```ts
+function bridgeModelToEngine(model: DataModelHandle, engine: Engine): () => void {
+  const unsubModel = model.subscribe((msg) => {
+    engine.pubIn({ [data$]: msg.rows, [groupIndices$]: msg.groups })
+  })
+  const unsubViewport = engine.sub(viewportRange$, (range) => {
+    model.send({ action: 'viewportChange', payload: range })
+  })
+  return () => {
+    unsubModel()
+    unsubViewport()
+  }
+}
+```
+
+The engine side stays declarative (cells and streams); the imperative side keeps its own protocol. data-table uses this to keep its data models (`localModel`, `remoteModel`) engine-free and independently testable.
+
+## Persistence adapters
+
+Persisting feature state generalizes into an adapter interface that each feature implements with its own pure serializers:
+
+```ts
+interface PersistenceAdapter<State> {
+  key: string
+  capture(context, previous: State | null): State // engine state -> storable shape
+  restore(context, state: State | null): void // storable shape -> publishes into the engine
+  subscribe(context, onChange): () => void // watch the nodes that mean "state changed, save it"
+  subscribeRestore?(context, onChange): () => void // watch the nodes that mean "re-apply saved state"
+}
+```
+
+An orchestrator component owns the storage, debounces writes, restores on mount, and knows nothing about any feature. Note the two subscription channels: `subscribe` watches user actions (save triggers), `subscribeRestore` watches structural changes like the column set (re-apply triggers). For simple cases — one cell, one storage key — skip the adapter machinery and use `linkCellToStorage` from `@virtuoso.dev/reactive-engine-storage`.
+
+## Invariants to respect
+
+- **Register dependency nodes before attaching bridges** in `initFn` — wiring inits must be in place before data starts flowing.
+- **Always return new references from reducers** (`changeWith`, `map`) — distinct is reference equality.
+- **Every bridge returns a cleanup**, and every cleanup reaches `engine.onDispose` (or the provider's unmount path).
+- **Keep the graph acyclic.** If two cells must influence each other, route one direction through an action stream or `delayWithMicrotask`.
+- **`singletonSub` for anything driven by React renders**; plain `sub` only in module wiring and inits.

--- a/plugins/virtuoso-skills/skills/reactive-engine/references/core/README.md
+++ b/plugins/virtuoso-skills/skills/reactive-engine/references/core/README.md
@@ -1,0 +1,46 @@
+# Reactive Engine Core
+
+`@virtuoso.dev/reactive-engine-core` is a framework-agnostic reactive state engine. State is modeled as a graph of typed nodes — stateful cells, stateless streams, and valueless triggers — connected through operators and combinators. An `Engine` instance activates the graph, propagates values, and manages subscriptions.
+
+The package is part of the Reactive Engine family:
+
+- [`@virtuoso.dev/reactive-engine-react`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-react) - React bindings (provider and hooks)
+- [`@virtuoso.dev/reactive-engine-query`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-query) - data fetching with queries and mutations
+- [`@virtuoso.dev/reactive-engine-router`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-router) - routing with routes, layouts, and guards
+- [`@virtuoso.dev/reactive-engine-storage`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-storage) - cell persistence in local/session storage or cookies
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core
+```
+
+## Quick Example
+
+```ts
+import { Cell, Engine } from '@virtuoso.dev/reactive-engine-core'
+
+const count$ = Cell(0)
+const engine = new Engine()
+
+engine.sub(count$, (value) => {
+  console.log('count is now', value)
+})
+
+engine.pub(count$, 1)
+engine.getValue(count$) // 1
+```
+
+## Concepts
+
+- **Cells** are stateful nodes that always hold a current value.
+- **Streams** are stateless nodes that emit values to their subscribers.
+- **Triggers** are valueless streams used to signal events.
+- **Resources** are cells with factory initialization and automatic disposal.
+- **Operators** (`map`, `filter`, `scan`, `debounceTime`, `throttleTime`, `withLatestFrom`, and more) transform values as they flow between nodes.
+- **Combinators** (`link`, `pipe`, `combine`, `merge`) wire nodes into a graph.
+- **Engine** instances activate node definitions, propagate published values, and manage subscriptions.
+
+## License
+
+MIT

--- a/plugins/virtuoso-skills/skills/reactive-engine/references/query/01.queries-and-mutations.md
+++ b/plugins/virtuoso-skills/skills/reactive-engine/references/query/01.queries-and-mutations.md
@@ -1,0 +1,124 @@
+---
+title: Queries and Mutations
+description: Data fetching as nodes - lifecycle, result states, retries, and wiring patterns.
+---
+
+`@virtuoso.dev/reactive-engine-query` expresses data fetching as engine nodes, so queries compose with the rest of the graph: route params can drive query params, mutation successes can trigger refetches, and components consume results with `useCellValue` like any other state.
+
+## Query
+
+```ts
+export const tasksQuery = Query<{ listId: string }, Task[]>({
+  queryFn: async ({ listId }, signal) => {
+    const res = await fetch(`/api/tasks?listId=${listId}`, { signal })
+    if (!res.ok) throw new Error('Failed to fetch tasks')
+    return res.json()
+  },
+  initialParams: { listId: '' },
+})
+```
+
+`Query()` returns a bundle of nodes:
+
+| Node          | Kind    | Role                                                        |
+| ------------- | ------- | ----------------------------------------------------------- |
+| `data$`       | Cell    | The query result (discriminated union below)                |
+| `params$`     | Cell    | Publishing new params re-executes the query                 |
+| `refetch$`    | Trigger | Re-execute with current params                              |
+| `invalidate$` | Trigger | Mark stale: keep showing data, set `isFetching`, re-execute |
+| `unload$`     | Trigger | Abort, clear data, return to pending                        |
+| `enabled$`    | Cell    | Gate execution; toggling to `true` executes                 |
+
+Options: `enabled` (default `true`), `retry` (default `3`; `retry: 3` means up to 4 attempts), `retryDelay` (default exponential backoff capped at 30s), `refetchInterval` (polling, starts after a successful fetch), `initialData`.
+
+### Result shape
+
+`data$` emits one of three states, discriminated on `type`:
+
+```ts
+{ type: 'pending', data: null,  isLoading: true,  isFetching: true,  isSuccess: false, isError: false, error: null }
+{ type: 'success', data: T,     isLoading: false, isFetching: boolean, isSuccess: true,  isError: false, error: null, dataUpdatedAt: number }
+{ type: 'error',   data: null,  isLoading: false, isFetching: false, isSuccess: false, isError: true,  error: unknown }
+```
+
+`isFetching: true` inside the success state means a background refresh is in flight while stale data stays visible — that is what `invalidate$` produces, versus `unload$` which drops to pending.
+
+### Lifecycle rules
+
+- A query executes when its `data$` first activates in an engine (if enabled), whenever `params$` emits (if enabled), on `refetch$`/`invalidate$`, and when `enabled$` flips to `true`.
+- Each execution aborts the previous in-flight request — the `signal` passed to `queryFn` must reach the actual fetch.
+- Disabling aborts in-flight work and stops polling.
+- Query state is per engine, like all node state; the same query in two engines fetches independently.
+
+## Mutation
+
+```ts
+export const createTask = Mutation<{ listId: string; title: string }, Task>({
+  mutationFn: async (params) => {
+    /* POST */
+  },
+})
+```
+
+Returns `data$` (states `idle | pending | success | error`, with `isPending`/`isSuccess`/`isError` flags), `mutate$` (publish params to execute), and `reset$` (back to idle). Mutations never auto-execute and don't retry by default. `onSuccess(data)`/`onError(error)` callbacks fire after the state publish.
+
+```tsx
+const create = usePublisher(createTask.mutate$)
+const result = useCellValue(createTask.data$)
+
+<button disabled={result.isPending} onClick={() => create({ listId, title })}>Add</button>
+```
+
+## Wiring patterns
+
+**Mutations trigger refetches in the graph, not in components.** Declare the relationship once at module scope:
+
+```ts
+e.link(
+  e.pipe(
+    e.merge(createTask.data$, updateTask.data$, deleteTask.data$),
+    e.filter((r) => r.type === 'success'),
+    e.map(() => undefined, false) // distinct=false: consecutive successes must each fire
+  ),
+  tasksQuery.refetch$
+)
+```
+
+**Routes drive query params.** A route node emits its params when matched; pipe it into `params$`:
+
+```ts
+e.link(
+  e.pipe(
+    tasks$, // Route('/lists/{id:string}', TasksPage)
+    e.filter((params) => params !== null),
+    e.map((params) => ({ listId: params.id }))
+  ),
+  tasksQuery.params$
+)
+```
+
+Navigation then transparently refetches — no effect hooks, no param threading through components.
+
+**Dependent queries** gate on their prerequisite:
+
+```ts
+e.link(
+  e.pipe(
+    userQuery.data$,
+    e.map((r) => r.type === 'success')
+  ),
+  ordersQuery.enabled$
+)
+```
+
+## Rendering results
+
+Branch on the discriminated union:
+
+```tsx
+const result = useCellValue(tasksQuery.data$)
+
+if (result.isLoading) return <Spinner />
+if (result.isError) return <ErrorView error={result.error} />
+return <TaskList tasks={result.data} refreshing={result.isFetching} />
+```

--- a/plugins/virtuoso-skills/skills/reactive-engine/references/query/README.md
+++ b/plugins/virtuoso-skills/skills/reactive-engine/references/query/README.md
@@ -1,0 +1,41 @@
+# Reactive Engine Query
+
+`@virtuoso.dev/reactive-engine-query` adds data fetching to [`@virtuoso.dev/reactive-engine-core`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-core). Queries and mutations are reactive nodes: parameters flow in, and pending/success/error results flow out to the rest of the graph.
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core @virtuoso.dev/reactive-engine-query
+```
+
+## Quick Example
+
+```ts
+import { Query } from '@virtuoso.dev/reactive-engine-query'
+
+interface Task {
+  id: string
+  title: string
+}
+
+export const tasksQuery = Query<{ listId: string }, Task[]>({
+  queryFn: async ({ listId }, signal) => {
+    const res = await fetch(`/api/tasks?listId=${listId}`, { signal })
+    if (!res.ok) {
+      throw new Error('Failed to fetch tasks')
+    }
+    return res.json()
+  },
+  initialParams: { listId: '' },
+})
+```
+
+## Features
+
+- `Query` - parameterized async reads with abort signal support, retries, and typed pending/success/error results
+- `Mutation` - async writes with typed idle/pending/success/error results
+- `executeWithRetry` / `defaultRetryDelay` - retry utilities used by both
+
+## License
+
+MIT

--- a/plugins/virtuoso-skills/skills/reactive-engine/references/react/01.react-integration.md
+++ b/plugins/virtuoso-skills/skills/reactive-engine/references/react/01.react-integration.md
@@ -1,0 +1,93 @@
+---
+title: React Integration
+description: EngineProvider lifecycle, hooks, and remote engine access.
+---
+
+## EngineProvider
+
+`EngineProvider` creates an engine when it mounts, provides it through context, and disposes it on unmount. While the provider is mounted, the engine is the source of truth; React components project its state.
+
+```tsx
+<EngineProvider
+  initWith={{ [theme$]: 'dark' }} // seed cell values at construction
+  initFn={(engine) => {
+    /* one-time setup: register nodes, bridges, singleton subs */
+  }}
+  updateFn={(engine) => {
+    /* re-publish changed props */
+  }}
+  updateDeps={[propA, propB]}
+  engineId="my-feature" // optional: global registry + storage namespacing
+  engineRef={engineRef} // optional: handle for remote hooks
+>
+  {children}
+</EngineProvider>
+```
+
+Lifecycle details that matter:
+
+- The engine is created in a `useState` initializer and `initFn` runs synchronously right after — before the first render of children.
+- `updateFn` runs in a layout effect whenever `updateDeps` change (including once after mount). It is independent of `initFn`; both should be written idempotently. Use `pubIn` for prop values (distinct cells absorb no-op republishes) and `singletonSub` for callback props.
+- On unmount the engine is disposed and (if set) removed from the registry/ref.
+- Nesting providers shadows the engine context — `useEngine()` returns the nearest provider's engine. Providers do not automatically parent-link; coordinate separate engines through remote hooks or construct child engines yourself.
+
+## Hooks
+
+| Hook                         | Returns                             | Notes                                                                                |
+| ---------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------ |
+| `useCellValue(cell$)`        | Current value, re-renders on change | Backed by `useSyncExternalStore`; SSR-safe                                           |
+| `useCellValues(a$, b$, ...)` | Tuple of values                     | Single subscription via a combined cell — one re-render when several change together |
+| `useCell(cell$)`             | `[value, publish]`                  | The `useState` shape                                                                 |
+| `usePublisher(node$)`        | Stable `(value) => void`            | Safe in effect dependency arrays                                                     |
+| `useEngine()`                | The provider's engine               | For imperative escape hatches                                                        |
+| `useEngineRef()`             | A stable `EngineRef`                | Pass to a provider's `engineRef` and to remote hooks                                 |
+
+Prefer `useCellValues` over several `useCellValue` calls when a component reads multiple cells that change in the same transaction — it collapses them into one re-render.
+
+## Remote hooks: reaching an engine from outside its tree
+
+Remote hooks accept an `EngineSource` — an `EngineRef` or a string `engineId` — and resolve the engine through the ref or a global registry:
+
+```tsx
+const value = useRemoteCellValue(scrollLocation$, engineRef)
+const publish = useRemotePublisher(scrollToRow$, 'orders-table')
+const [v, setV] = useRemoteCell(theme$, engineRef)
+const values = useRemoteCellValues({ cells: [a$, b$], engineSource: engineRef })
+```
+
+The defining behavior: **remote hooks return `undefined` until the target engine exists**. They subscribe to the ref/registry and start delivering values as soon as the provider mounts. Guard accordingly:
+
+```tsx
+const location = useRemoteCellValue(scrollLocation$, engineRef)
+if (location === undefined) return null // table not mounted yet
+```
+
+Use an `engineRef` when the controlling UI and the provider share a component (a toolbar next to its table); use an `engineId` when they are far apart and threading a ref is impractical. The id registry is global to the page — namespace ids if several independent features use them.
+
+## SSR
+
+`useCellValue` provides a server snapshot through `useSyncExternalStore`, so server rendering reads the engine's initial values. Reading a cell during render must stay side-effect free. Effect-timing hooks use a layout effect in the browser and a regular effect on the server (`useIsomorphicLayoutEffect`).
+
+## Component patterns
+
+Keep components projection-only:
+
+```tsx
+const VisibilityMenu = () => {
+  const visibility = useCellValue(columnVisibilityState$)
+  const setVisibility = usePublisher(setColumnVisibility$)
+
+  return (
+    <>
+      {[...visibility].map(([key, visible]) => (
+        <label key={key}>
+          <input type="checkbox" checked={visible} onChange={(ev) => setVisibility({ key, visible: ev.target.checked })} />
+          {key}
+        </label>
+      ))}
+    </>
+  )
+}
+```
+
+Logic — what a visibility change means, how it composes with declarations — lives in the module-scope wiring, where it is shared by every instance and testable with a bare `Engine` and no React at all.

--- a/plugins/virtuoso-skills/skills/reactive-engine/references/react/README.md
+++ b/plugins/virtuoso-skills/skills/reactive-engine/references/react/README.md
@@ -1,0 +1,45 @@
+# Reactive Engine React
+
+`@virtuoso.dev/reactive-engine-react` provides React bindings for [`@virtuoso.dev/reactive-engine-core`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-core): an `EngineProvider` component and hooks for reading cell values and publishing into nodes from components.
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core @virtuoso.dev/reactive-engine-react
+```
+
+## Quick Example
+
+```tsx
+import { Cell } from '@virtuoso.dev/reactive-engine-core'
+import { EngineProvider, useCellValue, usePublisher } from '@virtuoso.dev/reactive-engine-react'
+
+const count$ = Cell(0)
+
+function Counter() {
+  const count = useCellValue(count$)
+  const setCount = usePublisher(count$)
+
+  return <button onClick={() => setCount(count + 1)}>{count}</button>
+}
+
+export function App() {
+  return (
+    <EngineProvider>
+      <Counter />
+    </EngineProvider>
+  )
+}
+```
+
+## Hooks
+
+- `useCellValue` / `useCellValues` - subscribe to one or several cells
+- `useCell` - read a cell value and get a publisher for it
+- `usePublisher` - get a publisher function for a node
+- `useEngine` / `useEngineRef` - access the engine instance from context
+- `useRemoteCell`, `useRemoteCellValue`, `useRemoteCellValues`, `useRemotePublisher` - work with cells from another engine instance
+
+## License
+
+MIT

--- a/plugins/virtuoso-skills/skills/reactive-engine/references/router/01.routing.md
+++ b/plugins/virtuoso-skills/skills/reactive-engine/references/router/01.routing.md
@@ -68,7 +68,7 @@ Layouts match by URL prefix and nest by specificity — `Layout('/')` wraps ever
 ## Guards
 
 ```tsx
-const authGuard = Guard('/admin/*', (context) => {
+const authGuard = Guard('/admin', (context) => {
   const user = context.engine.getValue(currentUser$)
   if (!user) {
     return context.redirect(login$, {})

--- a/plugins/virtuoso-skills/skills/reactive-engine/references/router/01.routing.md
+++ b/plugins/virtuoso-skills/skills/reactive-engine/references/router/01.routing.md
@@ -1,0 +1,99 @@
+---
+title: Routing
+description: Typed routes as nodes, navigation, layouts, guards, and browser history.
+---
+
+`@virtuoso.dev/reactive-engine-router` represents each route as a node. A route node emits its parsed params when the route is active and `null` when it is not — which makes routing composable with the rest of the graph (drive query params from routes, gate features on the active route).
+
+## Defining routes
+
+```tsx
+import { Route } from '@virtuoso.dev/reactive-engine-router'
+
+export const home$ = Route('/', HomePage)
+export const user$ = Route('/users/{id:number}', UserPage)
+export const blog$ = Route('/blog/{slug}/?category={category?}&tag={tag?}', BlogPage)
+export const files$ = Route('/files/{*rest}', FilesPage)
+```
+
+The path syntax is parsed at the type level — params arrive typed:
+
+- `{id:number}` → `{ id: number }`; `{slug}` defaults to string
+- `?q={query}&limit={limit?:number}` → optional search params under `$search`
+- `{*rest}` → catch-all, `string[]`
+
+The route component receives the params as props, typed as `RouteParams<'/users/{id:number}'>`:
+
+```tsx
+export const UserPage: React.ComponentType<RouteParams<'/users/{id:number}'>> = ({ id }) => <h1>User {id}</h1>
+```
+
+## Mounting and navigating
+
+```tsx
+<EngineProvider>
+  <Router routes={[home$, user$, blog$]} layouts={[rootLayout]} guards={[authGuard]} />
+</EngineProvider>
+```
+
+`Router` needs an engine (mount it inside an `EngineProvider`). Props: `routes`, `layouts`, `guards`, `basePath`, `useBrowserHistory` (default `true` — syncs with the address bar and back/forward buttons).
+
+Navigation is publishing params to a route node:
+
+```tsx
+const goToUser = usePublisher(user$)
+goToUser({ id: 42 }) // navigates to /users/42
+```
+
+Since route nodes are also outputs, the same node tells you whether the route is active:
+
+```tsx
+const userParams = useCellValue(user$) // null when not on /users/...
+```
+
+## Layouts
+
+```tsx
+const rootLayout = Layout('/', ({ children }) => (
+  <main>
+    <Nav />
+    {children}
+  </main>
+))
+const blogLayout = Layout('/blog', ({ children }) => <BlogShell>{children}</BlogShell>)
+```
+
+Layouts match by URL prefix and nest by specificity — `Layout('/')` wraps everything, `Layout('/blog')` wraps inside it for blog routes. For regions a route fills inside a layout (a context-dependent sidebar), create a slot cell with `LayoutSlotPortal()`, render it in the layout with `<LayoutSlot slotPortal={...}>`, and provide content from a page with `<LayoutSlotFill slotPortal={...}>`.
+
+## Guards
+
+```tsx
+const authGuard = Guard('/admin/*', (context) => {
+  const user = context.engine.getValue(currentUser$)
+  if (!user) {
+    return context.redirect(login$, {})
+  }
+  return context.continue()
+})
+```
+
+- A guard's pattern uses route syntax; all guards matching the target URL run in order (priority option, then specificity, then registration order).
+- The context offers `continue()`, `navigate(urlOrRoute, params?)` (retarget and keep evaluating guards against the new URL), `redirect(urlOrRoute, params?)` (abort and navigate), plus `params`, `location`, and `engine`.
+- Guards may be async — the route renders inside `Suspense` while pending, so provide a Suspense boundary above the `Router`.
+
+## Wiring routes into the graph
+
+The canonical pattern — route activation drives data fetching:
+
+```ts
+e.link(
+  e.pipe(
+    user$,
+    e.filter((params) => params !== null),
+    e.map((params) => ({ userId: params.id }))
+  ),
+  userQuery.params$
+)
+```
+
+Pages then need no fetch logic at all: navigating publishes params, params trigger the query, the page reads `userQuery.data$`.

--- a/plugins/virtuoso-skills/skills/reactive-engine/references/router/README.md
+++ b/plugins/virtuoso-skills/skills/reactive-engine/references/router/README.md
@@ -1,0 +1,51 @@
+# Reactive Engine Router
+
+`@virtuoso.dev/reactive-engine-router` is a router built on [`@virtuoso.dev/reactive-engine-core`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-core). Routes are reactive nodes - navigation is publishing into a route node, and the current route flows through the graph like any other value.
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core @virtuoso.dev/reactive-engine-react @virtuoso.dev/reactive-engine-router
+```
+
+## Quick Example
+
+```tsx
+import { usePublisher } from '@virtuoso.dev/reactive-engine-react'
+import { Layout, Router } from '@virtuoso.dev/reactive-engine-router'
+
+import { about$, home$ } from './routes'
+
+const rootLayout = Layout('/', ({ children }) => (
+  <div>
+    <Navigation />
+    <main>{children}</main>
+  </div>
+))
+
+function Navigation() {
+  const goHome = usePublisher(home$)
+  const goToAbout = usePublisher(about$)
+
+  return (
+    <nav>
+      <button onClick={() => goHome({})}>Home</button>
+      <button onClick={() => goToAbout({})}>About</button>
+    </nav>
+  )
+}
+
+export function App() {
+  return <Router layouts={[rootLayout]} routes={[home$, about$]} />
+}
+```
+
+## Features
+
+- **Routes** - typed route definitions with parameters
+- **Layouts** - nested layout components matched by path, with slot/fill composition (`LayoutSlot`, `LayoutSlotFill`)
+- **Guards** - sync or async navigation guards that can continue, redirect, or navigate elsewhere
+
+## License
+
+MIT

--- a/plugins/virtuoso-skills/skills/reactive-engine/references/storage/01.storage-links.md
+++ b/plugins/virtuoso-skills/skills/reactive-engine/references/storage/01.storage-links.md
@@ -1,0 +1,47 @@
+---
+title: Storage Links
+description: Persisting cells to localStorage, sessionStorage, and cookies.
+---
+
+`linkCellToStorage` keeps a cell in sync with browser storage. Declare it at module scope next to the cell:
+
+```ts
+import { Cell } from '@virtuoso.dev/reactive-engine-core'
+import { linkCellToStorage } from '@virtuoso.dev/reactive-engine-storage'
+
+export const theme$ = Cell<'light' | 'dark'>('light')
+
+linkCellToStorage(theme$, {
+  storageType: 'localStorage',
+  key: 'app-theme',
+  debounceMs: 300,
+})
+```
+
+Options form a union on `storageType`:
+
+- `'localStorage'` / `'sessionStorage'` — `{ key, debounceMs?, serialize?, deserialize? }`
+- `'cookie'` — additionally `cookieOptions`: `{ expires?: Date | '7d' | '1h' | '30m', path?, domain?, sameSite?, secure? }`
+
+Serialization defaults to `JSON.stringify`/`JSON.parse`; failures in either direction are swallowed (the cell keeps its in-memory value).
+
+## Timing semantics
+
+The link is implemented as a node init, so everything is lazy and per engine:
+
+- **Read** happens once per engine, when the engine first activates the cell. The stored value (if any) is published into the cell at that moment — before components subscribe through the provider. Reading the cell before any engine activates it yields the constructor's initial value.
+- **Write** happens on cell changes, debounced (default 500ms for localStorage, 0 otherwise). Pending writes are flushed/cleared on engine disposal.
+- **Cross-tab sync** applies to localStorage only: changes from other tabs publish into the cell; the link ignores echoes of its own writes.
+
+## Key namespacing
+
+If the engine has an id (`new Engine({}, 'my-app')` or `<EngineProvider engineId="my-app">`), localStorage/sessionStorage keys become `my-app:app-theme`. This is how multiple instances of the same engine-based component (for example two data tables) persist independently while sharing node definitions. Cookies are not namespaced.
+
+## Server-side rendering
+
+The link is a no-op when `window` is unavailable or the storage type is inaccessible — cells keep their initial values on the server, and storage hydrates them on the client when the engine activates the cell. Expect a possible flash of the initial value before client hydration, and avoid branching server-rendered markup on persisted state.
+
+## When to use what
+
+- One cell, one key: `linkCellToStorage`.
+- Composite, versioned feature state (like a table's column layout): a persistence adapter orchestrator — see "Building on the Engine" in the core docs for the pattern data-table uses.

--- a/plugins/virtuoso-skills/skills/reactive-engine/references/storage/README.md
+++ b/plugins/virtuoso-skills/skills/reactive-engine/references/storage/README.md
@@ -1,0 +1,27 @@
+# Reactive Engine Storage
+
+`@virtuoso.dev/reactive-engine-storage` persists [`@virtuoso.dev/reactive-engine-core`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-core) cells in `localStorage`, `sessionStorage`, or cookies. A storage link hydrates the cell on engine startup and writes changes back as the cell updates.
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core @virtuoso.dev/reactive-engine-storage
+```
+
+## Quick Example
+
+```ts
+import { Cell } from '@virtuoso.dev/reactive-engine-core'
+import { linkCellToStorage } from '@virtuoso.dev/reactive-engine-storage'
+
+const theme$ = Cell<'light' | 'dark'>('light')
+
+linkCellToStorage(theme$, {
+  key: 'app-theme',
+  storageType: 'localStorage',
+})
+```
+
+## License
+
+MIT

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ catalogs:
       specifier: ^0.21.1
       version: 0.21.1
     playwright:
-      specifier: ^1.58.2
-      version: 1.58.2
+      specifier: ^1.60.0
+      version: 1.60.0
     react:
       specifier: ^19.2.3
       version: 19.2.3
@@ -382,7 +382,7 @@ importers:
         version: 4.7.0(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(playwright@1.58.2)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
+        version: 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -463,10 +463,10 @@ importers:
         version: 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(playwright@1.58.2)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
+        version: 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
       playwright:
         specifier: 'catalog:'
-        version: 1.58.2
+        version: 1.60.0
       react:
         specifier: 'catalog:'
         version: 19.2.3
@@ -518,7 +518,7 @@ importers:
         version: 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(playwright@1.58.2)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
+        version: 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
       jsdom:
         specifier: 'catalog:'
         version: 28.1.0
@@ -530,7 +530,7 @@ importers:
         version: 6.1.13
       playwright:
         specifier: 'catalog:'
-        version: 1.58.2
+        version: 1.60.0
       react:
         specifier: 'catalog:'
         version: 19.2.3
@@ -565,8 +565,8 @@ importers:
         specifier: 'catalog:'
         version: 7.57.7(@types/node@25.5.0)
       '@playwright/test':
-        specifier: ^1.58.2
-        version: 1.58.2
+        specifier: ^1.60.0
+        version: 1.60.0
       '@testing-library/react':
         specifier: 'catalog:'
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -593,7 +593,7 @@ importers:
         version: 4.17.21
       playwright:
         specifier: 'catalog:'
-        version: 1.58.2
+        version: 1.60.0
       react:
         specifier: 'catalog:'
         version: 19.2.3
@@ -728,10 +728,10 @@ importers:
         version: 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(playwright@1.58.2)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
+        version: 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
       playwright:
         specifier: 'catalog:'
-        version: 1.58.2
+        version: 1.60.0
       react:
         specifier: 'catalog:'
         version: 19.2.3
@@ -789,10 +789,10 @@ importers:
         version: 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(playwright@1.58.2)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
+        version: 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
       playwright:
         specifier: 'catalog:'
-        version: 1.58.2
+        version: 1.60.0
       react:
         specifier: 'catalog:'
         version: 19.2.3
@@ -2414,8 +2414,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@playwright/test@1.58.2':
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5542,13 +5542,13 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -8548,9 +8548,9 @@ snapshots:
   '@pagefind/windows-x64@1.4.0':
     optional: true
 
-  '@playwright/test@1.58.2':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.58.2
+      playwright: 1.60.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -9532,11 +9532,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser-playwright@4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(playwright@1.58.2)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)':
+  '@vitest/browser-playwright@4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)':
     dependencies:
       '@vitest/browser': 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
       '@vitest/mocker': 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))
-      playwright: 1.58.2
+      playwright: 1.60.0
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@types/node@22.19.1)(@vitest/browser-playwright@4.1.5)(jsdom@28.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))
     transitivePeerDependencies:
@@ -9545,11 +9545,11 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser-playwright@4.1.5(msw@2.12.3(@types/node@25.5.0)(typescript@5.9.3))(playwright@1.58.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)':
+  '@vitest/browser-playwright@4.1.5(msw@2.12.3(@types/node@25.5.0)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)':
     dependencies:
       '@vitest/browser': 4.1.5(msw@2.12.3(@types/node@25.5.0)(typescript@5.9.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
       '@vitest/mocker': 4.1.5(msw@2.12.3(@types/node@25.5.0)(typescript@5.9.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))
-      playwright: 1.58.2
+      playwright: 1.60.0
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@types/node@25.5.0)(@vitest/browser-playwright@4.1.5)(jsdom@28.1.0)(msw@2.12.3(@types/node@25.5.0)(typescript@5.9.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))
     transitivePeerDependencies:
@@ -12328,11 +12328,11 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  playwright-core@1.58.2: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.58.2:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -13442,7 +13442,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.1
-      '@vitest/browser-playwright': 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(playwright@1.58.2)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
+      '@vitest/browser-playwright': 4.1.5(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
       jsdom: 28.1.0
     transitivePeerDependencies:
       - msw
@@ -13471,7 +13471,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
-      '@vitest/browser-playwright': 4.1.5(msw@2.12.3(@types/node@25.5.0)(typescript@5.9.3))(playwright@1.58.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
+      '@vitest/browser-playwright': 4.1.5(msw@2.12.3(@types/node@25.5.0)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(vitest@4.1.5)
       jsdom: 28.1.0
     transitivePeerDependencies:
       - msw

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,7 +26,7 @@ catalog:
   vitest: ^4.1.5
   '@vitejs/plugin-react': ^4.7.0
   vite-plugin-dts: ^4.5.4
-  playwright: ^1.58.2
+  playwright: ^1.60.0
   '@vitest/browser': ^4.1.5
   '@vitest/browser-playwright': ^4.1.5
   oxlint: ^1.60.0

--- a/skills/data-table/SKILL.md
+++ b/skills/data-table/SKILL.md
@@ -1,8 +1,143 @@
 ---
 name: data-table
-description: Placeholder - content authoring pending. This skill will provide agent guidance for the @virtuoso.dev/data-table package.
+description: >-
+  Build virtualized data tables with @virtuoso.dev/data-table. Use this skill when (1) building a data grid with sorting, filtering,
+  or grouped rows, (2) installing the shadcn-styled or headless table, (3) connecting remote/paginated data sources, (4) adding sticky,
+  resizable, reorderable, or hideable columns, (5) persisting table state, (6) controlling a table from outside (scrolling, actions),
+  (7) migrating from TableVirtuoso, or any task involving VirtuosoDataTable, DataTable, DataTableColumn, localModel, remoteModel,
+  or engine refs like scrollToRow$ and dispatchModelAction$.
 ---
 
-# Data Table Skill
+# @virtuoso.dev/data-table
 
-TODO: Author skill body. See references/ for source docs.
+A virtualized React data table (rows and columns) with grouped rows, sticky columns, column resizing/reordering/visibility, state persistence, and remote data support. It is the successor to `TableVirtuoso` for table-shaped problems: instead of row renderers, you pass a data source (model) and declare columns as JSX.
+
+## Installation: two paths
+
+**Shadcn (pre-styled wrapper)** — for projects using shadcn/ui conventions:
+
+```bash
+npx shadcn@latest add https://virtuoso.dev/r/data-table.json
+```
+
+This installs a styled wrapper at `@/components/ui/data-table` exporting `DataTable`, `DataTableColumn`, `DataTableColumnHeader`, `DataTableCell`.
+
+**Headless** — for custom design systems:
+
+```bash
+npm install @virtuoso.dev/data-table
+```
+
+Import the structural styles (`@import '@virtuoso.dev/data-table/styles.css'`) and use the unstyled `VirtuosoDataTable`, `Column`, `ColumnHeader`, `Cell`. Ask which path fits the project before installing; the shadcn wrapper is the faster start in Tailwind/shadcn codebases.
+
+## Minimal example (shadcn wrapper)
+
+```tsx
+import { DataTable, DataTableCell, DataTableColumn, DataTableColumnHeader } from '@/components/ui/data-table'
+import { localModel } from '@virtuoso.dev/data-table'
+
+const model = localModel({ data: products })
+
+export default function App() {
+  return (
+    <DataTable className="rounded-xl" model={model} style={{ height: 360 }}>
+      <DataTableColumn field="name">
+        <DataTableColumnHeader>Product</DataTableColumnHeader>
+        <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
+      </DataTableColumn>
+    </DataTable>
+  )
+}
+```
+
+Columns are JSX, not config objects. `field` is both the row-data lookup key and the column's public identifier (used by visibility, reordering, persistence). The table needs a real height, like every Virtuoso component.
+
+## Choosing a data model
+
+| Situation                                                       | Model                                                                                                 |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Rows in memory; filter/sort/group client-side                   | `localModel({ data, pipeline?, actions?, groups? })`                                                  |
+| API-backed, known total count (placeholder rows while fetching) | `remoteModel` with offset mode (`defaultOffsetViewportHandler`); fetch returns `{ rows, totalCount }` |
+| API-backed, cursor pagination / infinite append                 | `remoteModel` with append mode (`defaultAppendViewportHandler`); fetch returns `{ rows }`             |
+
+Hold the model in `useState` with lazy init — `const [model] = useState(() => localModel({ data }))`. Do not use `useMemo`; React may discard memoized values, and the model instance must be retained. Module scope is fine for a static singleton table.
+
+Local filtering/sorting/grouping runs through a named-stage pipeline: declare `pipeline: ['filter', 'sort']` plus `actions`, then dispatch with `model.send({ action: 'filter', payload })`. See [local-data-model](references/2.data-model/01.local-data-model.md) and the [local-filter-sort-group example](references/8.examples/07.local-filter-sort-group.md).
+
+Provide `computeRowKey={({ data }) => data.id}` whenever rows can reorder (sort, filter, remote updates) — without it rows remount and lose local state.
+
+## Column features
+
+- **Sticky columns:** `<DataTableColumn field="name" sticky="left" />` (or `"right"`); multiple sticky columns stack.
+- **Visibility:** declaratively via `visible={false}`, or at runtime through `setColumnVisibility$` / `columnVisibilityState$` from `@virtuoso.dev/data-table/column-visibility`.
+- **Resizing:** mount `ResizeHandle` in the `HeaderEdge` slot; programmatic via `resizeColumn$` from `@virtuoso.dev/data-table/column-resize`.
+- **Reordering:** `ReorderGrip` in `HeaderStart` + `ReorderDropZone` in `HeaderOverlay`; programmatic via `reorderColumns$` from `@virtuoso.dev/data-table/column-reorder`.
+- **Header slots:** `HeaderStart` (before label), `HeaderEnd` (after label), `HeaderEdge` (pinned to the column boundary), `HeaderOverlay` (covers the header) — see [header-slots](references/7.customization/06.header-slots.md).
+- **Grouped rows:** pass `groups: [{ index, level }]` alongside `data` and render headers with `GroupHeaderCell` — see [grouped-rows](references/4.grouped-rows.md).
+
+State persistence: mount `<DataTableStatePersistence adapters={[...]} storageKey="my-table" />` with adapters from the feature subpaths (`columnVisibilityPersistenceAdapter()`, `columnOrderPersistenceAdapter()`, `columnWidthPersistenceAdapter()`, `modelStatePersistenceAdapter()`). See [state-persistence](references/5.state-persistence.md).
+
+## Controlling the table from outside
+
+The table's state lives in an internal reactive engine, and the package intentionally exports cells (readable state, `$`-suffixed) and streams (actions) for remote control — state is not lifted into props:
+
+```tsx
+import { scrollLocation$, scrollToRow$, useEngineRef, useRemoteCellValue, useRemotePublisher } from '@virtuoso.dev/data-table'
+
+const engineRef = useEngineRef()
+const scrollToRow = useRemotePublisher(scrollToRow$, engineRef)
+const location = useRemoteCellValue(scrollLocation$, engineRef)
+
+<DataTable engineRef={engineRef} model={model}>...</DataTable>
+<button onClick={() => scrollToRow({ index: 100, align: 'start' })}>Go to row 100</button>
+```
+
+For UI far from the table, pass `engineId="orders-table"` and use the same hooks with the string id. Useful nodes: `scrollToRow$`, `scrollIntoView$`, `setColumnVisibility$`, `dispatchModelAction$` (actions); `scrollLocation$`, `columns$`, `columnVisibilityState$`, `modelActionState$`, `loadingState$` (state). See [controlling-the-table](references/6.controlling-the-table.md).
+
+## Customization
+
+- Styling goes through `className` on the wrapper components and semantic data attributes — never use `data-testid` as a styling hook.
+- Replace internals via the `components` prop: `Row`, `StickyColumnContainer`, `LoadingPlaceholder`, `LoadingOverlay`, `LoadingFooter` (component overrides must forward refs). Top-level: `EmptyPlaceholder`, `ScrollElement`.
+- `context={{ ... }}` flows to `computeRowKey`, `EmptyPlaceholder`, loading slots, and component overrides — but not to cell/header renderers (use React context there). See [ambient-context](references/7.customization/05.ambient-context.md).
+- Scroll modes: default internal scroller, `useWindowScroll`, or `customScrollParent` — pick exactly one.
+
+## Migrating from TableVirtuoso
+
+| TableVirtuoso         | data-table                                                  |
+| --------------------- | ----------------------------------------------------------- |
+| `data` array          | `localModel({ data })` passed as `model`                    |
+| `itemContent`         | `DataTableColumn` + `DataTableCell`                         |
+| `fixedHeaderContent`  | `DataTableColumnHeader`                                     |
+| grouped rows          | `groups` + `GroupHeaderCell`                                |
+| fixed columns (CSS)   | `sticky="left"` / `sticky="right"`                          |
+| ref + `scrollToIndex` | `engineRef` + `scrollToRow$`                                |
+| `rangeChanged`        | `onRenderedDataChange`, `viewportRange$`, `scrollLocation$` |
+
+Full guide: [migrating-from-table-virtuoso](references/9.guides/04.migrating-from-table-virtuoso.md).
+
+## Troubleshooting
+
+| Symptom                                 | Fix                                                                                                 |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Blank table or header only              | Give the table a measurable height                                                                  |
+| Shadcn component imports fail           | Run the registry install, or import headless from `@virtuoso.dev/data-table`                        |
+| Page and table both scroll              | Use only one scroll mode                                                                            |
+| Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through |
+| Rows remount / lose state after sorting | Add `computeRowKey`                                                                                 |
+| Sticky columns clipped                  | Check parent `overflow` and column min-widths                                                       |
+| Empty cells flash on horizontal scroll  | Raise `columnOverscanCount`                                                                         |
+
+For tests, wrap in `VirtuosoDataTableTestingContext.Provider value={{ itemHeight, viewportHeight }}` (JSDOM has no layout) and assert behavior, not exact DOM row counts — overscan renders extra rows. Use real-browser tests for sticky columns, resizing, and drag interactions. See [testing](references/9.guides/01.testing.md).
+
+## References
+
+- [references/README.md](references/README.md) — overview
+- `references/1.installation/` — [shadcn](references/1.installation/01.shadcn.md), [headless](references/1.installation/02.headless.md)
+- `references/2.data-model/` — [local](references/2.data-model/01.local-data-model.md), [remote](references/2.data-model/02.remote-data-model.md), [row-keys](references/2.data-model/03.row-keys.md)
+- `references/3.columns/` — [defining-columns](references/3.columns/01.defining-columns.md), [cell-and-header-renderers](references/3.columns/02.cell-and-header-renderers.md), [column-groups](references/3.columns/03.column-groups.md), [sticky-columns](references/3.columns/04.sticky-columns.md), [visibility](references/3.columns/05.column-visibility.md), [resizing](references/3.columns/06.column-resizing.md), [reordering](references/3.columns/07.column-reordering.md), [runtime-columns](references/3.columns/08.runtime-columns.md)
+- Features: [grouped-rows](references/4.grouped-rows.md), [state-persistence](references/5.state-persistence.md), [controlling-the-table](references/6.controlling-the-table.md)
+- `references/7.customization/` — [styling](references/7.customization/01.styling.md), [replacing-internals](references/7.customization/02.replacing-internals.md), [empty-and-loading-states](references/7.customization/03.empty-and-loading-states.md), [scroll-containers](references/7.customization/04.scroll-containers.md), [ambient-context](references/7.customization/05.ambient-context.md), [header-slots](references/7.customization/06.header-slots.md), [shadcn-wrapper](references/7.customization/07.shadcn-wrapper.md)
+- `references/8.examples/` — worked examples from basic table to remote pagination, dashboards, and persistence
+- `references/9.guides/` — [testing](references/9.guides/01.testing.md), [performance](references/9.guides/02.performance.md), [troubleshooting](references/9.guides/03.troubleshooting.md), [migrating-from-table-virtuoso](references/9.guides/04.migrating-from-table-virtuoso.md), [debug-instrumentation](references/9.guides/05.debug-instrumentation.md)
+
+Full API reference: <https://virtuoso.dev/data-table/>

--- a/skills/message-list/SKILL.md
+++ b/skills/message-list/SKILL.md
@@ -1,8 +1,153 @@
 ---
 name: message-list
-description: Placeholder - content authoring pending. This skill will provide agent guidance for the @virtuoso.dev/message-list package.
+description: >-
+  Build chat, messaging, and AI conversation UIs with @virtuoso.dev/message-list. Use this skill when (1) building a chat or
+  messaging interface, (2) streaming AI assistant responses into a conversation, (3) loading older messages when scrolling up,
+  (4) adding scroll-to-bottom buttons or unseen-message indicators, (5) switching between channels/conversations, or (6) any task
+  involving VirtuosoMessageList, VirtuosoMessageListLicense, useVirtuosoMethods, useVirtuosoLocation, scrollModifier, or
+  data.append/prepend/map. The package is commercial and requires a license key.
 ---
 
-# Message List Skill
+# @virtuoso.dev/message-list
 
-TODO: Author skill body. See references/ for source docs.
+`VirtuosoMessageList` is a virtualized list purpose-built for human and AI chat: stick-to-bottom behavior, streaming responses that grow without scroll jumps, history prepending that preserves the visual position, and scroll position tracking. Use it instead of plain `Virtuoso` when building conversation UIs — these behaviors are built in rather than hand-assembled.
+
+## Licensing
+
+The package is commercial (annual, per-developer). Every instance must be wrapped in `VirtuosoMessageListLicense`:
+
+```tsx
+<VirtuosoMessageListLicense licenseKey={licenseKey}>
+  <VirtuosoMessageList ... />
+</VirtuosoMessageListLicense>
+```
+
+An empty `licenseKey=""` works as a 30-day non-production trial. Validation is local — no network requests. Surface this to the user when introducing the package into a project; keys come from <https://virtuoso.dev/pricing/>.
+
+## Core mental model: data updates carry scroll instructions
+
+Instead of separate imperative scroll calls, each data update includes a `scrollModifier` describing how the viewport should react:
+
+```tsx
+const [data, setData] = useState<VirtuosoMessageListProps<Message, null>['data']>(() => ({
+  data: initialMessages,
+  scrollModifier: { type: 'item-location', location: { index: 'LAST', align: 'end' } },
+}))
+
+<VirtuosoMessageList<Message, null> style={{ height: '100%' }} data={data} computeItemKey={({ data }) => data.key} ItemContent={ItemContent} />
+```
+
+`ItemContent` is a component receiving `{ data, index, context }` props (not positional arguments like react-virtuoso).
+
+### Scroll modifier reference
+
+| Modifier                                               | When to use                                                                                             |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- | ------ | -------------------------- |
+| `{ type: 'item-location', location, purgeItemSizes? }` | Initial load or channel switch; `purgeItemSizes: true` clears cached sizes when the items are different |
+| `{ type: 'auto-scroll-to-bottom', autoScroll }`        | New messages arrive; callback receives `{ atBottom, scrollInProgress, ... }` and returns `'smooth'      | 'auto' | false` or an item location |
+| `'prepend'`                                            | Older messages added to the top; keeps the current messages visually in place                           |
+| `{ type: 'items-change', behavior }`                   | Existing items changed size (streaming text, reactions); stays at bottom if already there               |
+| `'remove-from-start'` / `'remove-from-end'`            | Trimming data while preserving the visual position                                                      |
+| `null` / `undefined`                                   | Leave the scroll position alone                                                                         |
+
+## Common patterns
+
+### Receiving messages (auto-scroll when at bottom)
+
+```tsx
+setData((current) => ({
+  data: [...current.data, incoming],
+  scrollModifier: {
+    type: 'auto-scroll-to-bottom',
+    autoScroll: ({ atBottom, scrollInProgress }) => ({
+      index: 'LAST',
+      align: 'end',
+      behavior: atBottom || scrollInProgress ? 'smooth' : 'auto',
+    }),
+  },
+}))
+```
+
+Returning `false` from `autoScroll` when not at bottom is how you keep the viewport still and instead increment an unseen-messages counter.
+
+### Streaming an AI response
+
+Append an empty assistant message, then grow it as tokens arrive:
+
+```tsx
+setData((current) => ({
+  data: current.data.map((msg) => (msg.key === botKey ? { ...msg, text: msg.text + chunk } : msg)),
+  scrollModifier: { type: 'items-change', behavior: 'smooth' },
+}))
+```
+
+`items-change` keeps the view pinned to the bottom while the message grows, without jumping if the user scrolled up. See [ai-chatbot](references/3.examples/02.ai-chatbot.md) and [gemini](references/3.examples/03.gemini.md) (question pinned to top, answer streams below).
+
+### Loading older messages on scroll-up
+
+```tsx
+<VirtuosoMessageList
+  onScroll={(location) => {
+    if (location.listOffset > -100 && !loading) {
+      loadOlder().then((older) => setData((current) => ({ data: [...older, ...current.data], scrollModifier: 'prepend' })))
+    }
+  }}
+/>
+```
+
+No `firstItemIndex` bookkeeping is needed (unlike plain Virtuoso) — `'prepend'` preserves the position automatically.
+
+### Scroll-to-bottom button
+
+`StickyFooter` renders fixed at the bottom of the viewport; combine with the location hook:
+
+```tsx
+const StickyFooter = () => {
+  const location = useVirtuosoLocation()
+  const methods = useVirtuosoMethods()
+  if (location.bottomOffset <= 200) return null
+  return <button onClick={() => methods.scrollToItem({ index: 'LAST', align: 'end', behavior: 'auto' })}>▼</button>
+}
+```
+
+### Switching channels
+
+Keep one data object per channel and swap with `replace`/`item-location` + `purgeItemSizes: true`, so size caches from the previous channel don't distort the new one. See [multiple-channels](references/2.tutorial/07.multiple-channels.md).
+
+## Imperative API
+
+Via `ref={useRef<VirtuosoMessageListMethods<Message>>(null)}` from outside, or `useVirtuosoMethods()` from components rendered inside the list:
+
+- `data.append(items, scrollToBottom?)`, `data.prepend(items)`
+- `data.map(fn, autoscrollBehavior?)` — update items (reactions, edits, streaming)
+- `data.findAndDelete(predicate)`, `data.deleteRange(start, length)`, `data.replace(data, options?)`
+- `data.find(predicate)`, `data.findIndex(predicate)`, `data.get()`, `data.getCurrentlyRendered()`
+- `scrollToItem({ index: number | 'LAST', align, behavior })`
+
+The declarative `data` prop and the imperative `data.*` methods are alternative ways to drive the same list — pick one as the primary mechanism per component to avoid fighting updates.
+
+## Key props and hooks
+
+- `ItemContent: ({ data, index, context }) => JSX` — message renderer
+- `context` — shared state (current user, loading flags) available to `ItemContent` and all custom slots; avoids prop drilling
+- `computeItemKey({ data })` — stable message key; required for prepending/streaming to work without remounts
+- Slots: `Header`, `Footer` (scroll with content), `StickyHeader`, `StickyFooter` (fixed, measured to avoid overlap), `EmptyPlaceholder`
+- `initialLocation: { index: 'LAST', align: 'end' }` — start at the bottom
+- Hooks (inside the list): `useVirtuosoMethods()`, `useVirtuosoLocation()` (`atBottom`, `bottomOffset`, `listOffset`, `scrollInProgress`), `useCurrentlyRenderedData()`
+
+## Pitfalls
+
+- **No height → nothing renders.** The component needs a real height (`style={{ height: '100%' }}` with a sized parent).
+- **Missing `computeItemKey`** causes remounts and scroll jumps on prepend and streaming updates.
+- **Margins on message items** break height measurement (ResizeObserver excludes margins) — use padding.
+- **"ResizeObserver loop" errors are benign** — filter them in dev overlays and error tracking; see [resize-observer-errors](references/19.resize-observer-errors.md).
+- **JSDOM tests need mocked measurements** via `VirtuosoMessageListTestingContext.Provider value={{ itemHeight, viewportHeight }}` plus a ResizeObserver polyfill; prefer Playwright for scroll behavior. See [testing](references/11.testing.md).
+
+## References
+
+- [references/README.md](references/README.md) — overview and live example
+- `references/2.tutorial/` — step-by-step chat build: [intro](references/2.tutorial/01.intro.md), [message-list](references/2.tutorial/02.message-list.md), [loading-older-messages](references/2.tutorial/03.loading-older-messages.md), [scroll-to-bottom-button](references/2.tutorial/04.scroll-to-bottom-button.md), [receive-messages](references/2.tutorial/05.receive-messages.md), [send-messages](references/2.tutorial/06.send-messages.md), [multiple-channels](references/2.tutorial/07.multiple-channels.md)
+- `references/3.examples/` — [messaging](references/3.examples/01.messaging.md), [ai-chatbot](references/3.examples/02.ai-chatbot.md), [gemini](references/3.examples/03.gemini.md), [reactions](references/3.examples/04.reactions.md), [date-separators](references/3.examples/05.date-separators.md), [scroll-to-reply](references/3.examples/06.scroll-to-reply.md), [grouped-messages](references/3.examples/07.grouped-messages.md)
+- Feature guides: [headers-footers](references/4.headers-footers.md), [context](references/5.context.md), [item-keys](references/6.item-keys.md), [hooks](references/7.hooks.md), [custom-scrollbar](references/8.custom-scrollbar.md), [scrolling-to-item](references/9.scrolling-to-item.md), [smooth-scrolling](references/10.smooth-scrolling.md), [imperative-data-api](references/15.imperative-data-api.md), [scroll-modifier](references/20.scroll-modifier.md), [testing](references/11.testing.md), [licensing](references/80.licensing.md)
+
+Full API reference: <https://virtuoso.dev/message-list/>

--- a/skills/react-virtuoso/SKILL.md
+++ b/skills/react-virtuoso/SKILL.md
@@ -14,7 +14,6 @@ description: >-
 
 ```tsx
 import { Virtuoso } from 'react-virtuoso'
-
 ;<Virtuoso style={{ height: '100%' }} data={users} itemContent={(index, user) => <div>{user.name}</div>} />
 ```
 

--- a/skills/react-virtuoso/SKILL.md
+++ b/skills/react-virtuoso/SKILL.md
@@ -1,8 +1,179 @@
 ---
 name: react-virtuoso
-description: Placeholder - content authoring pending. This skill will provide agent guidance for the react-virtuoso package.
+description: >-
+  Build virtualized lists, grids, and tables with react-virtuoso. Use this skill when (1) rendering large or infinite lists,
+  (2) building grouped lists with sticky headers, (3) virtualizing HTML tables, (4) laying out same-sized items in a responsive grid,
+  (5) building feeds or logs that follow new items at the bottom, (6) diagnosing virtualization symptoms such as jumpy scrolling,
+  a list that does not scroll to the bottom, items overlapping, blank items, or "zero-sized element" errors, or (7) any task involving
+  Virtuoso, GroupedVirtuoso, VirtuosoGrid, TableVirtuoso, VirtuosoHandle, itemContent, followOutput, or firstItemIndex.
 ---
 
-# React Virtuoso Skill
+# react-virtuoso
 
-TODO: Author skill body. See references/ for source docs.
+`react-virtuoso` renders only the visible portion of large lists, grids, and tables. It measures item sizes automatically with ResizeObserver — variable item heights work out of the box, with no size configuration.
+
+```tsx
+import { Virtuoso } from 'react-virtuoso'
+
+;<Virtuoso style={{ height: '100%' }} data={users} itemContent={(index, user) => <div>{user.name}</div>} />
+```
+
+## Picking the right component
+
+| Need                                                                    | Use                                                                 |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Flat list, variable or fixed item heights                               | `Virtuoso`                                                          |
+| Groups with sticky group headers                                        | `GroupedVirtuoso`                                                   |
+| HTML table with virtualized rows                                        | `TableVirtuoso`                                                     |
+| Table with grouped rows and sticky group headers                        | `GroupedTableVirtuoso`                                              |
+| Same-sized items in a responsive multi-column grid                      | `VirtuosoGrid`                                                      |
+| Chat / AI conversation UI (streaming, stick-to-bottom, prepend history) | `@virtuoso.dev/message-list` — use the `message-list` skill instead |
+| Data grid with columns, sorting, filtering, column features             | `@virtuoso.dev/data-table` — use the `data-table` skill instead     |
+
+All components share the same core props (`data`/`totalCount`, `itemContent`, `components`, scroll callbacks, ref methods).
+
+## What you do NOT need to do
+
+Unlike TanStack Virtual or react-window, react-virtuoso measures items itself. Do not carry those libraries' patterns over:
+
+- No `estimateSize`, no `measureElement`, no `data-index` wiring — measurement is automatic.
+- No absolute positioning or `transform: translateY` on items — the library positions items.
+- No fixed `itemSize` requirement — variable heights are the default. If items genuinely have one uniform height, pass `fixedItemHeight` as a performance optimization only.
+- No windowing math — pass `data` (or `totalCount`) and render the item in `itemContent`.
+
+## Core rules
+
+- **The component needs a height.** Set `style={{ height: '100%' }}` (with a sized parent) or a fixed height. A zero-height container renders nothing.
+- **Never put CSS margins on items.** ResizeObserver reports `contentRect`, which excludes margins, so the computed total height comes up short — the classic symptom is a list that cannot scroll all the way to the bottom. Use padding instead. Watch for default margins on `<p>`, headings, `<ul>`, `<blockquote>`, `<pre>`.
+- **Use `data`, not `totalCount`, when you have the items.** With `data`, `itemContent={(index, item) => ...}` receives the item. Use `totalCount` only when items are derived from the index. Updates must produce a new array reference.
+- **Provide `computeItemKey={(index, item) => item.id}`** whenever the list can be prepended, reordered, or filtered. The default key is the index, which remounts items (losing state) when positions shift.
+- **Define `components` overrides outside the render function.** Inline definitions create a new component type each render, remounting the subtree on every scroll. `Scroller` and `List` overrides must forward `ref` to their DOM element.
+- **Item content must not render zero-height elements.** The error "zero-sized element, this should not happen" means an item measured 0px — filter empty items out of the data instead.
+
+## Common patterns
+
+### Infinite scrolling
+
+```tsx
+<Virtuoso data={items} endReached={() => loadMore()} itemContent={(index, item) => <Item item={item} />} />
+```
+
+`endReached` fires at the bottom; render a spinner via `components.Footer`. For "load more" on click, put the button in `Footer`.
+
+### Prepending items (reverse infinite scroll)
+
+Prepending naively makes the list jump. Instead, keep a `firstItemIndex` that you decrease by the number of prepended items:
+
+```tsx
+const [firstItemIndex, setFirstItemIndex] = useState(START)
+
+const prepend = (older: Item[]) => {
+  setFirstItemIndex((i) => i - older.length)
+  setItems((current) => [...older, ...current])
+}
+
+<Virtuoso firstItemIndex={firstItemIndex} initialTopMostItemIndex={START} data={items} startReached={prepend} ... />
+```
+
+`firstItemIndex` must stay a positive number, so start it large (e.g. `100000`). For `GroupedVirtuoso`, decrease it by the number of new items only, excluding the group headers. See [endless-scrolling](references/1.virtuoso/endless-scrolling.md).
+
+### Following new items (logs, feeds)
+
+```tsx
+<Virtuoso followOutput="smooth" data={messages} ... />
+```
+
+`followOutput` scrolls to new bottom items only when the user is already at the bottom. It accepts `'auto' | 'smooth' | false` or a function `(isAtBottom) => ...` for custom logic. For full chat UIs prefer `@virtuoso.dev/message-list`.
+
+### Scrolling programmatically
+
+```tsx
+const ref = useRef<VirtuosoHandle>(null)
+ref.current?.scrollToIndex({ index: 500, align: 'center', behavior: 'smooth' })
+```
+
+Also on the handle: `scrollIntoView` (only scrolls if not visible — right for keyboard navigation), `scrollTo`/`scrollBy` (pixel-based), and `getState` (snapshot for `restoreStateFrom` when remounting, e.g. back navigation).
+
+To start at an item, use `initialTopMostItemIndex={{ index, align: 'start' }}` — not `initialScrollTop`, which first renders at the top and then jumps.
+
+### Grouped lists
+
+```tsx
+<GroupedVirtuoso
+  groupCounts={[20, 30]} // items per group, in order
+  groupContent={(groupIndex) => <Header group={groups[groupIndex]} />}
+  itemContent={(index, groupIndex) => <Item item={items[index]} />} // index is absolute across all items
+/>
+```
+
+You provide flat data plus `groupCounts`; map indexes back to your data yourself.
+
+### Tables
+
+```tsx
+<TableVirtuoso
+  data={rows}
+  fixedHeaderContent={() => (
+    <tr>
+      <th>Name</th>
+    </tr>
+  )}
+  itemContent={(index, row) => (
+    <>
+      <td>{row.name}</td>
+    </>
+  )} // <td> cells only — the row <tr> is rendered for you
+/>
+```
+
+Do not set `border-collapse: collapse` on the table — the sticky header's borders scroll away with the body. Use `border-collapse: separate` with explicit cell borders. Customize structure via `components` (`Table`, `TableRow`, `TableHead`, `TableBody`).
+
+### Grid
+
+`VirtuosoGrid` virtualizes same-sized items in columns. You control column count with CSS — give `components.Item` a percentage width (`33%` for three columns, changed via media queries) and `components.List` `display: flex; flex-wrap: wrap`. See [grid-responsive-columns](references/3.virtuoso-grid/grid-responsive-columns.md).
+
+### Page-level scrolling
+
+Use `useWindowScroll` to drive the list from the document scroll, or `customScrollParent={element}` to attach to an existing scrollable ancestor. Pick exactly one scroll mode — combining them makes both containers scroll.
+
+### Testing
+
+JSDOM has no layout, so items will not render in Jest/Vitest without mocked measurements:
+
+```tsx
+render(<Virtuoso data={data} />, {
+  wrapper: ({ children }) => (
+    <VirtuosoMockContext.Provider value={{ viewportHeight: 300, itemHeight: 100 }}>{children}</VirtuosoMockContext.Provider>
+  ),
+})
+```
+
+Use `VirtuosoGridMockContext` (adds `viewportWidth`, `itemWidth`) for grids. Prefer real-browser tests (Playwright) for scroll behavior.
+
+## Troubleshooting
+
+| Symptom                                                                       | Likely cause                                                     | Fix                                                                                          |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Nothing renders                                                               | Container has zero height                                        | Give the component or its parent a real height                                               |
+| Cannot scroll to the last items / jumps near the bottom                       | Margins on item content                                          | Replace margins with padding                                                                 |
+| Items flicker or lose state while scrolling                                   | Inline `components` definitions or index-based keys              | Hoist components; add `computeItemKey`                                                       |
+| List jumps on prepend                                                         | Items added without `firstItemIndex` adjustment                  | Use the `firstItemIndex` prepend pattern                                                     |
+| "zero-sized element, this should not happen"                                  | An item rendered with zero height                                | Filter empty items from the data                                                             |
+| "ResizeObserver loop completed with undelivered notifications" overlay in dev | Benign ResizeObserver timing, surfaced by the dev-server overlay | Disable `runtimeErrors` in the webpack/vite overlay config; safe to filter in error tracking |
+| Hard-to-explain size behavior                                                 | —                                                                | Set `logLevel={LogLevel.DEBUG}` and watch the console with all levels enabled                |
+
+Tuning: `increaseViewportBy` renders extra pixels outside the viewport (smoother, more DOM); `defaultItemHeight` skips the initial probe render; `fixedItemHeight` skips measurement entirely (uniform items only); `scrollSeekConfiguration` swaps items for placeholders during fast scrolling.
+
+## References
+
+Detailed guides with full code in [references/](references/):
+
+- [references/README.md](references/README.md) — package overview and full feature list
+- `references/1.virtuoso/` — flat list guides: [basic-usage](references/1.virtuoso/basic-usage.md), [endless-scrolling](references/1.virtuoso/endless-scrolling.md), [press-to-load-more](references/1.virtuoso/press-to-load-more.md), [initial-index](references/1.virtuoso/initial-index.md), [scroll-to-index](references/1.virtuoso/scroll-to-index.md), [keyboard-navigation](references/1.virtuoso/keyboard-navigation.md), [customize-rendering](references/1.virtuoso/customize-rendering.md), [footer](references/1.virtuoso/footer.md), [top-items](references/1.virtuoso/top-items.md), [scroll-handling](references/1.virtuoso/scroll-handling.md), [range-change-callback](references/1.virtuoso/range-change-callback.md), [scroll-seek-placeholders](references/1.virtuoso/scroll-seek-placeholders.md), [auto-resizing](references/1.virtuoso/auto-resizing.md), [window-scrolling](references/1.virtuoso/window-scrolling.md), [custom-scroll-container](references/1.virtuoso/custom-scroll-container.md), [horizontal-mode](references/1.virtuoso/horizontal-mode.md)
+- `references/2.grouped-virtuoso/` — grouped lists: [grouped-numbers](references/2.grouped-virtuoso/grouped-numbers.md), [grouped-by-first-letter](references/2.grouped-virtuoso/grouped-by-first-letter.md), [scroll-to-group](references/2.grouped-virtuoso/scroll-to-group.md), [grouped-with-load-on-demand](references/2.grouped-virtuoso/grouped-with-load-on-demand.md)
+- `references/3.virtuoso-grid/` — [grid-responsive-columns](references/3.virtuoso-grid/grid-responsive-columns.md)
+- `references/4.table-virtuoso/` — tables: [basic-table](references/4.table-virtuoso/basic-table.md), [table-fixed-headers](references/4.table-virtuoso/table-fixed-headers.md), [table-fixed-columns](references/4.table-virtuoso/table-fixed-columns.md), [table-grouped](references/4.table-virtuoso/table-grouped.md)
+- `references/5.third-party-integration/` — [mocking-in-tests](references/5.third-party-integration/mocking-in-tests.md), [tanstack-table-integration](references/5.third-party-integration/tanstack-table-integration.md), [mui-table-virtual-scroll](references/5.third-party-integration/mui-table-virtual-scroll.md), [material-ui-endless-scrolling](references/5.third-party-integration/material-ui-endless-scrolling.md)
+- [references/6.troubleshooting.md](references/6.troubleshooting.md) — full troubleshooting guide
+
+Full API reference: <https://virtuoso.dev/react-virtuoso/>

--- a/skills/react-virtuoso/references/README.md
+++ b/skills/react-virtuoso/references/README.md
@@ -29,6 +29,12 @@ React components for efficiently rendering large lists, grids, and tables with v
 npm install react-virtuoso
 ```
 
+If you work with a coding agent (Claude Code, Codex, Cursor), install the [Virtuoso agent skills](https://virtuoso.dev/skills/) so it knows the component selection rules, measurement constraints, and common pitfalls:
+
+```bash
+npx skills add virtuoso-dev/skills --skill react-virtuoso
+```
+
 ## Quick Start
 
 ### Virtuoso

--- a/skills/reactive-engine/SKILL.md
+++ b/skills/reactive-engine/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: reactive-engine
+description: >-
+  Manage application state with the @virtuoso.dev/reactive-engine-* package family. Use this skill when (1) defining reactive state
+  with Cell, Stream, Trigger, or Resource nodes, (2) wiring React components through EngineProvider, useCellValue, useCellValues, or
+  usePublisher, (3) fetching data with Query and Mutation from reactive-engine-query, (4) routing with Route, Layout, and Guard from
+  reactive-engine-router, (5) persisting cells with linkCellToStorage, (6) architecting a component or library on top of the engine,
+  or (7) any task involving Engine, pub, sub, getValue, combine, pipe, link, changeWith, the e namespace, or the error
+  "No active engine found".
+---
+
+# Reactive Engine
+
+A reactive state system built on a graph of typed nodes. Five packages compose:
+
+| Package                                 | Provides                                                                                                            |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `@virtuoso.dev/reactive-engine-core`    | Nodes (`Cell`, `Stream`, `Trigger`, `Resource`, `DerivedCell`), `Engine`, operators, combinators, the `e` namespace |
+| `@virtuoso.dev/reactive-engine-react`   | `EngineProvider`, hooks (`useCellValue`, `usePublisher`, remote hooks)                                              |
+| `@virtuoso.dev/reactive-engine-query`   | `Query` and `Mutation` data fetching on top of nodes                                                                |
+| `@virtuoso.dev/reactive-engine-router`  | `Route`, `Layout`, `Guard`, `Router` — routes are nodes                                                             |
+| `@virtuoso.dev/reactive-engine-storage` | `linkCellToStorage` (localStorage / sessionStorage / cookie)                                                        |
+
+It also powers `@virtuoso.dev/data-table` internally — the same concepts apply when remote-controlling the table, and data-table's architecture is the reference for building on the engine ([building-on-the-engine](references/core/05.building-on-the-engine.md)).
+
+## Mental model: nodes are definitions, engines hold state
+
+Node constructors return inert references (symbols at runtime), defined at module scope with a `$` suffix. They hold no state. An `Engine` instance activates nodes lazily on first use and owns their values — two engines using the same node have independent state. This is what makes engine-based libraries reusable: one module-scope graph, one engine per component instance.
+
+```ts
+import { Cell, Stream, Engine, e } from '@virtuoso.dev/reactive-engine-core'
+
+const count$ = Cell(0)
+const engine = new Engine()
+engine.sub(count$, (value) => console.log('count:', value))
+engine.pub(count$, 1) // logs 'count: 1'
+```
+
+Node types — pick by statefulness:
+
+| Node                            | State                          | Use for                                       |
+| ------------------------------- | ------------------------------ | --------------------------------------------- |
+| `Cell(initial, distinct?)`      | Stateful, has a current value  | App state, settings                           |
+| `DerivedCell(initial, source$)` | Stateful, tracks a source      | Read-only computed state                      |
+| `Stream<T>(distinct?)`          | Stateless, emits values        | Events, commands                              |
+| `Trigger()`                     | Stateless, valueless           | "Something happened" signals (refetch, reset) |
+| `Resource(factory)`             | Factory-initialized per engine | Objects needing setup/disposal                |
+
+Nodes are distinct by default using **reference equality** (`===`): publishing the same reference (or an equal primitive) does not re-emit. Always publish new references from updates (`new Map(old)`, spread). Pass `false` to always emit, or a comparator `(prev, next) => boolean` (true = equal = suppress); `prev` is `undefined` on first emission.
+
+## The three API flavors (most important distinction)
+
+The same verbs exist in three forms — using the wrong one is the main source of errors:
+
+| Flavor                   | Examples                                               | Where                                             | Effect                                                           |
+| ------------------------ | ------------------------------------------------------ | ------------------------------------------------- | ---------------------------------------------------------------- |
+| Module-scope combinators | `link`, `pipe`, `sub`, `changeWith`, `combine` / `e.*` | Anywhere, incl. module top level                  | Deferred wiring, applied once per engine when the nodes activate |
+| Engine instance methods  | `engine.pub`, `engine.sub`, `engine.getValue`          | Wherever you hold an engine                       | Immediate, on that engine                                        |
+| Context-bound utilities  | standalone `pub`, `getValue`, `pubIn` / `e.pub`, ...   | Only inside subscription callbacks and node inits | Acts on the currently executing engine                           |
+
+Calling a context-bound utility elsewhere throws `No active engine found. You can use getValue only in the context of node subscription callbacks.` — fix by using `engine.*` methods, React hooks, or moving the code into a subscription. Note the asymmetry: standalone `sub`/`link`/`changeWith` are safe at module scope (they defer); standalone `pub`/`getValue` are not.
+
+The `e` export bundles all combinators, operators, and context utilities into one namespace — idiomatic for wiring blocks:
+
+```ts
+e.link(
+  e.pipe(
+    toggleTheme$,
+    e.withLatestFrom(theme$),
+    e.map(([, t]) => (t === 'light' ? 'dark' : 'light'))
+  ),
+  theme$
+)
+```
+
+## Wiring the graph
+
+- `link(source$, sink$)` — forward emissions; `pipe(source$, ...ops)` — derive a new node
+- `combine(a$, b$, ...)` — emit `[a, b, ...]` when ANY source emits; `withLatestFrom(...)` (operator) — read other nodes passively, emit only when the source emits
+- `changeWith(cell$, source$, (cell, value) => next)` — reducer-style cell update from a stream (return a new reference)
+- `sub`, `subMultiple`, `singletonSub` (replaces the previous singleton subscription — use for callbacks driven by React renders)
+- Operators: `map(fn, distinct?)`, `filter` (supports type guards), `mapTo`, `scan`, `once`, `throttleTime`, `debounceTime`, `delayWithMicrotask`, `onNext`, `handlePromise`
+
+Publishing is transactional: `engine.pubIn({ [a$]: 1, [b$]: 2 })` batches into one cycle; the graph executes in topological order, so diamond dependencies emit downstream exactly once with consistent inputs. Emissions are synchronous; there are no error/completion channels (exceptions abort the cycle — handle errors at the edges). Subscribing never replays a current value; read cells with `getValue` when needed. See [transactions](references/core/03.transactions.md).
+
+## React integration
+
+```tsx
+import { EngineProvider, useCellValue, usePublisher } from '@virtuoso.dev/reactive-engine-react'
+
+const Counter = () => {
+  const count = useCellValue(count$)
+  const setCount = usePublisher(count$)
+  return <button onClick={() => setCount(count + 1)}>{count}</button>
+}
+```
+
+- `useCellValue(cell$)` subscribes and re-renders; `useCellValues(a$, b$, ...)` returns a tuple with a single combined subscription (prefer it for cells that change together); `useCell` is the `useState` shape; `usePublisher(node$)` returns a stable publish function
+- `EngineProvider` props: `initFn(engine)` (one-time setup: register nodes, seed with `pubIn`, attach bridges), `initWith` (initial cell values), `updateFn`/`updateDeps` (re-publish changed props; use `singletonSub` for callback props so re-renders replace instead of stack), `engineId`, `engineRef`
+- Remote hooks (`useRemoteCellValue`, `useRemotePublisher`, `useRemoteCell`, `useRemoteCellValues`) reach another provider's engine via `useEngineRef()` or a string `engineId` — they return `undefined` until that engine mounts; guard for it
+- Components stay projection-only: read cells, publish actions. Logic lives in module-scope wiring, testable with a bare `Engine` and no React
+
+## Data fetching (reactive-engine-query)
+
+```ts
+export const tasksQuery = Query<{ listId: string }, Task[]>({
+  queryFn: async ({ listId }, signal) => {
+    const res = await fetch(`/api/tasks?listId=${listId}`, { signal })
+    if (!res.ok) throw new Error('Failed to fetch tasks')
+    return res.json()
+  },
+  initialParams: { listId: '' },
+})
+```
+
+`Query` returns nodes: `data$` (cell with `{ type: 'pending' | 'success' | 'error', data, error, isLoading, isFetching, ... }`), `params$` (publish to refetch with new params), `refetch$`, `invalidate$` (keep showing stale data, `isFetching: true`, re-execute), `unload$` (abort and clear), `enabled$`. Queries auto-execute on activation and param changes; each execution aborts the previous via the `signal`. Options: `retry` (default 3, exponential backoff), `refetchInterval`, `initialData`, `enabled`.
+
+`Mutation({ mutationFn, onSuccess?, onError? })` returns `data$`, `mutate$`, `reset$`. Mutations never auto-execute — publish params to `mutate$`. Wire mutations to refetch queries in the graph, not in components:
+
+```ts
+e.link(
+  e.pipe(
+    e.merge(createTask.data$, deleteTask.data$),
+    e.filter((r) => r.type === 'success'),
+    e.map(() => undefined, false) // distinct=false so consecutive successes each fire
+  ),
+  tasksQuery.refetch$
+)
+```
+
+## Routing (reactive-engine-router)
+
+```tsx
+export const user$ = Route('/users/{id:number}', UserPage) // params typed from the path
+const root = Layout('/', ({ children }) => <main>{children}</main>)
+
+<Router routes={[user$]} layouts={[root]} guards={[authGuard]} />
+```
+
+Route nodes emit typed params when matched, `null` otherwise. Navigate by publishing params to the route node (`usePublisher(user$)({ id: 42 })`). Pipe route params into query params to fetch on navigation. `Guard(pattern, fn)` runs on matching navigations — its context offers `continue()`, `navigate()`, `redirect()`; async guards render the route inside `Suspense`. Layouts match by URL prefix and nest by specificity; `LayoutSlotPortal`/`LayoutSlot`/`LayoutSlotFill` let pages fill layout regions. `Router` syncs with browser history by default.
+
+## Persistence (reactive-engine-storage)
+
+```ts
+linkCellToStorage(theme$, { storageType: 'localStorage', key: 'app-theme', debounceMs: 300 })
+```
+
+`storageType: 'localStorage' | 'sessionStorage' | 'cookie'` (cookie adds `cookieOptions`). Reads happen lazily, once per engine, when the engine first activates the cell; writes are debounced; localStorage links sync across tabs. The engine's `id` namespaces keys (`my-app:app-theme`) so multiple instances persist independently. SSR-safe (no-op without `window`).
+
+## Building a component or library on the engine
+
+Follow the data-table architecture ([full patterns](references/core/05.building-on-the-engine.md)):
+
+- Module-scope node graph + one engine per component instance (via `EngineProvider`)
+- Public API = action streams in (`setX$`, `resetX$`), state cells out (`xState$`, often `DerivedCell`); wiring stays internal
+- Props flow into cells via `pubIn` in `initFn`/`updateFn`; callback props via `singletonSub`
+- Optional features as separate modules (subpath exports) that attach wiring to core nodes — unused features cost nothing because inits are lazy
+- External control via `engineRef`/`engineId` + remote hooks against the exported nodes
+- Bridge imperative subsystems with subscribe-both-ways functions whose cleanup reaches `engine.onDispose`
+
+## Common mistakes
+
+- Calling standalone `pub`/`getValue`/`pubIn` outside a subscription callback — use `engine.*` methods or React hooks.
+- Mutating and republishing the same object — distinct is reference equality; nothing emits. Publish new references.
+- Expecting a node to hold state by itself — values live in an engine; the same `Cell` in two engines has two values.
+- Expecting `Stream` subscriptions to fire on subscribe with a current value — streams are stateless; only `Cell` has a value.
+- Piping into a trigger through `map` without `distinct: false` — consecutive identical mapped values get filtered.
+- Triggering a `Mutation` by changing params — mutations only run when params are published to `mutate$`.
+- Plain `sub` in code that re-runs with React renders — subscriptions accumulate; use `singletonSub`.
+- Creating cycles in the graph — cycles hang or loop; break one direction with an action stream or `delayWithMicrotask`.
+
+## References
+
+Guides in [references/](references/), per package:
+
+- `references/core/` — [core-concepts](references/core/01.core-concepts.md) (node types, distinct, the `e` namespace), [engine-and-lifecycle](references/core/02.engine-and-lifecycle.md) (activation, API flavors, child engines, disposal), [transactions](references/core/03.transactions.md) (cycles, topological execution, RxJS differences), [operators-and-combinators](references/core/04.operators-and-combinators.md) (full reference), [building-on-the-engine](references/core/05.building-on-the-engine.md) (architecture patterns from data-table), [README](references/core/README.md)
+- `references/react/` — [react-integration](references/react/01.react-integration.md) (EngineProvider lifecycle, hooks, remote hooks, SSR), [README](references/react/README.md)
+- `references/query/` — [queries-and-mutations](references/query/01.queries-and-mutations.md) (result states, lifecycle, wiring patterns), [README](references/query/README.md)
+- `references/router/` — [routing](references/router/01.routing.md) (path syntax, navigation, layouts, guards), [README](references/router/README.md)
+- `references/storage/` — [storage-links](references/storage/01.storage-links.md) (timing, namespacing, cross-tab sync), [README](references/storage/README.md)
+
+The JSDoc on the exported symbols in `@virtuoso.dev/reactive-engine-core` is extensive — when in doubt about a signature, read the type definitions shipped with the package.

--- a/skills/reactive-engine/references/core/01.core-concepts.md
+++ b/skills/reactive-engine/references/core/01.core-concepts.md
@@ -1,0 +1,113 @@
+---
+title: Core Concepts
+description: Nodes, engines, and the separation between graph definitions and runtime state.
+---
+
+The reactive engine models application logic as a graph of typed nodes. Two ideas carry everything else:
+
+1. **Nodes are definitions, not state.** A node constructor returns an inert reference — at runtime it is literally a `Symbol`. Creating a node records its definition (type, initial value, distinct behavior) in a global registry, but holds no value.
+2. **Engines hold state.** An `Engine` instance activates nodes on first use and owns their values. The same node used by two engines has two independent values.
+
+```ts
+import { Cell, Engine } from '@virtuoso.dev/reactive-engine-core'
+
+const count$ = Cell(0) // a definition, usually at module scope
+
+const a = new Engine()
+const b = new Engine()
+a.pub(count$, 5)
+a.getValue(count$) // 5
+b.getValue(count$) // 0 — independent state
+```
+
+This split is what makes the engine suitable for building reusable components: a library defines its node graph once at module scope, and every component instance gets its own engine — its own state — without re-declaring anything.
+
+## Node types
+
+| Node                            | State          | Emits                  | Use for                                            |
+| ------------------------------- | -------------- | ---------------------- | -------------------------------------------------- |
+| `Cell(initial, distinct?)`      | Current value  | On value change        | App state, configuration, derived values           |
+| `Stream<T>(distinct?)`          | None           | On publish             | Events, commands, transient data                   |
+| `Trigger()`                     | None           | On publish (valueless) | "Something happened" signals                       |
+| `Resource(factory)`             | Factory result | —                      | Per-engine objects with setup/teardown             |
+| `DerivedCell(initial, source$)` | Current value  | When the source emits  | Read-only computed state                           |
+| `Pipe<T>(...operators)`         | —              | —                      | An input/output node pair with a transform between |
+
+```ts
+import { Cell, Stream, Trigger, Resource } from '@virtuoso.dev/reactive-engine-core'
+
+const theme$ = Cell<'light' | 'dark'>('light')
+const keyPressed$ = Stream<string>()
+const reset$ = Trigger()
+const cache$ = Resource(() => ({
+  data: new Map<string, unknown>(),
+  dispose() {
+    this.data.clear()
+  },
+}))
+```
+
+A `Resource` factory runs once per engine, the first time the engine touches the node. On `engine.dispose()` the engine calls the instance's `[Symbol.dispose]()` if present, falling back to `dispose()`.
+
+`DerivedCell` is a cell whose value tracks a source expression:
+
+```ts
+import { DerivedCell, e } from '@virtuoso.dev/reactive-engine-core'
+
+const fahrenheit$ = DerivedCell(
+  32,
+  e.pipe(
+    celsius$,
+    e.map((c) => c * 1.8 + 32)
+  )
+)
+```
+
+Components read it like any cell; nothing can publish into it directly without going through the source.
+
+## Distinct semantics
+
+Every Cell and Stream filters duplicate emissions by default:
+
+- `true` (default) — compare with `===` (the `defaultComparator`; reference equality, not deep equality)
+- `false` — never filter; every publish emits
+- `(prev, next) => boolean` — custom comparator returning `true` when values are equal (suppress emission)
+
+```ts
+const user$ = Cell<User | null>(null, (prev, next) => prev?.id === next?.id)
+```
+
+Two consequences worth internalizing:
+
+- Because the default is reference equality, publishing a mutated object does not emit. Always publish new references (`new Map(old)`, spread), the same discipline React state requires.
+- The comparator receives `undefined` as `prev` on the first emission — write comparators with optional chaining.
+
+Triggers never filter; every publish fires.
+
+## The `e` namespace
+
+The package exports each operator and combinator individually, and also bundles them in a single `e` object — convenient when wiring many connections:
+
+```ts
+import { e } from '@virtuoso.dev/reactive-engine-core'
+
+e.link(
+  e.pipe(
+    toggleTheme$,
+    e.withLatestFrom(theme$),
+    e.map(([, current]) => (current === 'light' ? 'dark' : 'light'))
+  ),
+  theme$
+)
+```
+
+`e` contains the combinators (`link`, `pipe`, `combine`, `merge`, `sub`, `changeWith`, ...), the operators (`map`, `filter`, `scan`, ...), and the context-bound utilities (`pub`, `getValue`, `pubIn` — see [Engine and Lifecycle](./02.engine-and-lifecycle.md) for where those are allowed).
+
+## Naming conventions
+
+- Node references take a `$` suffix: `count$`, `setColumnVisibility$`.
+- Input streams that represent user actions read as commands: `resizeColumn$`, `toggleTheme$`.
+- State cells read as nouns: `theme$`, `scrollLocation$`.
+- Plain helper functions take no suffix.
+
+These conventions come from the packages built on the engine (data-table follows them throughout) and make the input/output boundary of a module visible at a glance.

--- a/skills/reactive-engine/references/core/02.engine-and-lifecycle.md
+++ b/skills/reactive-engine/references/core/02.engine-and-lifecycle.md
@@ -1,0 +1,108 @@
+---
+title: Engine and Lifecycle
+description: How engines activate nodes, the three API flavors, engine context, child engines, and disposal.
+---
+
+## Activation: how a node comes alive in an engine
+
+Nodes register lazily. The first time an engine touches a node — through `pub`, `sub`, `getValue`, `link`, or an explicit `engine.register(node$)` — the engine:
+
+1. Looks up the node's definition in the global registry and creates its state slot (or runs the `Resource` factory).
+2. Runs every **node init** attached to the node, once per engine, inside engine context.
+
+Node inits are the deferred-wiring mechanism. `addNodeInit(fn, ...nodes$)` attaches a function that runs when any of the listed nodes first activates in an engine:
+
+```ts
+import { addNodeInit } from '@virtuoso.dev/reactive-engine-core'
+
+addNodeInit((engine) => {
+  engine.link(source$, sink$)
+}, source$)
+```
+
+You rarely call `addNodeInit` directly — the module-scope combinators do it for you (next section). But understanding it explains the engine's central trick: _wiring declared at module scope applies to every engine that ever uses those nodes, paid for only when used._
+
+## The three API flavors
+
+The same verbs exist in three forms. Choosing the right one is most of the learning curve:
+
+| Flavor                   | Examples                                                        | Where it works                                    | What it does                                                                          |
+| ------------------------ | --------------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Module-scope combinators | `link`, `pipe`, `sub`, `changeWith`, `combine` (also via `e.*`) | Anywhere, including module top level              | Registers a node init — deferred wiring for **every** engine that activates the nodes |
+| Engine instance methods  | `engine.pub`, `engine.sub`, `engine.link`, `engine.getValue`    | Anywhere you hold an engine                       | Acts immediately on **that** engine                                                   |
+| Context-bound utilities  | `pub`, `getValue`, `pubIn` (standalone or via `e.*`)            | Only inside subscription callbacks and node inits | Acts on the currently executing engine                                                |
+
+```ts
+import { Cell, Stream, Engine, e } from '@virtuoso.dev/reactive-engine-core'
+
+const saveRequested$ = Stream<void>()
+const draft$ = Cell('')
+const save$ = Stream<string>()
+
+// Module scope: wiring for all engines, applied lazily
+e.sub(saveRequested$, () => {
+  // Context-bound: we are inside a subscription, an engine is active
+  e.pub(save$, e.getValue(draft$))
+})
+
+// Imperative code with an engine in hand
+const engine = new Engine()
+engine.pub(draft$, 'hello')
+engine.pub(saveRequested$)
+```
+
+Calling a context-bound utility outside engine context throws:
+
+```text
+No active engine found. You can use getValue only in the context of node subscription callbacks.
+```
+
+When you hit this error, the fix is one of: use the engine instance method, use a React hook (`useCellValue`, `usePublisher`), or move the code into a subscription/init where context exists.
+
+Note the asymmetry: standalone `sub`/`link`/`changeWith` are safe at module scope (they defer), but standalone `pub`/`getValue`/`pubIn` are not (they need a live engine). The subscription callback also receives the engine as a second argument — `sub(node$, (value, engine) => ...)` — when you prefer being explicit.
+
+## Engine construction
+
+```ts
+new Engine(initialValues?: Record<symbol, unknown>, id?: string, parentEngine?: Engine)
+```
+
+- `initialValues` — seed cell values, keyed by node: `new Engine({ [theme$]: 'dark' })`.
+- `id` — names the engine; used for storage key namespacing and the React engine registry.
+- `parentEngine` — creates a child engine (below).
+
+Key instance methods beyond the verbs already covered: `pubIn(values)` (batch several publishes into one transaction — see [Transactions](./03.transactions.md)), `subMultiple(nodes, cb)`, `singletonSub(node$, cb)`, `combineCells(cells)` (cached combination used by the React bindings), `register(node$)`, `onDispose(cb)`, `dispose()`, and the low-level `connect({ sources, pulls, sink, map })` that all operators reduce to.
+
+## singletonSub: subscriptions that replace themselves
+
+`engine.singletonSub(node$, callback)` keeps at most one subscription per node, replacing the previous one on each call. Regular `sub` subscriptions accumulate — calling `sub` in code that re-runs (React renders, update functions) leaks duplicate callbacks. `singletonSub` exists precisely for "the latest callback wins" situations, such as forwarding a node to a React prop:
+
+```ts
+// In an EngineProvider initFn AND updateFn — safe, replaces rather than stacks
+engine.singletonSub(onScroll$, onScroll)
+```
+
+`engine.resetSingletonSubs()` clears them all.
+
+## Child engines
+
+```ts
+const parent = new Engine()
+const child = new Engine({}, 'child-id', parent)
+```
+
+A child engine delegates operations on nodes the parent has registered: publishing or subscribing to a parent-owned node from the child reaches the parent's state, and parent emissions propagate into child subscriptions. Nodes the parent does not own activate locally in the child. Use child engines to scope a feature's state while still seeing shared application state.
+
+## Disposal
+
+`engine.dispose()`:
+
+- runs callbacks registered with `engine.onDispose(cb)`
+- disposes `Resource` instances (`[Symbol.dispose]()` or `dispose()`)
+- clears subscriptions and state; `engine.isDisposed` becomes `true`
+
+Anything that bridges the engine to the outside world (DOM listeners, timers, external stores) should register cleanup with `onDispose` at the point where the bridge is created. The React `EngineProvider` disposes its engine on unmount.
+
+## Debugging
+
+`debug(node$, 'label')` logs every emission of a node with the given label. Subscriptions also receive the engine, so ad-hoc inspection from a callback is `console.log(engine.getValue(other$))`.

--- a/skills/reactive-engine/references/core/03.transactions.md
+++ b/skills/reactive-engine/references/core/03.transactions.md
@@ -1,0 +1,56 @@
+---
+title: Transactions and Execution
+description: How publishing works - transactional cycles, topological ordering, and how the engine differs from RxJS.
+---
+
+## One publish, one cycle
+
+Every `engine.pub(node$, value)` runs a complete computation cycle, synchronously:
+
+1. The engine computes the **execution map**: a topological sort of every node reachable from the published node through the graph.
+2. It walks the map sources-before-sinks, computing each node's new value from the latest values of its inputs.
+3. Each node's distinct comparator decides whether it actually emits; nodes that don't emit prune their downstream.
+4. Subscriptions fire for every node that emitted, inside engine context.
+
+By the time `pub` returns, the whole graph is consistent and all subscriptions have run.
+
+## pubIn: batching into a single transaction
+
+`engine.pubIn({ [a$]: 1, [b$]: 2 })` publishes several nodes in **one** cycle. Derived nodes that depend on both inputs compute once, seeing both new values — instead of twice with an inconsistent intermediate state. Whenever you publish more than one related value, use `pubIn`:
+
+```ts
+engine.pubIn({
+  [data$]: rows,
+  [groupIndices$]: groups,
+})
+```
+
+## Diamond dependencies emit once
+
+Given `a$ → b$`, `a$ → c$`, and `(b$, c$) → d$`, publishing to `a$` makes `d$` emit exactly once per cycle, after both `b$` and `c$` computed. This is the property that makes derived state composable — you never observe a "glitch" where `d$` fires with one fresh and one stale input.
+
+## When distinct is checked
+
+The comparator runs during node computation, comparing against the node's current value. It is not a pre-publish check on the caller's side. Implications:
+
+- A `Cell` that receives the same value emits nothing downstream — derived nodes and subscriptions stay quiet.
+- `map(fn, distinct?)` takes its own distinct parameter; a derived node can filter duplicates even when its source always emits.
+- The comparator sees `prev === undefined` on a node's first computation.
+
+## Re-entrancy
+
+Publishing from inside a subscription starts a **nested cycle** — cycles are not queued or merged. This is allowed and common (a subscription reacting to one node by publishing another), but recursive publishes to the same node must terminate, or you have an infinite loop. To defer work to after the current cycle, route it through `delayWithMicrotask()`:
+
+```ts
+e.link(e.pipe(burst$, e.delayWithMicrotask()), settled$)
+```
+
+## Differences from RxJS
+
+If you come from RxJS (or urx), recalibrate on these points:
+
+- **No completion, no error channel.** Nodes never complete; exceptions in operators or subscriptions propagate to the publisher and abort the cycle. Handle errors at the edges — inside `queryFn`-style async work or subscription bodies — not in the graph.
+- **Synchronous by default.** Emissions happen during `pub`, not on a scheduler. Only `throttleTime`, `debounceTime`, `delayWithMicrotask`, and `handlePromise` introduce asynchrony.
+- **Subscribing does not replay.** Subscribing to a `Cell` does not invoke the callback with the current value — read it with `getValue` if needed at subscribe time. (The React hooks do this for you.) Streams have no current value at all; `getValue` on a stream returns `undefined`.
+- **No per-subscription operator chains.** Operators transform nodes into new nodes (`pipe` returns a `NodeRef`); they are part of the shared graph, not private to a subscriber.
+- **Promises resolve out of order.** `handlePromise` emits results as promises settle; a slow earlier request can emit after a fast later one. Abort or sequence-guard async work where ordering matters (the `Query` package does this for you).

--- a/skills/reactive-engine/references/core/04.operators-and-combinators.md
+++ b/skills/reactive-engine/references/core/04.operators-and-combinators.md
@@ -1,0 +1,68 @@
+---
+title: Operators and Combinators
+description: Reference for transforming and connecting nodes.
+---
+
+Combinators connect nodes; operators transform values inside a `pipe`. All are available as named exports and on the `e` namespace object. The module-scope forms register deferred wiring (applied per engine on activation); the `Engine` instance methods of the same names act immediately on one engine.
+
+## Combinators
+
+| Combinator                                                    | Purpose                                                                  |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `link(source$, sink$)`                                        | Forward every emission from source to sink                               |
+| `pipe(source$, ...operators)`                                 | Derive a new node by running emissions through operators                 |
+| `combine(a$, b$, ...)`                                        | Node emitting `[a, b, ...]` whenever any source emits (up to 22 sources) |
+| `merge(a$, b$, ...)`                                          | Node emitting each source's values individually                          |
+| `sub(node$, cb)`                                              | Subscribe; `cb(value, engine)`                                           |
+| `singletonSub(node$, cb)`                                     | Exclusive subscription — replaces the previous singleton on the node     |
+| `subMultiple([a$, b$], cb)`                                   | One callback over several nodes                                          |
+| `changeWith(cell$, source$, (cell, value) => next)`           | Update a cell from a stream, reducer-style                               |
+| `withResource(source$, resource$, (value, resource) => void)` | Side effect pairing emissions with a resource instance                   |
+
+`changeWith` is the workhorse for "action stream updates state cell":
+
+```ts
+e.changeWith(columnWidths$, resizeColumn$, (widths, { key, width }) => {
+  const next = new Map(widths)
+  next.set(key, width)
+  return next
+})
+```
+
+Return a **new** reference from the reducer — cells are distinct by reference equality, so mutating and returning the same Map emits nothing.
+
+## Operators
+
+| Operator                                    | Behavior                                                                                          |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `map(fn, distinct?)`                        | Transform each value; optional distinct filter on the output                                      |
+| `filter(predicate)`                         | Drop values failing the predicate; supports type-guard predicates for narrowing                   |
+| `mapTo(value)`                              | Replace every emission with a constant                                                            |
+| `scan((acc, value) => acc, seed)`           | Running accumulation                                                                              |
+| `once()`                                    | Pass only the first emission                                                                      |
+| `withLatestFrom(...nodes$)`                 | Append the latest values of other nodes to each source emission; emits only when the source emits |
+| `throttleTime(ms)`                          | Rate-limit emissions                                                                              |
+| `debounceTime(ms)`                          | Emit only after the source goes quiet for the duration                                            |
+| `delayWithMicrotask()`                      | Re-emit in a microtask, after the current cycle                                                   |
+| `onNext(buf$)`                              | Buffer the source value, emit `[buffered, value]` when `buf$` next emits                          |
+| `handlePromise(onLoad, onSuccess, onError)` | Expand a promise-emitting node into loading/success/error emissions                               |
+
+Two distinctions that prevent common mistakes:
+
+- `combine` vs `withLatestFrom`: `combine` emits when _any_ input changes; `withLatestFrom` only when the _source_ emits, with the other nodes read passively. Use `withLatestFrom` for "when the user clicks, read the current settings", `combine` for "recompute whenever anything changes".
+- `map(..., distinct)` vs node distinct: pass `false` as map's distinct when piping into a Trigger-like sink that must fire every time — for example mapping mutation successes to `undefined` for a refetch trigger:
+
+```ts
+e.link(
+  e.pipe(
+    e.merge(create.data$, remove.data$),
+    e.filter((r) => r.type === 'success'),
+    e.map(() => undefined, false) // without false, the second success would be filtered as a duplicate undefined
+  ),
+  tasksQuery.refetch$
+)
+```
+
+## The low-level primitive: connect
+
+Every operator and combinator reduces to `engine.connect({ sources, pulls, sink, map })`: when any node in `sources` emits, call `map(done)(...sourceValues, ...pullValues)`; calling `done(value)` proposes an emission on `sink` (still subject to the sink's distinct check). `pulls` are read passively without triggering. Reach for `connect` only when no operator combination expresses the dependency shape — it is the engine's assembly language.

--- a/skills/reactive-engine/references/core/05.building-on-the-engine.md
+++ b/skills/reactive-engine/references/core/05.building-on-the-engine.md
@@ -1,0 +1,142 @@
+---
+title: Building on the Engine
+description: Architecture patterns for components and libraries built on the reactive engine, extracted from @virtuoso.dev/data-table.
+---
+
+`@virtuoso.dev/data-table` is the largest production system built on the engine. Its architecture demonstrates the patterns that make engine-based components scale. Each pattern below is generic; data-table serves as the worked example.
+
+## Module-scope graph, per-instance engine
+
+Define the entire node graph and its wiring at module scope. Instantiate one engine per component instance. Because module-scope combinators register deferred inits, the wiring applies automatically to every engine that activates the nodes — and each instance's state stays isolated.
+
+```ts
+// feature module, module scope — runs once per import, applies to every engine
+export const setColumnVisibility$ = Stream<SetColumnVisibilityPayload>()
+export const resetColumnVisibility$ = Trigger()
+
+e.changeWith(
+  columnVisibilityOverrides$,
+  e.pipe(setColumnVisibility$, e.withLatestFrom(columns$)),
+  (overrides, [{ key, visible }, columns]) => {
+    /* return a new Map */
+  }
+)
+```
+
+Two tables on one page (`engineId="orders"` / `engineId="invoices"`) share this wiring but never share state.
+
+## Action streams in, state cells out
+
+Design a module's public API as a boundary of nodes:
+
+- **Inputs**: streams and triggers named as commands — `setColumnVisibility$`, `resizeColumn$`, `resetColumnOrder$`. The outside world publishes; it never writes state directly.
+- **Outputs**: cells (often `DerivedCell`) named as state — `columnVisibilityState$`, `scrollLocation$`. The outside world reads and subscribes; it cannot publish into a derived cell.
+
+The wiring between inputs and outputs is internal. This gives the module the same encapsulation a reducer gives a store: all state transitions are enumerable, and every consumer (React component, persistence adapter, test) goes through the same two node kinds.
+
+## Derived cells for computed state
+
+Represent any state computable from other state as a `DerivedCell` over `combine`:
+
+```ts
+export const columnVisibilityState$ = DerivedCell(
+  new Map<string, boolean>(),
+  e.pipe(
+    e.combine(columns$, columnVisibilityOverrides$),
+    e.map(([columns, overrides]) => new Map([...columns].map(([key, c]) => [key, overrides.get(key) ?? c.visible !== false])))
+  )
+)
+```
+
+Store only the minimal independent state (the overrides) and derive the rest. The transaction system guarantees derived cells never observe partially-updated inputs.
+
+## React props flow in through initFn/updateFn; callbacks flow out through singletonSub
+
+The component shell is thin: an `EngineProvider` that pushes props into cells and forwards node emissions to callback props.
+
+```tsx
+<EngineProvider
+  initFn={(e) => {
+    e.register(columns$) // activate nodes whose inits must run eagerly
+    e.pubIn({ [context$]: context, [computeRowKey$]: computeRowKey })
+    e.singletonSub(onScroll$, onScroll)
+  }}
+  updateFn={(e) => {
+    e.pubIn({ [context$]: context, [computeRowKey$]: computeRowKey })
+    e.singletonSub(onScroll$, onScroll) // replaces, never stacks
+  }}
+  updateDeps={[context, computeRowKey, onScroll]}
+  engineId={engineId}
+  engineRef={engineRef}
+>
+```
+
+- `initFn` runs once at engine creation: register nodes, seed cells with `pubIn`, attach bridges.
+- `updateFn` runs whenever `updateDeps` change: re-publish the changed props. Distinct cells make redundant publishes free.
+- Callback props always go through `singletonSub` so re-renders replace the subscription instead of accumulating duplicates.
+
+Inside the component tree, rendering is just `useCellValue(cell$)` and event handlers are just `usePublisher(action$)` — components contain no logic, only projection.
+
+## Batch related publishes with pubIn
+
+When several cells change together (a data result and its group indices; a set of props), publish them in one `pubIn` transaction so derived nodes compute once with a consistent view.
+
+## Feature modules as opt-in subpath exports
+
+Each optional feature lives in its own module exporting its action streams, state cells, pure helper converters, and UI fragments — published as a package subpath (`@virtuoso.dev/data-table/column-visibility`). The core never imports features; features import core nodes and attach wiring. Because wiring is deferred inits, an unused feature costs nothing: its inits never run in engines that never touch its nodes.
+
+## Remote control: engineRef and engineId
+
+Because state lives in an engine rather than React state, external UI does not need prop drilling or lifted state. The component accepts an identity (`engineRef` from `useEngineRef()` for nearby UI, string `engineId` for distant UI), and external components use remote hooks against the exported nodes:
+
+```tsx
+const scrollToRow = useRemotePublisher(scrollToRow$, engineRef)
+const location = useRemoteCellValue(scrollLocation$, engineRef)
+```
+
+The public node set defines exactly what external control is possible. Remote hooks return `undefined` until the target engine mounts — design consumers to tolerate that.
+
+## Bridging imperative systems
+
+Non-reactive subsystems (data sources, network layers) connect through a bridge: a function that subscribes both directions and returns a cleanup, registered with `engine.onDispose`.
+
+```ts
+function bridgeModelToEngine(model: DataModelHandle, engine: Engine): () => void {
+  const unsubModel = model.subscribe((msg) => {
+    engine.pubIn({ [data$]: msg.rows, [groupIndices$]: msg.groups })
+  })
+  const unsubViewport = engine.sub(viewportRange$, (range) => {
+    model.send({ action: 'viewportChange', payload: range })
+  })
+  return () => {
+    unsubModel()
+    unsubViewport()
+  }
+}
+```
+
+The engine side stays declarative (cells and streams); the imperative side keeps its own protocol. data-table uses this to keep its data models (`localModel`, `remoteModel`) engine-free and independently testable.
+
+## Persistence adapters
+
+Persisting feature state generalizes into an adapter interface that each feature implements with its own pure serializers:
+
+```ts
+interface PersistenceAdapter<State> {
+  key: string
+  capture(context, previous: State | null): State // engine state -> storable shape
+  restore(context, state: State | null): void // storable shape -> publishes into the engine
+  subscribe(context, onChange): () => void // watch the nodes that mean "state changed, save it"
+  subscribeRestore?(context, onChange): () => void // watch the nodes that mean "re-apply saved state"
+}
+```
+
+An orchestrator component owns the storage, debounces writes, restores on mount, and knows nothing about any feature. Note the two subscription channels: `subscribe` watches user actions (save triggers), `subscribeRestore` watches structural changes like the column set (re-apply triggers). For simple cases — one cell, one storage key — skip the adapter machinery and use `linkCellToStorage` from `@virtuoso.dev/reactive-engine-storage`.
+
+## Invariants to respect
+
+- **Register dependency nodes before attaching bridges** in `initFn` — wiring inits must be in place before data starts flowing.
+- **Always return new references from reducers** (`changeWith`, `map`) — distinct is reference equality.
+- **Every bridge returns a cleanup**, and every cleanup reaches `engine.onDispose` (or the provider's unmount path).
+- **Keep the graph acyclic.** If two cells must influence each other, route one direction through an action stream or `delayWithMicrotask`.
+- **`singletonSub` for anything driven by React renders**; plain `sub` only in module wiring and inits.

--- a/skills/reactive-engine/references/core/README.md
+++ b/skills/reactive-engine/references/core/README.md
@@ -1,0 +1,46 @@
+# Reactive Engine Core
+
+`@virtuoso.dev/reactive-engine-core` is a framework-agnostic reactive state engine. State is modeled as a graph of typed nodes — stateful cells, stateless streams, and valueless triggers — connected through operators and combinators. An `Engine` instance activates the graph, propagates values, and manages subscriptions.
+
+The package is part of the Reactive Engine family:
+
+- [`@virtuoso.dev/reactive-engine-react`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-react) - React bindings (provider and hooks)
+- [`@virtuoso.dev/reactive-engine-query`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-query) - data fetching with queries and mutations
+- [`@virtuoso.dev/reactive-engine-router`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-router) - routing with routes, layouts, and guards
+- [`@virtuoso.dev/reactive-engine-storage`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-storage) - cell persistence in local/session storage or cookies
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core
+```
+
+## Quick Example
+
+```ts
+import { Cell, Engine } from '@virtuoso.dev/reactive-engine-core'
+
+const count$ = Cell(0)
+const engine = new Engine()
+
+engine.sub(count$, (value) => {
+  console.log('count is now', value)
+})
+
+engine.pub(count$, 1)
+engine.getValue(count$) // 1
+```
+
+## Concepts
+
+- **Cells** are stateful nodes that always hold a current value.
+- **Streams** are stateless nodes that emit values to their subscribers.
+- **Triggers** are valueless streams used to signal events.
+- **Resources** are cells with factory initialization and automatic disposal.
+- **Operators** (`map`, `filter`, `scan`, `debounceTime`, `throttleTime`, `withLatestFrom`, and more) transform values as they flow between nodes.
+- **Combinators** (`link`, `pipe`, `combine`, `merge`) wire nodes into a graph.
+- **Engine** instances activate node definitions, propagate published values, and manage subscriptions.
+
+## License
+
+MIT

--- a/skills/reactive-engine/references/query/01.queries-and-mutations.md
+++ b/skills/reactive-engine/references/query/01.queries-and-mutations.md
@@ -1,0 +1,124 @@
+---
+title: Queries and Mutations
+description: Data fetching as nodes - lifecycle, result states, retries, and wiring patterns.
+---
+
+`@virtuoso.dev/reactive-engine-query` expresses data fetching as engine nodes, so queries compose with the rest of the graph: route params can drive query params, mutation successes can trigger refetches, and components consume results with `useCellValue` like any other state.
+
+## Query
+
+```ts
+export const tasksQuery = Query<{ listId: string }, Task[]>({
+  queryFn: async ({ listId }, signal) => {
+    const res = await fetch(`/api/tasks?listId=${listId}`, { signal })
+    if (!res.ok) throw new Error('Failed to fetch tasks')
+    return res.json()
+  },
+  initialParams: { listId: '' },
+})
+```
+
+`Query()` returns a bundle of nodes:
+
+| Node          | Kind    | Role                                                        |
+| ------------- | ------- | ----------------------------------------------------------- |
+| `data$`       | Cell    | The query result (discriminated union below)                |
+| `params$`     | Cell    | Publishing new params re-executes the query                 |
+| `refetch$`    | Trigger | Re-execute with current params                              |
+| `invalidate$` | Trigger | Mark stale: keep showing data, set `isFetching`, re-execute |
+| `unload$`     | Trigger | Abort, clear data, return to pending                        |
+| `enabled$`    | Cell    | Gate execution; toggling to `true` executes                 |
+
+Options: `enabled` (default `true`), `retry` (default `3`; `retry: 3` means up to 4 attempts), `retryDelay` (default exponential backoff capped at 30s), `refetchInterval` (polling, starts after a successful fetch), `initialData`.
+
+### Result shape
+
+`data$` emits one of three states, discriminated on `type`:
+
+```ts
+{ type: 'pending', data: null,  isLoading: true,  isFetching: true,  isSuccess: false, isError: false, error: null }
+{ type: 'success', data: T,     isLoading: false, isFetching: boolean, isSuccess: true,  isError: false, error: null, dataUpdatedAt: number }
+{ type: 'error',   data: null,  isLoading: false, isFetching: false, isSuccess: false, isError: true,  error: unknown }
+```
+
+`isFetching: true` inside the success state means a background refresh is in flight while stale data stays visible — that is what `invalidate$` produces, versus `unload$` which drops to pending.
+
+### Lifecycle rules
+
+- A query executes when its `data$` first activates in an engine (if enabled), whenever `params$` emits (if enabled), on `refetch$`/`invalidate$`, and when `enabled$` flips to `true`.
+- Each execution aborts the previous in-flight request — the `signal` passed to `queryFn` must reach the actual fetch.
+- Disabling aborts in-flight work and stops polling.
+- Query state is per engine, like all node state; the same query in two engines fetches independently.
+
+## Mutation
+
+```ts
+export const createTask = Mutation<{ listId: string; title: string }, Task>({
+  mutationFn: async (params) => {
+    /* POST */
+  },
+})
+```
+
+Returns `data$` (states `idle | pending | success | error`, with `isPending`/`isSuccess`/`isError` flags), `mutate$` (publish params to execute), and `reset$` (back to idle). Mutations never auto-execute and don't retry by default. `onSuccess(data)`/`onError(error)` callbacks fire after the state publish.
+
+```tsx
+const create = usePublisher(createTask.mutate$)
+const result = useCellValue(createTask.data$)
+
+<button disabled={result.isPending} onClick={() => create({ listId, title })}>Add</button>
+```
+
+## Wiring patterns
+
+**Mutations trigger refetches in the graph, not in components.** Declare the relationship once at module scope:
+
+```ts
+e.link(
+  e.pipe(
+    e.merge(createTask.data$, updateTask.data$, deleteTask.data$),
+    e.filter((r) => r.type === 'success'),
+    e.map(() => undefined, false) // distinct=false: consecutive successes must each fire
+  ),
+  tasksQuery.refetch$
+)
+```
+
+**Routes drive query params.** A route node emits its params when matched; pipe it into `params$`:
+
+```ts
+e.link(
+  e.pipe(
+    tasks$, // Route('/lists/{id:string}', TasksPage)
+    e.filter((params) => params !== null),
+    e.map((params) => ({ listId: params.id }))
+  ),
+  tasksQuery.params$
+)
+```
+
+Navigation then transparently refetches — no effect hooks, no param threading through components.
+
+**Dependent queries** gate on their prerequisite:
+
+```ts
+e.link(
+  e.pipe(
+    userQuery.data$,
+    e.map((r) => r.type === 'success')
+  ),
+  ordersQuery.enabled$
+)
+```
+
+## Rendering results
+
+Branch on the discriminated union:
+
+```tsx
+const result = useCellValue(tasksQuery.data$)
+
+if (result.isLoading) return <Spinner />
+if (result.isError) return <ErrorView error={result.error} />
+return <TaskList tasks={result.data} refreshing={result.isFetching} />
+```

--- a/skills/reactive-engine/references/query/README.md
+++ b/skills/reactive-engine/references/query/README.md
@@ -1,0 +1,41 @@
+# Reactive Engine Query
+
+`@virtuoso.dev/reactive-engine-query` adds data fetching to [`@virtuoso.dev/reactive-engine-core`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-core). Queries and mutations are reactive nodes: parameters flow in, and pending/success/error results flow out to the rest of the graph.
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core @virtuoso.dev/reactive-engine-query
+```
+
+## Quick Example
+
+```ts
+import { Query } from '@virtuoso.dev/reactive-engine-query'
+
+interface Task {
+  id: string
+  title: string
+}
+
+export const tasksQuery = Query<{ listId: string }, Task[]>({
+  queryFn: async ({ listId }, signal) => {
+    const res = await fetch(`/api/tasks?listId=${listId}`, { signal })
+    if (!res.ok) {
+      throw new Error('Failed to fetch tasks')
+    }
+    return res.json()
+  },
+  initialParams: { listId: '' },
+})
+```
+
+## Features
+
+- `Query` - parameterized async reads with abort signal support, retries, and typed pending/success/error results
+- `Mutation` - async writes with typed idle/pending/success/error results
+- `executeWithRetry` / `defaultRetryDelay` - retry utilities used by both
+
+## License
+
+MIT

--- a/skills/reactive-engine/references/react/01.react-integration.md
+++ b/skills/reactive-engine/references/react/01.react-integration.md
@@ -1,0 +1,93 @@
+---
+title: React Integration
+description: EngineProvider lifecycle, hooks, and remote engine access.
+---
+
+## EngineProvider
+
+`EngineProvider` creates an engine when it mounts, provides it through context, and disposes it on unmount. While the provider is mounted, the engine is the source of truth; React components project its state.
+
+```tsx
+<EngineProvider
+  initWith={{ [theme$]: 'dark' }} // seed cell values at construction
+  initFn={(engine) => {
+    /* one-time setup: register nodes, bridges, singleton subs */
+  }}
+  updateFn={(engine) => {
+    /* re-publish changed props */
+  }}
+  updateDeps={[propA, propB]}
+  engineId="my-feature" // optional: global registry + storage namespacing
+  engineRef={engineRef} // optional: handle for remote hooks
+>
+  {children}
+</EngineProvider>
+```
+
+Lifecycle details that matter:
+
+- The engine is created in a `useState` initializer and `initFn` runs synchronously right after — before the first render of children.
+- `updateFn` runs in a layout effect whenever `updateDeps` change (including once after mount). It is independent of `initFn`; both should be written idempotently. Use `pubIn` for prop values (distinct cells absorb no-op republishes) and `singletonSub` for callback props.
+- On unmount the engine is disposed and (if set) removed from the registry/ref.
+- Nesting providers shadows the engine context — `useEngine()` returns the nearest provider's engine. Providers do not automatically parent-link; coordinate separate engines through remote hooks or construct child engines yourself.
+
+## Hooks
+
+| Hook                         | Returns                             | Notes                                                                                |
+| ---------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------ |
+| `useCellValue(cell$)`        | Current value, re-renders on change | Backed by `useSyncExternalStore`; SSR-safe                                           |
+| `useCellValues(a$, b$, ...)` | Tuple of values                     | Single subscription via a combined cell — one re-render when several change together |
+| `useCell(cell$)`             | `[value, publish]`                  | The `useState` shape                                                                 |
+| `usePublisher(node$)`        | Stable `(value) => void`            | Safe in effect dependency arrays                                                     |
+| `useEngine()`                | The provider's engine               | For imperative escape hatches                                                        |
+| `useEngineRef()`             | A stable `EngineRef`                | Pass to a provider's `engineRef` and to remote hooks                                 |
+
+Prefer `useCellValues` over several `useCellValue` calls when a component reads multiple cells that change in the same transaction — it collapses them into one re-render.
+
+## Remote hooks: reaching an engine from outside its tree
+
+Remote hooks accept an `EngineSource` — an `EngineRef` or a string `engineId` — and resolve the engine through the ref or a global registry:
+
+```tsx
+const value = useRemoteCellValue(scrollLocation$, engineRef)
+const publish = useRemotePublisher(scrollToRow$, 'orders-table')
+const [v, setV] = useRemoteCell(theme$, engineRef)
+const values = useRemoteCellValues({ cells: [a$, b$], engineSource: engineRef })
+```
+
+The defining behavior: **remote hooks return `undefined` until the target engine exists**. They subscribe to the ref/registry and start delivering values as soon as the provider mounts. Guard accordingly:
+
+```tsx
+const location = useRemoteCellValue(scrollLocation$, engineRef)
+if (location === undefined) return null // table not mounted yet
+```
+
+Use an `engineRef` when the controlling UI and the provider share a component (a toolbar next to its table); use an `engineId` when they are far apart and threading a ref is impractical. The id registry is global to the page — namespace ids if several independent features use them.
+
+## SSR
+
+`useCellValue` provides a server snapshot through `useSyncExternalStore`, so server rendering reads the engine's initial values. Reading a cell during render must stay side-effect free. Effect-timing hooks use a layout effect in the browser and a regular effect on the server (`useIsomorphicLayoutEffect`).
+
+## Component patterns
+
+Keep components projection-only:
+
+```tsx
+const VisibilityMenu = () => {
+  const visibility = useCellValue(columnVisibilityState$)
+  const setVisibility = usePublisher(setColumnVisibility$)
+
+  return (
+    <>
+      {[...visibility].map(([key, visible]) => (
+        <label key={key}>
+          <input type="checkbox" checked={visible} onChange={(ev) => setVisibility({ key, visible: ev.target.checked })} />
+          {key}
+        </label>
+      ))}
+    </>
+  )
+}
+```
+
+Logic — what a visibility change means, how it composes with declarations — lives in the module-scope wiring, where it is shared by every instance and testable with a bare `Engine` and no React at all.

--- a/skills/reactive-engine/references/react/README.md
+++ b/skills/reactive-engine/references/react/README.md
@@ -1,0 +1,45 @@
+# Reactive Engine React
+
+`@virtuoso.dev/reactive-engine-react` provides React bindings for [`@virtuoso.dev/reactive-engine-core`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-core): an `EngineProvider` component and hooks for reading cell values and publishing into nodes from components.
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core @virtuoso.dev/reactive-engine-react
+```
+
+## Quick Example
+
+```tsx
+import { Cell } from '@virtuoso.dev/reactive-engine-core'
+import { EngineProvider, useCellValue, usePublisher } from '@virtuoso.dev/reactive-engine-react'
+
+const count$ = Cell(0)
+
+function Counter() {
+  const count = useCellValue(count$)
+  const setCount = usePublisher(count$)
+
+  return <button onClick={() => setCount(count + 1)}>{count}</button>
+}
+
+export function App() {
+  return (
+    <EngineProvider>
+      <Counter />
+    </EngineProvider>
+  )
+}
+```
+
+## Hooks
+
+- `useCellValue` / `useCellValues` - subscribe to one or several cells
+- `useCell` - read a cell value and get a publisher for it
+- `usePublisher` - get a publisher function for a node
+- `useEngine` / `useEngineRef` - access the engine instance from context
+- `useRemoteCell`, `useRemoteCellValue`, `useRemoteCellValues`, `useRemotePublisher` - work with cells from another engine instance
+
+## License
+
+MIT

--- a/skills/reactive-engine/references/router/01.routing.md
+++ b/skills/reactive-engine/references/router/01.routing.md
@@ -68,7 +68,7 @@ Layouts match by URL prefix and nest by specificity — `Layout('/')` wraps ever
 ## Guards
 
 ```tsx
-const authGuard = Guard('/admin/*', (context) => {
+const authGuard = Guard('/admin', (context) => {
   const user = context.engine.getValue(currentUser$)
   if (!user) {
     return context.redirect(login$, {})

--- a/skills/reactive-engine/references/router/01.routing.md
+++ b/skills/reactive-engine/references/router/01.routing.md
@@ -1,0 +1,99 @@
+---
+title: Routing
+description: Typed routes as nodes, navigation, layouts, guards, and browser history.
+---
+
+`@virtuoso.dev/reactive-engine-router` represents each route as a node. A route node emits its parsed params when the route is active and `null` when it is not — which makes routing composable with the rest of the graph (drive query params from routes, gate features on the active route).
+
+## Defining routes
+
+```tsx
+import { Route } from '@virtuoso.dev/reactive-engine-router'
+
+export const home$ = Route('/', HomePage)
+export const user$ = Route('/users/{id:number}', UserPage)
+export const blog$ = Route('/blog/{slug}/?category={category?}&tag={tag?}', BlogPage)
+export const files$ = Route('/files/{*rest}', FilesPage)
+```
+
+The path syntax is parsed at the type level — params arrive typed:
+
+- `{id:number}` → `{ id: number }`; `{slug}` defaults to string
+- `?q={query}&limit={limit?:number}` → optional search params under `$search`
+- `{*rest}` → catch-all, `string[]`
+
+The route component receives the params as props, typed as `RouteParams<'/users/{id:number}'>`:
+
+```tsx
+export const UserPage: React.ComponentType<RouteParams<'/users/{id:number}'>> = ({ id }) => <h1>User {id}</h1>
+```
+
+## Mounting and navigating
+
+```tsx
+<EngineProvider>
+  <Router routes={[home$, user$, blog$]} layouts={[rootLayout]} guards={[authGuard]} />
+</EngineProvider>
+```
+
+`Router` needs an engine (mount it inside an `EngineProvider`). Props: `routes`, `layouts`, `guards`, `basePath`, `useBrowserHistory` (default `true` — syncs with the address bar and back/forward buttons).
+
+Navigation is publishing params to a route node:
+
+```tsx
+const goToUser = usePublisher(user$)
+goToUser({ id: 42 }) // navigates to /users/42
+```
+
+Since route nodes are also outputs, the same node tells you whether the route is active:
+
+```tsx
+const userParams = useCellValue(user$) // null when not on /users/...
+```
+
+## Layouts
+
+```tsx
+const rootLayout = Layout('/', ({ children }) => (
+  <main>
+    <Nav />
+    {children}
+  </main>
+))
+const blogLayout = Layout('/blog', ({ children }) => <BlogShell>{children}</BlogShell>)
+```
+
+Layouts match by URL prefix and nest by specificity — `Layout('/')` wraps everything, `Layout('/blog')` wraps inside it for blog routes. For regions a route fills inside a layout (a context-dependent sidebar), create a slot cell with `LayoutSlotPortal()`, render it in the layout with `<LayoutSlot slotPortal={...}>`, and provide content from a page with `<LayoutSlotFill slotPortal={...}>`.
+
+## Guards
+
+```tsx
+const authGuard = Guard('/admin/*', (context) => {
+  const user = context.engine.getValue(currentUser$)
+  if (!user) {
+    return context.redirect(login$, {})
+  }
+  return context.continue()
+})
+```
+
+- A guard's pattern uses route syntax; all guards matching the target URL run in order (priority option, then specificity, then registration order).
+- The context offers `continue()`, `navigate(urlOrRoute, params?)` (retarget and keep evaluating guards against the new URL), `redirect(urlOrRoute, params?)` (abort and navigate), plus `params`, `location`, and `engine`.
+- Guards may be async — the route renders inside `Suspense` while pending, so provide a Suspense boundary above the `Router`.
+
+## Wiring routes into the graph
+
+The canonical pattern — route activation drives data fetching:
+
+```ts
+e.link(
+  e.pipe(
+    user$,
+    e.filter((params) => params !== null),
+    e.map((params) => ({ userId: params.id }))
+  ),
+  userQuery.params$
+)
+```
+
+Pages then need no fetch logic at all: navigating publishes params, params trigger the query, the page reads `userQuery.data$`.

--- a/skills/reactive-engine/references/router/README.md
+++ b/skills/reactive-engine/references/router/README.md
@@ -1,0 +1,51 @@
+# Reactive Engine Router
+
+`@virtuoso.dev/reactive-engine-router` is a router built on [`@virtuoso.dev/reactive-engine-core`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-core). Routes are reactive nodes - navigation is publishing into a route node, and the current route flows through the graph like any other value.
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core @virtuoso.dev/reactive-engine-react @virtuoso.dev/reactive-engine-router
+```
+
+## Quick Example
+
+```tsx
+import { usePublisher } from '@virtuoso.dev/reactive-engine-react'
+import { Layout, Router } from '@virtuoso.dev/reactive-engine-router'
+
+import { about$, home$ } from './routes'
+
+const rootLayout = Layout('/', ({ children }) => (
+  <div>
+    <Navigation />
+    <main>{children}</main>
+  </div>
+))
+
+function Navigation() {
+  const goHome = usePublisher(home$)
+  const goToAbout = usePublisher(about$)
+
+  return (
+    <nav>
+      <button onClick={() => goHome({})}>Home</button>
+      <button onClick={() => goToAbout({})}>About</button>
+    </nav>
+  )
+}
+
+export function App() {
+  return <Router layouts={[rootLayout]} routes={[home$, about$]} />
+}
+```
+
+## Features
+
+- **Routes** - typed route definitions with parameters
+- **Layouts** - nested layout components matched by path, with slot/fill composition (`LayoutSlot`, `LayoutSlotFill`)
+- **Guards** - sync or async navigation guards that can continue, redirect, or navigate elsewhere
+
+## License
+
+MIT

--- a/skills/reactive-engine/references/storage/01.storage-links.md
+++ b/skills/reactive-engine/references/storage/01.storage-links.md
@@ -1,0 +1,47 @@
+---
+title: Storage Links
+description: Persisting cells to localStorage, sessionStorage, and cookies.
+---
+
+`linkCellToStorage` keeps a cell in sync with browser storage. Declare it at module scope next to the cell:
+
+```ts
+import { Cell } from '@virtuoso.dev/reactive-engine-core'
+import { linkCellToStorage } from '@virtuoso.dev/reactive-engine-storage'
+
+export const theme$ = Cell<'light' | 'dark'>('light')
+
+linkCellToStorage(theme$, {
+  storageType: 'localStorage',
+  key: 'app-theme',
+  debounceMs: 300,
+})
+```
+
+Options form a union on `storageType`:
+
+- `'localStorage'` / `'sessionStorage'` — `{ key, debounceMs?, serialize?, deserialize? }`
+- `'cookie'` — additionally `cookieOptions`: `{ expires?: Date | '7d' | '1h' | '30m', path?, domain?, sameSite?, secure? }`
+
+Serialization defaults to `JSON.stringify`/`JSON.parse`; failures in either direction are swallowed (the cell keeps its in-memory value).
+
+## Timing semantics
+
+The link is implemented as a node init, so everything is lazy and per engine:
+
+- **Read** happens once per engine, when the engine first activates the cell. The stored value (if any) is published into the cell at that moment — before components subscribe through the provider. Reading the cell before any engine activates it yields the constructor's initial value.
+- **Write** happens on cell changes, debounced (default 500ms for localStorage, 0 otherwise). Pending writes are flushed/cleared on engine disposal.
+- **Cross-tab sync** applies to localStorage only: changes from other tabs publish into the cell; the link ignores echoes of its own writes.
+
+## Key namespacing
+
+If the engine has an id (`new Engine({}, 'my-app')` or `<EngineProvider engineId="my-app">`), localStorage/sessionStorage keys become `my-app:app-theme`. This is how multiple instances of the same engine-based component (for example two data tables) persist independently while sharing node definitions. Cookies are not namespaced.
+
+## Server-side rendering
+
+The link is a no-op when `window` is unavailable or the storage type is inaccessible — cells keep their initial values on the server, and storage hydrates them on the client when the engine activates the cell. Expect a possible flash of the initial value before client hydration, and avoid branching server-rendered markup on persisted state.
+
+## When to use what
+
+- One cell, one key: `linkCellToStorage`.
+- Composite, versioned feature state (like a table's column layout): a persistence adapter orchestrator — see "Building on the Engine" in the core docs for the pattern data-table uses.

--- a/skills/reactive-engine/references/storage/README.md
+++ b/skills/reactive-engine/references/storage/README.md
@@ -1,0 +1,27 @@
+# Reactive Engine Storage
+
+`@virtuoso.dev/reactive-engine-storage` persists [`@virtuoso.dev/reactive-engine-core`](https://www.npmjs.com/package/@virtuoso.dev/reactive-engine-core) cells in `localStorage`, `sessionStorage`, or cookies. A storage link hydrates the cell on engine startup and writes changes back as the cell updates.
+
+## Installation
+
+```bash
+npm install @virtuoso.dev/reactive-engine-core @virtuoso.dev/reactive-engine-storage
+```
+
+## Quick Example
+
+```ts
+import { Cell } from '@virtuoso.dev/reactive-engine-core'
+import { linkCellToStorage } from '@virtuoso.dev/reactive-engine-storage'
+
+const theme$ = Cell<'light' | 'dark'>('light')
+
+linkCellToStorage(theme$, {
+  key: 'app-theme',
+  storageType: 'localStorage',
+})
+```
+
+## License
+
+MIT


### PR DESCRIPTION
Turns the skills distribution from placeholder scaffolding into a shipped, discoverable product.

## What's in here

**Reactive engine documentation.** The `@virtuoso.dev/reactive-engine-*` packages get READMEs, package descriptions, and `docs/` guides covering what the JSDoc alone can't teach: the nodes-as-definitions/engines-as-state model, lazy activation and the three API flavors, transactional execution semantics, the operator/combinator reference, and the architecture patterns extracted from how data-table is built on the engine.

**A reactive-engine skill.** The skills build now supports multi-package skills (a list of doc sources per skill, each with a destination subdirectory), so one skill covers the five-package engine family with per-package reference folders.

**Authored content for all four skills.** Each SKILL.md follows the patterns from the strongest published library skills: trigger-spec descriptions enumerating situations, symptoms, and API names; component/package selection tables; rules stated with their reasoning; common patterns; pitfalls and troubleshooting. The react-virtuoso skill explicitly corrects the TanStack Virtual/react-window habits agents carry over; message-list leads with licensing and the scroll-modifier model; data-table covers the install and data-model decisions plus remote-controlled state; reactive-engine teaches the engine from scratch.

**Distribution and discoverability.** A new sync workflow mirrors the generated `skills/` directory to [virtuoso-dev/skills](https://github.com/virtuoso-dev/skills) on every main push (the repo is already seeded; `npx skills add virtuoso-dev/skills` verified working). virtuoso.dev gets an Agent Skills page linked from the site navigation, and the react-virtuoso README points at the skills next to the package install.

## Notes

- The `SKILLS_SYNC_TOKEN` secret is already configured; the sync workflow's first live run happens on merge.
- Generated references and mirrors are committed in sync; the existing CI drift check guards them.