### PR TITLE
Improve message-list docs and skill guidance

### DIFF
--- a/.changeset/refresh-message-list-skill-guidance.md
+++ b/.changeset/refresh-message-list-skill-guidance.md
@@ -1,0 +1,5 @@
+---
+"@virtuoso.dev/virtuoso-skills": patch
+---
+
+Refresh message-list docs and skill guidance for controlled mode, scroll policy, and row measurement patterns.

--- a/.changeset/refresh-message-list-skill-guidance.md
+++ b/.changeset/refresh-message-list-skill-guidance.md
@@ -1,5 +1,5 @@
 ---
-"@virtuoso.dev/virtuoso-skills": patch
+'@virtuoso.dev/virtuoso-skills': patch
 ---
 
 Refresh message-list docs and skill guidance for controlled mode, scroll policy, and row measurement patterns.

--- a/packages/message-list/README.md
+++ b/packages/message-list/README.md
@@ -136,6 +136,7 @@ export default function App() {
               scrollModifier: {
                 type: 'auto-scroll-to-bottom',
                 autoScroll: ({ scrollInProgress, atBottom }) => {
+                  // This is a local user action, so it intentionally brings the question into view.
                   return {
                     index: 'LAST',
                     align: 'start',

--- a/packages/message-list/docs/15.imperative-data-api.md
+++ b/packages/message-list/docs/15.imperative-data-api.md
@@ -13,7 +13,7 @@ In addition to the `data` prop, the message list component exposes an imperative
 
 :::info
 
-### What is an imperative API and why does the message list uses it?
+### What is an imperative API and why does the message list use it?
 
 There are two ways to work with React components - the imperative way and the declarative way. In the declarative way, you describe the UI based on the current state, and React takes care of updating the UI when the state changes.
 
@@ -64,7 +64,7 @@ export default function App() {
 
 Appending data to the message list usually requires an adjustment to the scroll position to keep the new messages in view. However, this is not always the case - for example, if the user is scrolling up to read older messages. Also, depending on various factors the adjustment may happen instantly or with a smooth scroll animation.
 
-To support those scenarios, the `data.append` method accepts `data` and, an optional, `scrollToBottom` argument that can be a string - `"smooth"`, `"auto"` or `"instant"` (passed directly to the underlying `scrollTo` DOM call), or a function that receives the following arguments as an object:
+To support those scenarios, the `data.append` method accepts `data` and an optional `scrollToBottom` argument that can be a string - `"smooth"`, `"auto"` or `"instant"` (passed directly to the underlying `scrollTo` DOM call), or a function that receives the following arguments as an object:
 
 - `scrollLocation: ListScrollLocation` - the current scroll location (same object as the one passed to the `onScroll` callback and the one available from `useScrollLocation` hook)
 - `scrollInProgress: boolean` - whether or not the list is currently scrolling
@@ -78,10 +78,17 @@ The function should return:
 - a string value, one of `"smooth"`, `"auto"` or `"instant"` to control the scroll behavior - the list will scroll to the bottom with the specified behavior
 - a location object, `{ index: number | 'LAST', align: 'start' | 'center' | 'end', behavior: 'smooth' | 'auto' }` to control the scroll behavior and the alignment of the new items. You can use this to scroll to the bottom, or to scroll the first new message to the top of the list.
 
+In callback form, returning a behavior or item location scrolls even when `atBottom` is `false`. Return `false` to preserve a scrolled-up user's viewport.
+
+The package exports two helpers for common policies:
+
+- `scrollToBottomIfAtBottom`: use for incoming messages or row growth. It returns `'smooth'` when the list is already at the bottom or already scrolling there, otherwise `false`.
+- `scrollToBottomAlways`: use for local sends or other current-user actions that should make the new last item visible.
+
 Experiment with the live example below to see how the scroll behavior changes when appending new items.
 
 ```tsx live
-import { VirtuosoMessageList, VirtuosoMessageListLicense, VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'
+import { scrollToBottomIfAtBottom, VirtuosoMessageList, VirtuosoMessageListLicense, VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'
 import { useRef } from 'react'
 
 export default function App() {
@@ -100,10 +107,7 @@ export default function App() {
       </VirtuosoMessageListLicense>
       <button
         onClick={() => {
-          ref.current.data.append(
-            Array.from({ length: 10 }, (_, index) => index + offset.current),
-            (params) => true
-          )
+          ref.current.data.append(Array.from({ length: 10 }, (_, index) => index + offset.current), scrollToBottomIfAtBottom)
           offset.current = offset.current + 10
         }}
       >
@@ -113,6 +117,65 @@ export default function App() {
   )
 }
 ```
+
+## Notifying Item Size Changes Without Data Changes
+
+Use `notifyItemsChanged({ scrollToBottom })` when rendered item content can change height without changing the message data array. Common examples include expansion state in `context`, side maps for reactions or approvals, activity-loading state, or any other external row state.
+
+```tsx
+import {
+  scrollToBottomIfAtBottom,
+  VirtuosoMessageList,
+  VirtuosoMessageListLicense,
+  VirtuosoMessageListMethods,
+} from '@virtuoso.dev/message-list'
+import { useRef, useState } from 'react'
+
+interface Message {
+  id: string
+  text: string
+}
+
+interface MessageListContext {
+  expandedMessages: Map<string, boolean>
+}
+
+export default function App() {
+  const ref = useRef<VirtuosoMessageListMethods<Message, MessageListContext>>(null)
+  const [expandedMessages, setExpandedMessages] = useState(() => new Map<string, boolean>())
+
+  return (
+    <VirtuosoMessageListLicense licenseKey="">
+      <VirtuosoMessageList<Message, MessageListContext>
+        ref={ref}
+        style={{ height: 500 }}
+        context={{ expandedMessages }}
+        initialData={[{ id: '1', text: 'Toggle extra row content' }]}
+        computeItemKey={({ data }) => data.id}
+        ItemContent={({ data, context }) => {
+          const expanded = context.expandedMessages.get(data.id) ?? false
+          return (
+            <div style={{ padding: 12 }}>
+              <button
+                onClick={() => {
+                  setExpandedMessages((current) => new Map(current).set(data.id, !expanded))
+                  ref.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+                }}
+              >
+                Toggle
+              </button>
+              <div>{data.text}</div>
+              {expanded && <div style={{ paddingTop: 12 }}>Additional details that make the row taller.</div>}
+            </div>
+          )
+        }}
+      />
+    </VirtuosoMessageListLicense>
+  )
+}
+```
+
+The `scrollToBottom` policy has the same callback shape as `data.append`. For `notifyItemsChanged`, the callback receives the current list data, the pre-change scroll location, `atBottom`, `scrollInProgress`, and `context`. ResizeObserver measures the new row heights; `notifyItemsChanged` supplies the scroll policy for preserving bottom stickiness.
 
 ## Updating Data
 
@@ -186,7 +249,7 @@ export default function App() {
 ## Replacing Data
 
 In case you're building a chat application with multiple channels, you might want to switch the message list to a different channel. The `data.replace` method lets you replace the current list of messages with a new one.
-The method accepts `data` and, optionally, an `options: { initalLocation: ItemLocation, purgeItemSizes?: boolean }` to specify the initial scroll position and weather to clear the cached item sizes. Purging the item sizes is useful when the new data has different item sizes than the previous data.
+The method accepts `data` and, optionally, an `options: { initialLocation: ItemLocation, purgeItemSizes?: boolean }` to specify the initial scroll position and whether to clear the cached item sizes. Purging the item sizes is useful when the new data has different item sizes than the previous data.
 
 ```tsx live
 import { VirtuosoMessageList, VirtuosoMessageListLicense, VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'

--- a/packages/message-list/docs/15.imperative-data-api.md
+++ b/packages/message-list/docs/15.imperative-data-api.md
@@ -88,7 +88,12 @@ The package exports two helpers for common policies:
 Experiment with the live example below to see how the scroll behavior changes when appending new items.
 
 ```tsx live
-import { scrollToBottomIfAtBottom, VirtuosoMessageList, VirtuosoMessageListLicense, VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'
+import {
+  scrollToBottomIfAtBottom,
+  VirtuosoMessageList,
+  VirtuosoMessageListLicense,
+  VirtuosoMessageListMethods,
+} from '@virtuoso.dev/message-list'
 import { useRef } from 'react'
 
 export default function App() {
@@ -107,7 +112,10 @@ export default function App() {
       </VirtuosoMessageListLicense>
       <button
         onClick={() => {
-          ref.current.data.append(Array.from({ length: 10 }, (_, index) => index + offset.current), scrollToBottomIfAtBottom)
+          ref.current.data.append(
+            Array.from({ length: 10 }, (_, index) => index + offset.current),
+            scrollToBottomIfAtBottom
+          )
           offset.current = offset.current + 10
         }}
       >

--- a/packages/message-list/docs/2.tutorial/02.message-list.md
+++ b/packages/message-list/docs/2.tutorial/02.message-list.md
@@ -158,11 +158,11 @@ feature in more detail in the next parts of the tutorial.
 
 ### The `style` prop
 
-**The Message List needs a height to render correctly**. We're setting the
+**The Message List needs a real height to render correctly**. We're setting the
 height to `80vh` to have a full-screen chat interface with a bit of space at the
 bottom. In your real world application, you might put the component into a flex
 box layout or use other methods to control the component's height - this works
-as well.
+as well. Make sure every parent in a `height: '100%'` chain is actually sized.
 
 ### The `computeItemKey` prop
 
@@ -252,6 +252,10 @@ const ItemContent: MessageListProps['ItemContent'] = ({ data: message, context }
   )
 }
 ```
+
+Message rows are measured with ResizeObserver. Avoid CSS margins on the measured
+row itself because margins are not included in the measured height. Use padding
+or an inner wrapper for spacing between messages.
 
 Now, let's pass `ItemContent` to the `VirtuosoMessageList` component and the
 `currentUser` to the context:

--- a/packages/message-list/docs/2.tutorial/05.receive-messages.md
+++ b/packages/message-list/docs/2.tutorial/05.receive-messages.md
@@ -53,6 +53,8 @@ Since we're using a smooth scroll, there's a slight chance of a new message comi
 The `auto-scroll-to-bottom` modifier is used for adding new messages to the end of the list. Through the `autoScroll` callback, you can conditionally determine if the list should catch up with the new messages or not.
 :::
 
+For the common version of this policy, use the exported `scrollToBottomIfAtBottom` helper. This tutorial keeps the callback inline so it can increment the unseen-message counter when the user is scrolled up.
+
 If everything works as expected, pressing the button will display a new message from another user with a smooth scroll animation.
 
 ## Display the New Message Counter

--- a/packages/message-list/docs/2.tutorial/06.send-messages.md
+++ b/packages/message-list/docs/2.tutorial/06.send-messages.md
@@ -14,7 +14,7 @@ Since the focus of this tutorial is the message list itself, we will use a butto
 
 ## Sending Messages and Scroll Position
 
-Unlike receiving messages, sending messages should always scroll the list to the bottom. This is because the user is sending a message, and they should see it immediately. The `autoScroll` callback will let us handle this.
+Unlike receiving messages, sending messages should always scroll the list to the bottom. This is because the user is sending a message, and they should see it immediately. The `autoScroll` callback will let us handle this. In app code, the exported `scrollToBottomAlways` helper represents this policy.
 
 ## Optimistic Updates
 
@@ -71,3 +71,5 @@ Add the following button next to the receive messages button:
 ```
 
 If everything works as expected, pressing the button will display a new message from the current user with a smooth scroll animation. After a short delay, the `Delivering...` indicator below the message should disappear.
+
+If your realtime backend echoes the same local message through a socket stream, reconcile that event by `localId` or another client-generated id. Treat it as a confirmation of the optimistic row, not as a new incoming remote message.

--- a/packages/message-list/docs/20.scroll-modifier.md
+++ b/packages/message-list/docs/20.scroll-modifier.md
@@ -37,6 +37,48 @@ setData((current) => ({
 This modifier should be used when new messages are added to the end of the list, and you want to scroll to the bottom of the list automatically (or conditionally, depending on the current position). An extensive example that uses this type can be found in the
 ["receiving messages" chapter of the tutorial](/virtuoso-message-list/tutorial/receive-messages/) - the behavior can be a callback function that receives the current state of the list and calculates the necessary location and scroll behavior.
 
+The `autoScroll` field accepts either a direct scroll behavior or a callback. Passing a direct behavior such as `'smooth'` applies only when the list is already at the bottom. Use the callback form when the policy depends on the source of the event. Returning `false` is the preserve-position path for users who have scrolled up. Returning a behavior, `true`, or an item location scrolls the list.
+
+The callback receives the scroll location from before the data change:
+
+- `scrollLocation`: the full `ListScrollLocation` object.
+- `atBottom`: whether the list was at the bottom before the change.
+- `scrollInProgress`: whether the list was already scrolling.
+- `data`: the appended or next data array, depending on the operation.
+- `context`: the current message-list context.
+
+For incoming remote messages, preserve users who are reading history:
+
+```tsx
+const ReceivedMessagesScrollModifier: ScrollModifier = {
+  type: 'auto-scroll-to-bottom',
+  autoScroll: ({ atBottom, scrollInProgress }) => {
+    if (atBottom || scrollInProgress) {
+      return 'smooth'
+    }
+    return false
+  },
+}
+```
+
+The package also exports helpers for common policies:
+
+```tsx
+import { scrollToBottomAlways, scrollToBottomIfAtBottom } from '@virtuoso.dev/message-list'
+
+const RemoteMessageScrollModifier: ScrollModifier = {
+  type: 'auto-scroll-to-bottom',
+  autoScroll: scrollToBottomIfAtBottom,
+}
+
+const LocalSendScrollModifier: ScrollModifier = {
+  type: 'auto-scroll-to-bottom',
+  autoScroll: scrollToBottomAlways,
+}
+```
+
+Use `scrollToBottomIfAtBottom` for incoming messages or row growth where a scrolled-up user should stay in place. Use `scrollToBottomAlways` for local actions, such as sending the current user's message, where the new item should become visible even if the user was reading older messages.
+
 ### `prepend`
 
 The `"prepend"` scroll modifier value signals that the data change will add messages to the top of the list. The scroll position will be adjusted to keep the current scroll position relative to the new data.
@@ -57,6 +99,26 @@ For the prepend modifier to work correctly, the **new data should extend the cur
 ### `{ type: 'items-change' }`
 
 This scroll modifier is useful when the data update keeps the same items but modifies their content/props - such an example would be a streaming bot response, or adding/removing reactions to certain messages. In this case, the scroll modifier lets you keep the message list scrolled to the bottom in case it is there. See the [reactions example](/virtuoso-message-list/examples/reactions/) for a live example.
+
+Use this modifier when the data array update is what changes the rendered item height:
+
+```tsx
+setData((current) => ({
+  data: current.data.map((message) => (message.id === streamingId ? { ...message, text: message.text + chunk } : message)),
+  scrollModifier: { type: 'items-change', behavior: 'smooth' },
+}))
+```
+
+If rendered rows change size because of `context`, side maps, expansion state, reactions stored outside the data array, approval state, activity loading, or other external row state, use the imperative `notifyItemsChanged` method instead. ResizeObserver will measure the rows either way; the modifier or method supplies the policy for whether the list should remain stuck to the bottom.
+
+```tsx
+const messageListRef = useRef<VirtuosoMessageListMethods<Message, MessageListContext>>(null)
+
+function setMessageExpanded(messageId: string, expanded: boolean) {
+  setExpandedMessages((current) => new Map(current).set(messageId, expanded))
+  messageListRef.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+}
+```
 
 ### `remove-from-start`
 

--- a/packages/message-list/docs/21.controlled-mode-recipes.md
+++ b/packages/message-list/docs/21.controlled-mode-recipes.md
@@ -1,0 +1,136 @@
+---
+id: virtuoso-message-list-controlled-mode-recipes
+title: Virtuoso Message List Controlled Mode Recipes
+description: Organize controlled message-list state behind app-owned actions for local sends, incoming messages, streaming updates, and row growth.
+sidebar_label: Controlled Mode Recipes
+sidebar_position: 11
+slug: /virtuoso-message-list/controlled-mode-recipes
+---
+
+## Controlled Mode Recipes
+
+When you drive the message list with the `data` prop, keep the message array and its `scrollModifier` together in a single `DataWithScrollModifier<Message>` state value. In larger chat integrations, wrap raw `setData` calls in app-owned actions that match product events.
+
+This page shows a recipe, not a public hook. If you wrap it in an app-local hook, keep that hook private to your application. Keep names like `appendIncoming` or `confirmLocal` in your application until several integrations prove the same abstraction is broadly reusable.
+
+```tsx
+import {
+  DataWithScrollModifier,
+  ScrollModifier,
+  scrollToBottomAlways,
+  scrollToBottomIfAtBottom,
+  VirtuosoMessageListMethods,
+} from '@virtuoso.dev/message-list'
+import { useCallback, useRef, useState } from 'react'
+
+interface Message {
+  id: string | null
+  localId: string | null
+  text: string
+  delivered: boolean
+}
+
+interface MessageListContext {
+  expandedMessages: Map<string, boolean>
+}
+
+type MessageListState = DataWithScrollModifier<Message>
+
+const InitialLocation: ScrollModifier = {
+  type: 'item-location',
+  location: { index: 'LAST', align: 'end' },
+  purgeItemSizes: true,
+}
+
+function useChatData() {
+  const messageListRef = useRef<VirtuosoMessageListMethods<Message, MessageListContext>>(null)
+  const [data, setData] = useState<MessageListState>({ data: [], scrollModifier: InitialLocation })
+  const [expandedMessages, setExpandedMessages] = useState(() => new Map<string, boolean>())
+
+  const replaceMessages = useCallback((messages: Message[]) => {
+    setData({ data: messages, scrollModifier: InitialLocation })
+  }, [])
+
+  const appendIncoming = useCallback((messages: Message[]) => {
+    setData((current) => ({
+      data: [...(current.data ?? []), ...messages],
+      scrollModifier: { type: 'auto-scroll-to-bottom', autoScroll: scrollToBottomIfAtBottom },
+    }))
+  }, [])
+
+  const appendLocal = useCallback((message: Message) => {
+    setData((current) => ({
+      data: [...(current.data ?? []), message],
+      scrollModifier: { type: 'auto-scroll-to-bottom', autoScroll: scrollToBottomAlways },
+    }))
+  }, [])
+
+  const confirmLocal = useCallback((localId: string, remoteMessage: Message) => {
+    setData((current) => ({
+      data: (current.data ?? []).map((message) => (message.localId === localId ? remoteMessage : message)),
+      scrollModifier: { type: 'items-change', behavior: 'smooth' },
+    }))
+  }, [])
+
+  const updateStreamingMessage = useCallback((id: string, chunk: string) => {
+    setData((current) => ({
+      data: (current.data ?? []).map((message) => (message.id === id ? { ...message, text: message.text + chunk } : message)),
+      scrollModifier: { type: 'items-change', behavior: 'smooth' },
+    }))
+  }, [])
+
+  const rowChromeChanged = useCallback((messageId: string, expanded: boolean) => {
+    setExpandedMessages((current) => new Map(current).set(messageId, expanded))
+    messageListRef.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+  }, [])
+
+  return {
+    appendIncoming,
+    appendLocal,
+    confirmLocal,
+    context: { expandedMessages },
+    data,
+    messageListRef,
+    replaceMessages,
+    rowChromeChanged,
+    updateStreamingMessage,
+  }
+}
+```
+
+Use `replaceMessages` when switching channels, threads, or conversations. The `purgeItemSizes: true` flag clears cached row sizes so the previous conversation does not distort the next one.
+
+Use `appendIncoming` for remote messages. It sticks to the bottom only when the user was already at the bottom or the list was already scrolling there. If the user is reading history, keep the viewport still and show an unseen-message indicator in your app.
+
+Use `appendLocal` for optimistic sends by the current user. Local sends normally force the list to the bottom so the sender can see the new message immediately.
+
+Use `confirmLocal` when the server acknowledges an optimistic message. Match by `localId` or another client-generated id, replace the local row with the canonical server row, and treat the confirmation as an existing-row update rather than a new incoming message.
+
+Use `updateStreamingMessage` when the data item itself grows, such as a streaming assistant response. The `items-change` modifier keeps the list pinned only if it was already pinned.
+
+Use `rowChromeChanged` when row height changes without a data-array update. Examples include expansion state in `context`, side maps for approvals or reactions, activity loading, and other external row state. `notifyItemsChanged` tells the list to re-evaluate the scroll-to-bottom policy while ResizeObserver performs the measurement.
+
+## Socket Echoes
+
+Realtime systems often echo the current user's optimistic message back through the same socket stream used for remote messages. Reconcile that event by identity and source before choosing a scroll policy:
+
+- If the event confirms a local optimistic row, call `confirmLocal`.
+- If the event is genuinely from another user, call `appendIncoming`.
+- If the event is a local send that was not rendered optimistically, call `appendLocal`.
+
+Do not treat every socket message as remote row growth. The event source determines whether to force bottom, preserve the scrolled-up viewport, or update an existing row.
+
+## Keys And Identity
+
+Set `computeItemKey` to a stable React key. In controlled mode, also set `itemIdentity` when prepend or remove-from-start operations need to match items but your reducer recreates item objects.
+
+```tsx
+<VirtuosoMessageList<Message, MessageListContext>
+  ref={messageListRef}
+  data={data}
+  context={context}
+  computeItemKey={({ data }) => data.id ?? `local-${data.localId}`}
+  itemIdentity={(item) => item.id ?? `local-${item.localId}`}
+  ItemContent={ItemContent}
+/>
+```

--- a/packages/message-list/docs/3.examples/02.ai-chatbot.md
+++ b/packages/message-list/docs/3.examples/02.ai-chatbot.md
@@ -90,6 +90,7 @@ export default function App() {
               scrollModifier: {
                 type: 'auto-scroll-to-bottom',
                 autoScroll: ({ scrollInProgress, atBottom }) => {
+                  // This is a local user action, so it intentionally brings the question into view.
                   return {
                     index: 'LAST',
                     align: 'start',

--- a/packages/message-list/docs/3.examples/03.gemini.md
+++ b/packages/message-list/docs/3.examples/03.gemini.md
@@ -89,6 +89,7 @@ export default function App() {
               scrollModifier: {
                 type: 'auto-scroll-to-bottom',
                 autoScroll: ({ scrollInProgress, atBottom }) => {
+                  // This is a local user action, so it intentionally brings the question into view.
                   return {
                     index: 'LAST',
                     align: 'start',

--- a/packages/message-list/docs/3.examples/04.reactions.md
+++ b/packages/message-list/docs/3.examples/04.reactions.md
@@ -15,6 +15,8 @@ A common problem in messaging interfaces is how to handle reactions to messages.
 The approach above is not exclusive to reactions - the same principle should be applied to any message state change that will change the message height (for example, expanding details, etc).
 :::
 
+This example stores the reaction state in the message data, so `items-change` is the right modifier. If reaction or expansion state lives in `context` or side maps instead, update that state and call `notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })` on the message-list ref.
+
 ```tsx live
 import {
   ScrollModifier,

--- a/packages/message-list/docs/5.context.md
+++ b/packages/message-list/docs/5.context.md
@@ -47,3 +47,12 @@ export default function App() {
   )
 }
 ```
+
+If context changes can make rendered message rows taller or shorter, notify the list after updating that external state:
+
+```tsx
+setExpandedMessages((current) => new Map(current).set(messageId, expanded))
+messageListRef.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+```
+
+Use this for expansion state, side maps, approval state, loading indicators, or reactions stored outside the message data array. ResizeObserver measures the changed rows, and `notifyItemsChanged` tells the list whether to keep sticking to the bottom or preserve a scrolled-up user's position.

--- a/packages/message-list/docs/6.item-keys.md
+++ b/packages/message-list/docs/6.item-keys.md
@@ -9,7 +9,7 @@ slug: /virtuoso-message-list/item-keys
 
 ## Item Keys
 
-React uses a unique key to identify each item in a list. By default, the Message List component uses the items numeric index for that, but this index might change as we load new messages or delete some. To address that, the message list exposes a `computeItemKey` prop. This prop should return a unique key for each item based on the item data.
+React uses a unique key to identify each item in a list. By default, the Message List component uses the item's numeric index for that, but this index might change as we load new messages or delete some. To address that, the message list exposes a `computeItemKey` prop. This prop should return a unique key for each item based on the item data.
 
 ```tsx live
 import { VirtuosoMessageList, VirtuosoMessageListLicense } from '@virtuoso.dev/message-list'
@@ -28,3 +28,18 @@ export default function App() {
   )
 }
 ```
+
+## `computeItemKey` And `itemIdentity`
+
+`computeItemKey` controls the React key used to mount and update item components. Use it for every chat integration with stable message ids, local optimistic ids, or both.
+
+`itemIdentity` is different. It controls how the message list matches items for controlled data operations such as `prepend` and `remove-from-start` when your reducer recreates item objects. If your controlled state creates new object references for the same messages, provide `itemIdentity` with the same stable identity you use for keys.
+
+```tsx
+<VirtuosoMessageList
+  computeItemKey={({ data }) => data.id ?? `local-${data.localId}`}
+  itemIdentity={(item) => item.id ?? `local-${item.localId}`}
+/>
+```
+
+If your data objects keep stable references across updates, `itemIdentity` is usually not necessary. If controlled prepend or trimming loses the previous visual position after recreating message objects, add it.

--- a/packages/message-list/docs/80.licensing.md
+++ b/packages/message-list/docs/80.licensing.md
@@ -13,7 +13,7 @@ The `@virtuoso.dev/message-list` package is distributed under a commercial licen
 
 ## License Seats Explained
 
-The number of licenses to **the maximum number of concurrent front-end developers** who contribute to a project that uses the package. This also includes developers who work on the project part-time or as contractors.
+The number of licenses is **the maximum number of concurrent front-end developers** who contribute to a project that uses the package. This also includes developers who work on the project part-time or as contractors.
 
 For example, your app uses the `VirtuosoMessageList` component for building an AI Chatbot interface. **Three front-end** and two back-end developers are working on the project. One developer develops and maintains the message list UI feature, but there are three developers in total who work on the front-end. You must purchase **three licenses** for the project.
 
@@ -41,6 +41,22 @@ The license key is a string that you need to pass as a prop to the `VirtuosoMess
 </VirtuosoMessageListLicense>
 ```
 
+In an application, put the license wrapper near the app root or around the route section that renders chat UI. Read the key from your normal public client-side environment configuration.
+
+```tsx
+const licenseKey = import.meta.env.VITE_VIRTUOSO_MESSAGE_LIST_LICENSE_KEY ?? ''
+
+export function App() {
+  return (
+    <VirtuosoMessageListLicense licenseKey={licenseKey}>
+      <Routes />
+    </VirtuosoMessageListLicense>
+  )
+}
+```
+
+For Next.js, use a public environment variable, for example `NEXT_PUBLIC_VIRTUOSO_MESSAGE_LIST_LICENSE_KEY`, and pass it from a client component.
+
 ### Next.js/SSR
 
 The license component is using a context to pass the license to the `VirtuosoMessageList` component, so you need to ensure that it is not rendered server-side only.
@@ -57,11 +73,11 @@ The license key is validated without any network requests, so you can safely use
 
 ### No license wrapper component
 
-The `VirtuosMessageListLicense` component will throw an error and render an error unless wrapped with a `VirtuosoMessageListLicense` component. For development/evaluation purposes, you need to wrap one, even with an empty key prop. This will allow you to use the component without a license key for 30 days, keeping an error message in the developer console as a reminder.
+The `VirtuosoMessageList` component will render an error unless wrapped with a `VirtuosoMessageListLicense` component. For development/evaluation purposes, you need to wrap one, even with an empty key prop. This will allow you to use the component without a license key for 30 days, keeping an error message in the developer console as a reminder.
 
 ### Missing key
 
-You can use the component without a license key for 30 days for non-production environments and for evaluation purposes - a message in the console will remind you that you have to add the key. If the component is deployed to production without a license key, it will render as an error message in the browser and an error in the console.
+You can use the component with an empty license key for 30 days for non-production environments and for evaluation purposes - a message in the console will remind you that you have to add the key. If the component is deployed to production without a valid license key, it will render as an error message in the browser and an error in the console.
 
 ### Invalid key
 

--- a/packages/virtuoso-skills/skills/message-list/SKILL.md
+++ b/packages/virtuoso-skills/skills/message-list/SKILL.md
@@ -4,8 +4,9 @@ description: >-
   Build chat, messaging, and AI conversation UIs with @virtuoso.dev/message-list. Use this skill when (1) building a chat or
   messaging interface, (2) streaming AI assistant responses into a conversation, (3) loading older messages when scrolling up,
   (4) adding scroll-to-bottom buttons or unseen-message indicators, (5) switching between channels/conversations, or (6) any task
-  involving VirtuosoMessageList, VirtuosoMessageListLicense, useVirtuosoMethods, useVirtuosoLocation, scrollModifier, or
-  data.append/prepend/map. The package is commercial and requires a license key.
+  involving VirtuosoMessageList, VirtuosoMessageListLicense, useVirtuosoMethods, useVirtuosoLocation, scrollModifier,
+  notifyItemsChanged, scrollToBottomIfAtBottom, scrollToBottomAlways, or data.append/prepend/map. The package is commercial
+  and requires a license key.
 ---
 
 # @virtuoso.dev/message-list
@@ -22,7 +23,7 @@ The package is commercial (annual, per-developer). Every instance must be wrappe
 </VirtuosoMessageListLicense>
 ```
 
-An empty `licenseKey=""` works as a 30-day non-production trial. Validation is local — no network requests. Surface this to the user when introducing the package into a project; keys come from <https://virtuoso.dev/pricing/>.
+An empty `licenseKey=""` is licensed for 30-day non-production evaluation: it keeps rendering in development with a console reminder, while production without a valid key renders an error. Validation is local — no network requests. Surface this to the user when introducing the package into a project; keys come from <https://virtuoso.dev/pricing/>. Prefer an app-level wrapper that reads from the normal public client-side environment configuration.
 
 ## Core mental model: data updates carry scroll instructions
 
@@ -37,38 +38,56 @@ const [data, setData] = useState<VirtuosoMessageListProps<Message, null>['data']
 <VirtuosoMessageList<Message, null> style={{ height: '100%' }} data={data} computeItemKey={({ data }) => data.key} ItemContent={ItemContent} />
 ```
 
-`ItemContent` is a component receiving `{ data, index, context }` props (not positional arguments like react-virtuoso).
+`ItemContent` is a component receiving `{ data, index, context }` props (not positional arguments like react-virtuoso). Extract it outside the parent render function unless it needs to close over local state.
+
+External row state is different from data updates. If `context`, side maps, expansion state, reactions, approvals, or loading flags can change row height without changing the data array, call `notifyItemsChanged({ scrollToBottom })` on the message-list ref after updating that state.
 
 ### Scroll modifier reference
 
 | Modifier                                               | When to use                                                                                             |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- | ------ | -------------------------- |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
 | `{ type: 'item-location', location, purgeItemSizes? }` | Initial load or channel switch; `purgeItemSizes: true` clears cached sizes when the items are different |
-| `{ type: 'auto-scroll-to-bottom', autoScroll }`        | New messages arrive; callback receives `{ atBottom, scrollInProgress, ... }` and returns `'smooth'      | 'auto' | false` or an item location |
+| `{ type: 'auto-scroll-to-bottom', autoScroll }`        | New messages are appended; callback can return `false`, a behavior, `true`, or an item location         |
 | `'prepend'`                                            | Older messages added to the top; keeps the current messages visually in place                           |
-| `{ type: 'items-change', behavior }`                   | Existing items changed size (streaming text, reactions); stays at bottom if already there               |
+| `{ type: 'items-change', behavior }`                   | Existing data items changed size, such as streaming text or reactions stored in the data item           |
 | `'remove-from-start'` / `'remove-from-end'`            | Trimming data while preserving the visual position                                                      |
 | `null` / `undefined`                                   | Leave the scroll position alone                                                                         |
+
+In callback form, returning a behavior or item location scrolls even when `atBottom` is false. Return `false` to preserve the viewport for a scrolled-up user.
 
 ## Common patterns
 
 ### Receiving messages (auto-scroll when at bottom)
 
 ```tsx
+import { scrollToBottomIfAtBottom } from '@virtuoso.dev/message-list'
+
 setData((current) => ({
   data: [...current.data, incoming],
   scrollModifier: {
     type: 'auto-scroll-to-bottom',
-    autoScroll: ({ atBottom, scrollInProgress }) => ({
-      index: 'LAST',
-      align: 'end',
-      behavior: atBottom || scrollInProgress ? 'smooth' : 'auto',
-    }),
+    autoScroll: scrollToBottomIfAtBottom,
   },
 }))
 ```
 
-Returning `false` from `autoScroll` when not at bottom is how you keep the viewport still and instead increment an unseen-messages counter.
+Use `scrollToBottomIfAtBottom` for remote messages. It returns `'smooth'` when the list is already at the bottom or already scrolling there, otherwise `false`. If the app needs an unseen-message counter, use the inline callback form and increment the counter before returning `false`.
+
+### Sending local messages (force bottom)
+
+```tsx
+import { scrollToBottomAlways } from '@virtuoso.dev/message-list'
+
+setData((current) => ({
+  data: [...current.data, optimisticLocalMessage],
+  scrollModifier: {
+    type: 'auto-scroll-to-bottom',
+    autoScroll: scrollToBottomAlways,
+  },
+}))
+```
+
+Use `scrollToBottomAlways` for local current-user actions where the new last item should become visible even if the user was scrolled up. If a realtime socket echoes the same optimistic message back, reconcile it by `localId` or another client-generated identity and treat it as confirmation, not a new incoming remote message.
 
 ### Streaming an AI response
 
@@ -82,6 +101,21 @@ setData((current) => ({
 ```
 
 `items-change` keeps the view pinned to the bottom while the message grows, without jumping if the user scrolled up. See [ai-chatbot](references/3.examples/02.ai-chatbot.md) and [gemini](references/3.examples/03.gemini.md) (question pinned to top, answer streams below).
+
+### External row state changed size
+
+Use `notifyItemsChanged` when row content changes size without changing the data array:
+
+```tsx
+import { scrollToBottomIfAtBottom, type VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'
+
+const messageListRef = useRef<VirtuosoMessageListMethods<Message, MessageListContext>>(null)
+
+setExpandedMessages((current) => new Map(current).set(messageId, expanded))
+messageListRef.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+```
+
+ResizeObserver measures the rows; `notifyItemsChanged` supplies the scroll policy. Use it for expansion state in `context`, side maps for reactions or approvals, activity loading, or any other external row state.
 
 ### Loading older messages on scroll-up
 
@@ -114,6 +148,19 @@ const StickyFooter = () => {
 
 Keep one data object per channel and swap with `replace`/`item-location` + `purgeItemSizes: true`, so size caches from the previous channel don't distort the new one. See [multiple-channels](references/2.tutorial/07.multiple-channels.md).
 
+### Controlled mode recipe
+
+For controlled `data` prop usage, keep `DataWithScrollModifier<Message>` behind app-owned actions such as `replaceMessages`, `appendIncoming`, `appendLocal`, `confirmLocal`, `updateStreamingMessage`, and `rowChromeChanged`. This is a recipe layer in app code, not an official exported hook and not a replacement for the imperative `data.*` API.
+
+- `replaceMessages`: channel or thread switch with `{ type: 'item-location', location: { index: 'LAST', align: 'end' }, purgeItemSizes: true }`.
+- `appendIncoming`: remote messages with `scrollToBottomIfAtBottom`.
+- `appendLocal`: optimistic local sends with `scrollToBottomAlways`.
+- `confirmLocal`: match the socket/server acknowledgement by `localId` and update the existing row.
+- `updateStreamingMessage`: map the existing message and use `{ type: 'items-change', behavior: 'smooth' }`.
+- `rowChromeChanged`: update external row state and call `notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })`.
+
+Do not invent or recommend a public `useVirtuosoMessageListData` hook before trying this recipe-level controlled state in app code. See [controlled-mode-recipes](references/21.controlled-mode-recipes.md).
+
 ## Imperative API
 
 Via `ref={useRef<VirtuosoMessageListMethods<Message>>(null)}` from outside, or `useVirtuosoMethods()` from components rendered inside the list:
@@ -122,6 +169,7 @@ Via `ref={useRef<VirtuosoMessageListMethods<Message>>(null)}` from outside, or `
 - `data.map(fn, autoscrollBehavior?)` — update items (reactions, edits, streaming)
 - `data.findAndDelete(predicate)`, `data.deleteRange(start, length)`, `data.replace(data, options?)`
 - `data.find(predicate)`, `data.findIndex(predicate)`, `data.get()`, `data.getCurrentlyRendered()`
+- `notifyItemsChanged({ scrollToBottom })` — use after context or side-state changes that can resize rendered rows without changing the data array
 - `scrollToItem({ index: number | 'LAST', align, behavior })`
 
 The declarative `data` prop and the imperative `data.*` methods are alternative ways to drive the same list — pick one as the primary mechanism per component to avoid fighting updates.
@@ -131,6 +179,7 @@ The declarative `data` prop and the imperative `data.*` methods are alternative 
 - `ItemContent: ({ data, index, context }) => JSX` — message renderer
 - `context` — shared state (current user, loading flags) available to `ItemContent` and all custom slots; avoids prop drilling
 - `computeItemKey({ data })` — stable message key; required for prepending/streaming to work without remounts
+- `itemIdentity(item)` — stable item identity for controlled prepend/remove-from-start matching when reducers recreate item objects
 - Slots: `Header`, `Footer` (scroll with content), `StickyHeader`, `StickyFooter` (fixed, measured to avoid overlap), `EmptyPlaceholder`
 - `initialLocation: { index: 'LAST', align: 'end' }` — start at the bottom
 - Hooks (inside the list): `useVirtuosoMethods()`, `useVirtuosoLocation()` (`atBottom`, `bottomOffset`, `listOffset`, `scrollInProgress`), `useCurrentlyRenderedData()`
@@ -138,16 +187,30 @@ The declarative `data` prop and the imperative `data.*` methods are alternative 
 ## Pitfalls
 
 - **No height → nothing renders.** The component needs a real height (`style={{ height: '100%' }}` with a sized parent).
+- **Missing license wrapper → runtime error.** Wrap with `VirtuosoMessageListLicense`; an empty key is only for non-production evaluation.
 - **Missing `computeItemKey`** causes remounts and scroll jumps on prepend and streaming updates.
-- **Margins on message items** break height measurement (ResizeObserver excludes margins) — use padding.
+- **Missing `itemIdentity` in controlled mode** can break prepend/remove-from-start matching when reducers recreate item objects.
+- **Margins on measured message rows** break height measurement because ResizeObserver excludes margins. Use padding or inner wrappers.
+- **Implicit scroll policy** causes chat regressions. Decide per source: local send usually forces bottom, remote receive preserves scrolled-up users, streaming uses `items-change`, and context-only row growth uses `notifyItemsChanged`.
 - **"ResizeObserver loop" errors are benign** — filter them in dev overlays and error tracking; see [resize-observer-errors](references/19.resize-observer-errors.md).
 - **JSDOM tests need mocked measurements** via `VirtuosoMessageListTestingContext.Provider value={{ itemHeight, viewportHeight }}` plus a ResizeObserver polyfill; prefer Playwright for scroll behavior. See [testing](references/11.testing.md).
+
+## Migration checklist from a plain mapped chat list
+
+- Add the `VirtuosoMessageListLicense` wrapper and decide how the key is supplied.
+- Give the list a real height through a sized parent or direct style.
+- Extract `ItemContent` and pass shared state through `context`.
+- Add stable `computeItemKey` for message ids and local optimistic ids.
+- Add `itemIdentity` when controlled data recreates objects and uses prepend/trimming.
+- Remove margins from measured rows; use padding or inner wrappers for spacing.
+- Choose an explicit scroll policy for local sends, remote receives, streaming updates, socket echoes, and external row growth.
+- Use Playwright/browser tests for scroll behavior where possible; use the testing context for JSDOM unit tests.
 
 ## References
 
 - [references/README.md](references/README.md) — overview and live example
 - `references/2.tutorial/` — step-by-step chat build: [intro](references/2.tutorial/01.intro.md), [message-list](references/2.tutorial/02.message-list.md), [loading-older-messages](references/2.tutorial/03.loading-older-messages.md), [scroll-to-bottom-button](references/2.tutorial/04.scroll-to-bottom-button.md), [receive-messages](references/2.tutorial/05.receive-messages.md), [send-messages](references/2.tutorial/06.send-messages.md), [multiple-channels](references/2.tutorial/07.multiple-channels.md)
 - `references/3.examples/` — [messaging](references/3.examples/01.messaging.md), [ai-chatbot](references/3.examples/02.ai-chatbot.md), [gemini](references/3.examples/03.gemini.md), [reactions](references/3.examples/04.reactions.md), [date-separators](references/3.examples/05.date-separators.md), [scroll-to-reply](references/3.examples/06.scroll-to-reply.md), [grouped-messages](references/3.examples/07.grouped-messages.md)
-- Feature guides: [headers-footers](references/4.headers-footers.md), [context](references/5.context.md), [item-keys](references/6.item-keys.md), [hooks](references/7.hooks.md), [custom-scrollbar](references/8.custom-scrollbar.md), [scrolling-to-item](references/9.scrolling-to-item.md), [smooth-scrolling](references/10.smooth-scrolling.md), [imperative-data-api](references/15.imperative-data-api.md), [scroll-modifier](references/20.scroll-modifier.md), [testing](references/11.testing.md), [licensing](references/80.licensing.md)
+- Feature guides: [headers-footers](references/4.headers-footers.md), [context](references/5.context.md), [item-keys](references/6.item-keys.md), [hooks](references/7.hooks.md), [custom-scrollbar](references/8.custom-scrollbar.md), [scrolling-to-item](references/9.scrolling-to-item.md), [smooth-scrolling](references/10.smooth-scrolling.md), [imperative-data-api](references/15.imperative-data-api.md), [scroll-modifier](references/20.scroll-modifier.md), [controlled-mode-recipes](references/21.controlled-mode-recipes.md), [testing](references/11.testing.md), [licensing](references/80.licensing.md)
 
 Full API reference: <https://virtuoso.dev/message-list/>

--- a/packages/virtuoso-skills/skills/message-list/references/15.imperative-data-api.md
+++ b/packages/virtuoso-skills/skills/message-list/references/15.imperative-data-api.md
@@ -13,7 +13,7 @@ In addition to the `data` prop, the message list component exposes an imperative
 
 :::info
 
-### What is an imperative API and why does the message list uses it?
+### What is an imperative API and why does the message list use it?
 
 There are two ways to work with React components - the imperative way and the declarative way. In the declarative way, you describe the UI based on the current state, and React takes care of updating the UI when the state changes.
 
@@ -64,7 +64,7 @@ export default function App() {
 
 Appending data to the message list usually requires an adjustment to the scroll position to keep the new messages in view. However, this is not always the case - for example, if the user is scrolling up to read older messages. Also, depending on various factors the adjustment may happen instantly or with a smooth scroll animation.
 
-To support those scenarios, the `data.append` method accepts `data` and, an optional, `scrollToBottom` argument that can be a string - `"smooth"`, `"auto"` or `"instant"` (passed directly to the underlying `scrollTo` DOM call), or a function that receives the following arguments as an object:
+To support those scenarios, the `data.append` method accepts `data` and an optional `scrollToBottom` argument that can be a string - `"smooth"`, `"auto"` or `"instant"` (passed directly to the underlying `scrollTo` DOM call), or a function that receives the following arguments as an object:
 
 - `scrollLocation: ListScrollLocation` - the current scroll location (same object as the one passed to the `onScroll` callback and the one available from `useScrollLocation` hook)
 - `scrollInProgress: boolean` - whether or not the list is currently scrolling
@@ -78,10 +78,17 @@ The function should return:
 - a string value, one of `"smooth"`, `"auto"` or `"instant"` to control the scroll behavior - the list will scroll to the bottom with the specified behavior
 - a location object, `{ index: number | 'LAST', align: 'start' | 'center' | 'end', behavior: 'smooth' | 'auto' }` to control the scroll behavior and the alignment of the new items. You can use this to scroll to the bottom, or to scroll the first new message to the top of the list.
 
+In callback form, returning a behavior or item location scrolls even when `atBottom` is `false`. Return `false` to preserve a scrolled-up user's viewport.
+
+The package exports two helpers for common policies:
+
+- `scrollToBottomIfAtBottom`: use for incoming messages or row growth. It returns `'smooth'` when the list is already at the bottom or already scrolling there, otherwise `false`.
+- `scrollToBottomAlways`: use for local sends or other current-user actions that should make the new last item visible.
+
 Experiment with the live example below to see how the scroll behavior changes when appending new items.
 
 ```tsx live
-import { VirtuosoMessageList, VirtuosoMessageListLicense, VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'
+import { scrollToBottomIfAtBottom, VirtuosoMessageList, VirtuosoMessageListLicense, VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'
 import { useRef } from 'react'
 
 export default function App() {
@@ -100,10 +107,7 @@ export default function App() {
       </VirtuosoMessageListLicense>
       <button
         onClick={() => {
-          ref.current.data.append(
-            Array.from({ length: 10 }, (_, index) => index + offset.current),
-            (params) => true
-          )
+          ref.current.data.append(Array.from({ length: 10 }, (_, index) => index + offset.current), scrollToBottomIfAtBottom)
           offset.current = offset.current + 10
         }}
       >
@@ -113,6 +117,65 @@ export default function App() {
   )
 }
 ```
+
+## Notifying Item Size Changes Without Data Changes
+
+Use `notifyItemsChanged({ scrollToBottom })` when rendered item content can change height without changing the message data array. Common examples include expansion state in `context`, side maps for reactions or approvals, activity-loading state, or any other external row state.
+
+```tsx
+import {
+  scrollToBottomIfAtBottom,
+  VirtuosoMessageList,
+  VirtuosoMessageListLicense,
+  VirtuosoMessageListMethods,
+} from '@virtuoso.dev/message-list'
+import { useRef, useState } from 'react'
+
+interface Message {
+  id: string
+  text: string
+}
+
+interface MessageListContext {
+  expandedMessages: Map<string, boolean>
+}
+
+export default function App() {
+  const ref = useRef<VirtuosoMessageListMethods<Message, MessageListContext>>(null)
+  const [expandedMessages, setExpandedMessages] = useState(() => new Map<string, boolean>())
+
+  return (
+    <VirtuosoMessageListLicense licenseKey="">
+      <VirtuosoMessageList<Message, MessageListContext>
+        ref={ref}
+        style={{ height: 500 }}
+        context={{ expandedMessages }}
+        initialData={[{ id: '1', text: 'Toggle extra row content' }]}
+        computeItemKey={({ data }) => data.id}
+        ItemContent={({ data, context }) => {
+          const expanded = context.expandedMessages.get(data.id) ?? false
+          return (
+            <div style={{ padding: 12 }}>
+              <button
+                onClick={() => {
+                  setExpandedMessages((current) => new Map(current).set(data.id, !expanded))
+                  ref.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+                }}
+              >
+                Toggle
+              </button>
+              <div>{data.text}</div>
+              {expanded && <div style={{ paddingTop: 12 }}>Additional details that make the row taller.</div>}
+            </div>
+          )
+        }}
+      />
+    </VirtuosoMessageListLicense>
+  )
+}
+```
+
+The `scrollToBottom` policy has the same callback shape as `data.append`. For `notifyItemsChanged`, the callback receives the current list data, the pre-change scroll location, `atBottom`, `scrollInProgress`, and `context`. ResizeObserver measures the new row heights; `notifyItemsChanged` supplies the scroll policy for preserving bottom stickiness.
 
 ## Updating Data
 
@@ -186,7 +249,7 @@ export default function App() {
 ## Replacing Data
 
 In case you're building a chat application with multiple channels, you might want to switch the message list to a different channel. The `data.replace` method lets you replace the current list of messages with a new one.
-The method accepts `data` and, optionally, an `options: { initalLocation: ItemLocation, purgeItemSizes?: boolean }` to specify the initial scroll position and weather to clear the cached item sizes. Purging the item sizes is useful when the new data has different item sizes than the previous data.
+The method accepts `data` and, optionally, an `options: { initialLocation: ItemLocation, purgeItemSizes?: boolean }` to specify the initial scroll position and whether to clear the cached item sizes. Purging the item sizes is useful when the new data has different item sizes than the previous data.
 
 ```tsx live
 import { VirtuosoMessageList, VirtuosoMessageListLicense, VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'

--- a/packages/virtuoso-skills/skills/message-list/references/15.imperative-data-api.md
+++ b/packages/virtuoso-skills/skills/message-list/references/15.imperative-data-api.md
@@ -88,7 +88,12 @@ The package exports two helpers for common policies:
 Experiment with the live example below to see how the scroll behavior changes when appending new items.
 
 ```tsx live
-import { scrollToBottomIfAtBottom, VirtuosoMessageList, VirtuosoMessageListLicense, VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'
+import {
+  scrollToBottomIfAtBottom,
+  VirtuosoMessageList,
+  VirtuosoMessageListLicense,
+  VirtuosoMessageListMethods,
+} from '@virtuoso.dev/message-list'
 import { useRef } from 'react'
 
 export default function App() {
@@ -107,7 +112,10 @@ export default function App() {
       </VirtuosoMessageListLicense>
       <button
         onClick={() => {
-          ref.current.data.append(Array.from({ length: 10 }, (_, index) => index + offset.current), scrollToBottomIfAtBottom)
+          ref.current.data.append(
+            Array.from({ length: 10 }, (_, index) => index + offset.current),
+            scrollToBottomIfAtBottom
+          )
           offset.current = offset.current + 10
         }}
       >

--- a/packages/virtuoso-skills/skills/message-list/references/2.tutorial/02.message-list.md
+++ b/packages/virtuoso-skills/skills/message-list/references/2.tutorial/02.message-list.md
@@ -158,11 +158,11 @@ feature in more detail in the next parts of the tutorial.
 
 ### The `style` prop
 
-**The Message List needs a height to render correctly**. We're setting the
+**The Message List needs a real height to render correctly**. We're setting the
 height to `80vh` to have a full-screen chat interface with a bit of space at the
 bottom. In your real world application, you might put the component into a flex
 box layout or use other methods to control the component's height - this works
-as well.
+as well. Make sure every parent in a `height: '100%'` chain is actually sized.
 
 ### The `computeItemKey` prop
 
@@ -252,6 +252,10 @@ const ItemContent: MessageListProps['ItemContent'] = ({ data: message, context }
   )
 }
 ```
+
+Message rows are measured with ResizeObserver. Avoid CSS margins on the measured
+row itself because margins are not included in the measured height. Use padding
+or an inner wrapper for spacing between messages.
 
 Now, let's pass `ItemContent` to the `VirtuosoMessageList` component and the
 `currentUser` to the context:

--- a/packages/virtuoso-skills/skills/message-list/references/2.tutorial/05.receive-messages.md
+++ b/packages/virtuoso-skills/skills/message-list/references/2.tutorial/05.receive-messages.md
@@ -53,6 +53,8 @@ Since we're using a smooth scroll, there's a slight chance of a new message comi
 The `auto-scroll-to-bottom` modifier is used for adding new messages to the end of the list. Through the `autoScroll` callback, you can conditionally determine if the list should catch up with the new messages or not.
 :::
 
+For the common version of this policy, use the exported `scrollToBottomIfAtBottom` helper. This tutorial keeps the callback inline so it can increment the unseen-message counter when the user is scrolled up.
+
 If everything works as expected, pressing the button will display a new message from another user with a smooth scroll animation.
 
 ## Display the New Message Counter

--- a/packages/virtuoso-skills/skills/message-list/references/2.tutorial/06.send-messages.md
+++ b/packages/virtuoso-skills/skills/message-list/references/2.tutorial/06.send-messages.md
@@ -14,7 +14,7 @@ Since the focus of this tutorial is the message list itself, we will use a butto
 
 ## Sending Messages and Scroll Position
 
-Unlike receiving messages, sending messages should always scroll the list to the bottom. This is because the user is sending a message, and they should see it immediately. The `autoScroll` callback will let us handle this.
+Unlike receiving messages, sending messages should always scroll the list to the bottom. This is because the user is sending a message, and they should see it immediately. The `autoScroll` callback will let us handle this. In app code, the exported `scrollToBottomAlways` helper represents this policy.
 
 ## Optimistic Updates
 
@@ -71,3 +71,5 @@ Add the following button next to the receive messages button:
 ```
 
 If everything works as expected, pressing the button will display a new message from the current user with a smooth scroll animation. After a short delay, the `Delivering...` indicator below the message should disappear.
+
+If your realtime backend echoes the same local message through a socket stream, reconcile that event by `localId` or another client-generated id. Treat it as a confirmation of the optimistic row, not as a new incoming remote message.

--- a/packages/virtuoso-skills/skills/message-list/references/20.scroll-modifier.md
+++ b/packages/virtuoso-skills/skills/message-list/references/20.scroll-modifier.md
@@ -37,6 +37,48 @@ setData((current) => ({
 This modifier should be used when new messages are added to the end of the list, and you want to scroll to the bottom of the list automatically (or conditionally, depending on the current position). An extensive example that uses this type can be found in the
 ["receiving messages" chapter of the tutorial](/virtuoso-message-list/tutorial/receive-messages/) - the behavior can be a callback function that receives the current state of the list and calculates the necessary location and scroll behavior.
 
+The `autoScroll` field accepts either a direct scroll behavior or a callback. Passing a direct behavior such as `'smooth'` applies only when the list is already at the bottom. Use the callback form when the policy depends on the source of the event. Returning `false` is the preserve-position path for users who have scrolled up. Returning a behavior, `true`, or an item location scrolls the list.
+
+The callback receives the scroll location from before the data change:
+
+- `scrollLocation`: the full `ListScrollLocation` object.
+- `atBottom`: whether the list was at the bottom before the change.
+- `scrollInProgress`: whether the list was already scrolling.
+- `data`: the appended or next data array, depending on the operation.
+- `context`: the current message-list context.
+
+For incoming remote messages, preserve users who are reading history:
+
+```tsx
+const ReceivedMessagesScrollModifier: ScrollModifier = {
+  type: 'auto-scroll-to-bottom',
+  autoScroll: ({ atBottom, scrollInProgress }) => {
+    if (atBottom || scrollInProgress) {
+      return 'smooth'
+    }
+    return false
+  },
+}
+```
+
+The package also exports helpers for common policies:
+
+```tsx
+import { scrollToBottomAlways, scrollToBottomIfAtBottom } from '@virtuoso.dev/message-list'
+
+const RemoteMessageScrollModifier: ScrollModifier = {
+  type: 'auto-scroll-to-bottom',
+  autoScroll: scrollToBottomIfAtBottom,
+}
+
+const LocalSendScrollModifier: ScrollModifier = {
+  type: 'auto-scroll-to-bottom',
+  autoScroll: scrollToBottomAlways,
+}
+```
+
+Use `scrollToBottomIfAtBottom` for incoming messages or row growth where a scrolled-up user should stay in place. Use `scrollToBottomAlways` for local actions, such as sending the current user's message, where the new item should become visible even if the user was reading older messages.
+
 ### `prepend`
 
 The `"prepend"` scroll modifier value signals that the data change will add messages to the top of the list. The scroll position will be adjusted to keep the current scroll position relative to the new data.
@@ -57,6 +99,26 @@ For the prepend modifier to work correctly, the **new data should extend the cur
 ### `{ type: 'items-change' }`
 
 This scroll modifier is useful when the data update keeps the same items but modifies their content/props - such an example would be a streaming bot response, or adding/removing reactions to certain messages. In this case, the scroll modifier lets you keep the message list scrolled to the bottom in case it is there. See the [reactions example](/virtuoso-message-list/examples/reactions/) for a live example.
+
+Use this modifier when the data array update is what changes the rendered item height:
+
+```tsx
+setData((current) => ({
+  data: current.data.map((message) => (message.id === streamingId ? { ...message, text: message.text + chunk } : message)),
+  scrollModifier: { type: 'items-change', behavior: 'smooth' },
+}))
+```
+
+If rendered rows change size because of `context`, side maps, expansion state, reactions stored outside the data array, approval state, activity loading, or other external row state, use the imperative `notifyItemsChanged` method instead. ResizeObserver will measure the rows either way; the modifier or method supplies the policy for whether the list should remain stuck to the bottom.
+
+```tsx
+const messageListRef = useRef<VirtuosoMessageListMethods<Message, MessageListContext>>(null)
+
+function setMessageExpanded(messageId: string, expanded: boolean) {
+  setExpandedMessages((current) => new Map(current).set(messageId, expanded))
+  messageListRef.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+}
+```
 
 ### `remove-from-start`
 

--- a/packages/virtuoso-skills/skills/message-list/references/21.controlled-mode-recipes.md
+++ b/packages/virtuoso-skills/skills/message-list/references/21.controlled-mode-recipes.md
@@ -1,0 +1,136 @@
+---
+id: virtuoso-message-list-controlled-mode-recipes
+title: Virtuoso Message List Controlled Mode Recipes
+description: Organize controlled message-list state behind app-owned actions for local sends, incoming messages, streaming updates, and row growth.
+sidebar_label: Controlled Mode Recipes
+sidebar_position: 11
+slug: /virtuoso-message-list/controlled-mode-recipes
+---
+
+## Controlled Mode Recipes
+
+When you drive the message list with the `data` prop, keep the message array and its `scrollModifier` together in a single `DataWithScrollModifier<Message>` state value. In larger chat integrations, wrap raw `setData` calls in app-owned actions that match product events.
+
+This page shows a recipe, not a public hook. If you wrap it in an app-local hook, keep that hook private to your application. Keep names like `appendIncoming` or `confirmLocal` in your application until several integrations prove the same abstraction is broadly reusable.
+
+```tsx
+import {
+  DataWithScrollModifier,
+  ScrollModifier,
+  scrollToBottomAlways,
+  scrollToBottomIfAtBottom,
+  VirtuosoMessageListMethods,
+} from '@virtuoso.dev/message-list'
+import { useCallback, useRef, useState } from 'react'
+
+interface Message {
+  id: string | null
+  localId: string | null
+  text: string
+  delivered: boolean
+}
+
+interface MessageListContext {
+  expandedMessages: Map<string, boolean>
+}
+
+type MessageListState = DataWithScrollModifier<Message>
+
+const InitialLocation: ScrollModifier = {
+  type: 'item-location',
+  location: { index: 'LAST', align: 'end' },
+  purgeItemSizes: true,
+}
+
+function useChatData() {
+  const messageListRef = useRef<VirtuosoMessageListMethods<Message, MessageListContext>>(null)
+  const [data, setData] = useState<MessageListState>({ data: [], scrollModifier: InitialLocation })
+  const [expandedMessages, setExpandedMessages] = useState(() => new Map<string, boolean>())
+
+  const replaceMessages = useCallback((messages: Message[]) => {
+    setData({ data: messages, scrollModifier: InitialLocation })
+  }, [])
+
+  const appendIncoming = useCallback((messages: Message[]) => {
+    setData((current) => ({
+      data: [...(current.data ?? []), ...messages],
+      scrollModifier: { type: 'auto-scroll-to-bottom', autoScroll: scrollToBottomIfAtBottom },
+    }))
+  }, [])
+
+  const appendLocal = useCallback((message: Message) => {
+    setData((current) => ({
+      data: [...(current.data ?? []), message],
+      scrollModifier: { type: 'auto-scroll-to-bottom', autoScroll: scrollToBottomAlways },
+    }))
+  }, [])
+
+  const confirmLocal = useCallback((localId: string, remoteMessage: Message) => {
+    setData((current) => ({
+      data: (current.data ?? []).map((message) => (message.localId === localId ? remoteMessage : message)),
+      scrollModifier: { type: 'items-change', behavior: 'smooth' },
+    }))
+  }, [])
+
+  const updateStreamingMessage = useCallback((id: string, chunk: string) => {
+    setData((current) => ({
+      data: (current.data ?? []).map((message) => (message.id === id ? { ...message, text: message.text + chunk } : message)),
+      scrollModifier: { type: 'items-change', behavior: 'smooth' },
+    }))
+  }, [])
+
+  const rowChromeChanged = useCallback((messageId: string, expanded: boolean) => {
+    setExpandedMessages((current) => new Map(current).set(messageId, expanded))
+    messageListRef.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+  }, [])
+
+  return {
+    appendIncoming,
+    appendLocal,
+    confirmLocal,
+    context: { expandedMessages },
+    data,
+    messageListRef,
+    replaceMessages,
+    rowChromeChanged,
+    updateStreamingMessage,
+  }
+}
+```
+
+Use `replaceMessages` when switching channels, threads, or conversations. The `purgeItemSizes: true` flag clears cached row sizes so the previous conversation does not distort the next one.
+
+Use `appendIncoming` for remote messages. It sticks to the bottom only when the user was already at the bottom or the list was already scrolling there. If the user is reading history, keep the viewport still and show an unseen-message indicator in your app.
+
+Use `appendLocal` for optimistic sends by the current user. Local sends normally force the list to the bottom so the sender can see the new message immediately.
+
+Use `confirmLocal` when the server acknowledges an optimistic message. Match by `localId` or another client-generated id, replace the local row with the canonical server row, and treat the confirmation as an existing-row update rather than a new incoming message.
+
+Use `updateStreamingMessage` when the data item itself grows, such as a streaming assistant response. The `items-change` modifier keeps the list pinned only if it was already pinned.
+
+Use `rowChromeChanged` when row height changes without a data-array update. Examples include expansion state in `context`, side maps for approvals or reactions, activity loading, and other external row state. `notifyItemsChanged` tells the list to re-evaluate the scroll-to-bottom policy while ResizeObserver performs the measurement.
+
+## Socket Echoes
+
+Realtime systems often echo the current user's optimistic message back through the same socket stream used for remote messages. Reconcile that event by identity and source before choosing a scroll policy:
+
+- If the event confirms a local optimistic row, call `confirmLocal`.
+- If the event is genuinely from another user, call `appendIncoming`.
+- If the event is a local send that was not rendered optimistically, call `appendLocal`.
+
+Do not treat every socket message as remote row growth. The event source determines whether to force bottom, preserve the scrolled-up viewport, or update an existing row.
+
+## Keys And Identity
+
+Set `computeItemKey` to a stable React key. In controlled mode, also set `itemIdentity` when prepend or remove-from-start operations need to match items but your reducer recreates item objects.
+
+```tsx
+<VirtuosoMessageList<Message, MessageListContext>
+  ref={messageListRef}
+  data={data}
+  context={context}
+  computeItemKey={({ data }) => data.id ?? `local-${data.localId}`}
+  itemIdentity={(item) => item.id ?? `local-${item.localId}`}
+  ItemContent={ItemContent}
+/>
+```

--- a/packages/virtuoso-skills/skills/message-list/references/3.examples/02.ai-chatbot.md
+++ b/packages/virtuoso-skills/skills/message-list/references/3.examples/02.ai-chatbot.md
@@ -90,6 +90,7 @@ export default function App() {
               scrollModifier: {
                 type: 'auto-scroll-to-bottom',
                 autoScroll: ({ scrollInProgress, atBottom }) => {
+                  // This is a local user action, so it intentionally brings the question into view.
                   return {
                     index: 'LAST',
                     align: 'start',

--- a/packages/virtuoso-skills/skills/message-list/references/3.examples/03.gemini.md
+++ b/packages/virtuoso-skills/skills/message-list/references/3.examples/03.gemini.md
@@ -89,6 +89,7 @@ export default function App() {
               scrollModifier: {
                 type: 'auto-scroll-to-bottom',
                 autoScroll: ({ scrollInProgress, atBottom }) => {
+                  // This is a local user action, so it intentionally brings the question into view.
                   return {
                     index: 'LAST',
                     align: 'start',

--- a/packages/virtuoso-skills/skills/message-list/references/3.examples/04.reactions.md
+++ b/packages/virtuoso-skills/skills/message-list/references/3.examples/04.reactions.md
@@ -15,6 +15,8 @@ A common problem in messaging interfaces is how to handle reactions to messages.
 The approach above is not exclusive to reactions - the same principle should be applied to any message state change that will change the message height (for example, expanding details, etc).
 :::
 
+This example stores the reaction state in the message data, so `items-change` is the right modifier. If reaction or expansion state lives in `context` or side maps instead, update that state and call `notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })` on the message-list ref.
+
 ```tsx live
 import {
   ScrollModifier,

--- a/packages/virtuoso-skills/skills/message-list/references/5.context.md
+++ b/packages/virtuoso-skills/skills/message-list/references/5.context.md
@@ -47,3 +47,12 @@ export default function App() {
   )
 }
 ```
+
+If context changes can make rendered message rows taller or shorter, notify the list after updating that external state:
+
+```tsx
+setExpandedMessages((current) => new Map(current).set(messageId, expanded))
+messageListRef.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+```
+
+Use this for expansion state, side maps, approval state, loading indicators, or reactions stored outside the message data array. ResizeObserver measures the changed rows, and `notifyItemsChanged` tells the list whether to keep sticking to the bottom or preserve a scrolled-up user's position.

--- a/packages/virtuoso-skills/skills/message-list/references/6.item-keys.md
+++ b/packages/virtuoso-skills/skills/message-list/references/6.item-keys.md
@@ -9,7 +9,7 @@ slug: /virtuoso-message-list/item-keys
 
 ## Item Keys
 
-React uses a unique key to identify each item in a list. By default, the Message List component uses the items numeric index for that, but this index might change as we load new messages or delete some. To address that, the message list exposes a `computeItemKey` prop. This prop should return a unique key for each item based on the item data.
+React uses a unique key to identify each item in a list. By default, the Message List component uses the item's numeric index for that, but this index might change as we load new messages or delete some. To address that, the message list exposes a `computeItemKey` prop. This prop should return a unique key for each item based on the item data.
 
 ```tsx live
 import { VirtuosoMessageList, VirtuosoMessageListLicense } from '@virtuoso.dev/message-list'
@@ -28,3 +28,18 @@ export default function App() {
   )
 }
 ```
+
+## `computeItemKey` And `itemIdentity`
+
+`computeItemKey` controls the React key used to mount and update item components. Use it for every chat integration with stable message ids, local optimistic ids, or both.
+
+`itemIdentity` is different. It controls how the message list matches items for controlled data operations such as `prepend` and `remove-from-start` when your reducer recreates item objects. If your controlled state creates new object references for the same messages, provide `itemIdentity` with the same stable identity you use for keys.
+
+```tsx
+<VirtuosoMessageList
+  computeItemKey={({ data }) => data.id ?? `local-${data.localId}`}
+  itemIdentity={(item) => item.id ?? `local-${item.localId}`}
+/>
+```
+
+If your data objects keep stable references across updates, `itemIdentity` is usually not necessary. If controlled prepend or trimming loses the previous visual position after recreating message objects, add it.

--- a/packages/virtuoso-skills/skills/message-list/references/80.licensing.md
+++ b/packages/virtuoso-skills/skills/message-list/references/80.licensing.md
@@ -13,7 +13,7 @@ The `@virtuoso.dev/message-list` package is distributed under a commercial licen
 
 ## License Seats Explained
 
-The number of licenses to **the maximum number of concurrent front-end developers** who contribute to a project that uses the package. This also includes developers who work on the project part-time or as contractors.
+The number of licenses is **the maximum number of concurrent front-end developers** who contribute to a project that uses the package. This also includes developers who work on the project part-time or as contractors.
 
 For example, your app uses the `VirtuosoMessageList` component for building an AI Chatbot interface. **Three front-end** and two back-end developers are working on the project. One developer develops and maintains the message list UI feature, but there are three developers in total who work on the front-end. You must purchase **three licenses** for the project.
 
@@ -41,6 +41,22 @@ The license key is a string that you need to pass as a prop to the `VirtuosoMess
 </VirtuosoMessageListLicense>
 ```
 
+In an application, put the license wrapper near the app root or around the route section that renders chat UI. Read the key from your normal public client-side environment configuration.
+
+```tsx
+const licenseKey = import.meta.env.VITE_VIRTUOSO_MESSAGE_LIST_LICENSE_KEY ?? ''
+
+export function App() {
+  return (
+    <VirtuosoMessageListLicense licenseKey={licenseKey}>
+      <Routes />
+    </VirtuosoMessageListLicense>
+  )
+}
+```
+
+For Next.js, use a public environment variable, for example `NEXT_PUBLIC_VIRTUOSO_MESSAGE_LIST_LICENSE_KEY`, and pass it from a client component.
+
 ### Next.js/SSR
 
 The license component is using a context to pass the license to the `VirtuosoMessageList` component, so you need to ensure that it is not rendered server-side only.
@@ -57,11 +73,11 @@ The license key is validated without any network requests, so you can safely use
 
 ### No license wrapper component
 
-The `VirtuosMessageListLicense` component will throw an error and render an error unless wrapped with a `VirtuosoMessageListLicense` component. For development/evaluation purposes, you need to wrap one, even with an empty key prop. This will allow you to use the component without a license key for 30 days, keeping an error message in the developer console as a reminder.
+The `VirtuosoMessageList` component will render an error unless wrapped with a `VirtuosoMessageListLicense` component. For development/evaluation purposes, you need to wrap one, even with an empty key prop. This will allow you to use the component without a license key for 30 days, keeping an error message in the developer console as a reminder.
 
 ### Missing key
 
-You can use the component without a license key for 30 days for non-production environments and for evaluation purposes - a message in the console will remind you that you have to add the key. If the component is deployed to production without a license key, it will render as an error message in the browser and an error in the console.
+You can use the component with an empty license key for 30 days for non-production environments and for evaluation purposes - a message in the console will remind you that you have to add the key. If the component is deployed to production without a valid license key, it will render as an error message in the browser and an error in the console.
 
 ### Invalid key
 

--- a/packages/virtuoso-skills/skills/message-list/references/README.md
+++ b/packages/virtuoso-skills/skills/message-list/references/README.md
@@ -136,6 +136,7 @@ export default function App() {
               scrollModifier: {
                 type: 'auto-scroll-to-bottom',
                 autoScroll: ({ scrollInProgress, atBottom }) => {
+                  // This is a local user action, so it intentionally brings the question into view.
                   return {
                     index: 'LAST',
                     align: 'start',

--- a/plugins/virtuoso-skills/skills/message-list/SKILL.md
+++ b/plugins/virtuoso-skills/skills/message-list/SKILL.md
@@ -4,8 +4,9 @@ description: >-
   Build chat, messaging, and AI conversation UIs with @virtuoso.dev/message-list. Use this skill when (1) building a chat or
   messaging interface, (2) streaming AI assistant responses into a conversation, (3) loading older messages when scrolling up,
   (4) adding scroll-to-bottom buttons or unseen-message indicators, (5) switching between channels/conversations, or (6) any task
-  involving VirtuosoMessageList, VirtuosoMessageListLicense, useVirtuosoMethods, useVirtuosoLocation, scrollModifier, or
-  data.append/prepend/map. The package is commercial and requires a license key.
+  involving VirtuosoMessageList, VirtuosoMessageListLicense, useVirtuosoMethods, useVirtuosoLocation, scrollModifier,
+  notifyItemsChanged, scrollToBottomIfAtBottom, scrollToBottomAlways, or data.append/prepend/map. The package is commercial
+  and requires a license key.
 ---
 
 # @virtuoso.dev/message-list
@@ -22,7 +23,7 @@ The package is commercial (annual, per-developer). Every instance must be wrappe
 </VirtuosoMessageListLicense>
 ```
 
-An empty `licenseKey=""` works as a 30-day non-production trial. Validation is local — no network requests. Surface this to the user when introducing the package into a project; keys come from <https://virtuoso.dev/pricing/>.
+An empty `licenseKey=""` is licensed for 30-day non-production evaluation: it keeps rendering in development with a console reminder, while production without a valid key renders an error. Validation is local — no network requests. Surface this to the user when introducing the package into a project; keys come from <https://virtuoso.dev/pricing/>. Prefer an app-level wrapper that reads from the normal public client-side environment configuration.
 
 ## Core mental model: data updates carry scroll instructions
 
@@ -37,38 +38,56 @@ const [data, setData] = useState<VirtuosoMessageListProps<Message, null>['data']
 <VirtuosoMessageList<Message, null> style={{ height: '100%' }} data={data} computeItemKey={({ data }) => data.key} ItemContent={ItemContent} />
 ```
 
-`ItemContent` is a component receiving `{ data, index, context }` props (not positional arguments like react-virtuoso).
+`ItemContent` is a component receiving `{ data, index, context }` props (not positional arguments like react-virtuoso). Extract it outside the parent render function unless it needs to close over local state.
+
+External row state is different from data updates. If `context`, side maps, expansion state, reactions, approvals, or loading flags can change row height without changing the data array, call `notifyItemsChanged({ scrollToBottom })` on the message-list ref after updating that state.
 
 ### Scroll modifier reference
 
 | Modifier                                               | When to use                                                                                             |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- | ------ | -------------------------- |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
 | `{ type: 'item-location', location, purgeItemSizes? }` | Initial load or channel switch; `purgeItemSizes: true` clears cached sizes when the items are different |
-| `{ type: 'auto-scroll-to-bottom', autoScroll }`        | New messages arrive; callback receives `{ atBottom, scrollInProgress, ... }` and returns `'smooth'      | 'auto' | false` or an item location |
+| `{ type: 'auto-scroll-to-bottom', autoScroll }`        | New messages are appended; callback can return `false`, a behavior, `true`, or an item location         |
 | `'prepend'`                                            | Older messages added to the top; keeps the current messages visually in place                           |
-| `{ type: 'items-change', behavior }`                   | Existing items changed size (streaming text, reactions); stays at bottom if already there               |
+| `{ type: 'items-change', behavior }`                   | Existing data items changed size, such as streaming text or reactions stored in the data item           |
 | `'remove-from-start'` / `'remove-from-end'`            | Trimming data while preserving the visual position                                                      |
 | `null` / `undefined`                                   | Leave the scroll position alone                                                                         |
+
+In callback form, returning a behavior or item location scrolls even when `atBottom` is false. Return `false` to preserve the viewport for a scrolled-up user.
 
 ## Common patterns
 
 ### Receiving messages (auto-scroll when at bottom)
 
 ```tsx
+import { scrollToBottomIfAtBottom } from '@virtuoso.dev/message-list'
+
 setData((current) => ({
   data: [...current.data, incoming],
   scrollModifier: {
     type: 'auto-scroll-to-bottom',
-    autoScroll: ({ atBottom, scrollInProgress }) => ({
-      index: 'LAST',
-      align: 'end',
-      behavior: atBottom || scrollInProgress ? 'smooth' : 'auto',
-    }),
+    autoScroll: scrollToBottomIfAtBottom,
   },
 }))
 ```
 
-Returning `false` from `autoScroll` when not at bottom is how you keep the viewport still and instead increment an unseen-messages counter.
+Use `scrollToBottomIfAtBottom` for remote messages. It returns `'smooth'` when the list is already at the bottom or already scrolling there, otherwise `false`. If the app needs an unseen-message counter, use the inline callback form and increment the counter before returning `false`.
+
+### Sending local messages (force bottom)
+
+```tsx
+import { scrollToBottomAlways } from '@virtuoso.dev/message-list'
+
+setData((current) => ({
+  data: [...current.data, optimisticLocalMessage],
+  scrollModifier: {
+    type: 'auto-scroll-to-bottom',
+    autoScroll: scrollToBottomAlways,
+  },
+}))
+```
+
+Use `scrollToBottomAlways` for local current-user actions where the new last item should become visible even if the user was scrolled up. If a realtime socket echoes the same optimistic message back, reconcile it by `localId` or another client-generated identity and treat it as confirmation, not a new incoming remote message.
 
 ### Streaming an AI response
 
@@ -82,6 +101,21 @@ setData((current) => ({
 ```
 
 `items-change` keeps the view pinned to the bottom while the message grows, without jumping if the user scrolled up. See [ai-chatbot](references/3.examples/02.ai-chatbot.md) and [gemini](references/3.examples/03.gemini.md) (question pinned to top, answer streams below).
+
+### External row state changed size
+
+Use `notifyItemsChanged` when row content changes size without changing the data array:
+
+```tsx
+import { scrollToBottomIfAtBottom, type VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'
+
+const messageListRef = useRef<VirtuosoMessageListMethods<Message, MessageListContext>>(null)
+
+setExpandedMessages((current) => new Map(current).set(messageId, expanded))
+messageListRef.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+```
+
+ResizeObserver measures the rows; `notifyItemsChanged` supplies the scroll policy. Use it for expansion state in `context`, side maps for reactions or approvals, activity loading, or any other external row state.
 
 ### Loading older messages on scroll-up
 
@@ -114,6 +148,19 @@ const StickyFooter = () => {
 
 Keep one data object per channel and swap with `replace`/`item-location` + `purgeItemSizes: true`, so size caches from the previous channel don't distort the new one. See [multiple-channels](references/2.tutorial/07.multiple-channels.md).
 
+### Controlled mode recipe
+
+For controlled `data` prop usage, keep `DataWithScrollModifier<Message>` behind app-owned actions such as `replaceMessages`, `appendIncoming`, `appendLocal`, `confirmLocal`, `updateStreamingMessage`, and `rowChromeChanged`. This is a recipe layer in app code, not an official exported hook and not a replacement for the imperative `data.*` API.
+
+- `replaceMessages`: channel or thread switch with `{ type: 'item-location', location: { index: 'LAST', align: 'end' }, purgeItemSizes: true }`.
+- `appendIncoming`: remote messages with `scrollToBottomIfAtBottom`.
+- `appendLocal`: optimistic local sends with `scrollToBottomAlways`.
+- `confirmLocal`: match the socket/server acknowledgement by `localId` and update the existing row.
+- `updateStreamingMessage`: map the existing message and use `{ type: 'items-change', behavior: 'smooth' }`.
+- `rowChromeChanged`: update external row state and call `notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })`.
+
+Do not invent or recommend a public `useVirtuosoMessageListData` hook before trying this recipe-level controlled state in app code. See [controlled-mode-recipes](references/21.controlled-mode-recipes.md).
+
 ## Imperative API
 
 Via `ref={useRef<VirtuosoMessageListMethods<Message>>(null)}` from outside, or `useVirtuosoMethods()` from components rendered inside the list:
@@ -122,6 +169,7 @@ Via `ref={useRef<VirtuosoMessageListMethods<Message>>(null)}` from outside, or `
 - `data.map(fn, autoscrollBehavior?)` — update items (reactions, edits, streaming)
 - `data.findAndDelete(predicate)`, `data.deleteRange(start, length)`, `data.replace(data, options?)`
 - `data.find(predicate)`, `data.findIndex(predicate)`, `data.get()`, `data.getCurrentlyRendered()`
+- `notifyItemsChanged({ scrollToBottom })` — use after context or side-state changes that can resize rendered rows without changing the data array
 - `scrollToItem({ index: number | 'LAST', align, behavior })`
 
 The declarative `data` prop and the imperative `data.*` methods are alternative ways to drive the same list — pick one as the primary mechanism per component to avoid fighting updates.
@@ -131,6 +179,7 @@ The declarative `data` prop and the imperative `data.*` methods are alternative 
 - `ItemContent: ({ data, index, context }) => JSX` — message renderer
 - `context` — shared state (current user, loading flags) available to `ItemContent` and all custom slots; avoids prop drilling
 - `computeItemKey({ data })` — stable message key; required for prepending/streaming to work without remounts
+- `itemIdentity(item)` — stable item identity for controlled prepend/remove-from-start matching when reducers recreate item objects
 - Slots: `Header`, `Footer` (scroll with content), `StickyHeader`, `StickyFooter` (fixed, measured to avoid overlap), `EmptyPlaceholder`
 - `initialLocation: { index: 'LAST', align: 'end' }` — start at the bottom
 - Hooks (inside the list): `useVirtuosoMethods()`, `useVirtuosoLocation()` (`atBottom`, `bottomOffset`, `listOffset`, `scrollInProgress`), `useCurrentlyRenderedData()`
@@ -138,16 +187,30 @@ The declarative `data` prop and the imperative `data.*` methods are alternative 
 ## Pitfalls
 
 - **No height → nothing renders.** The component needs a real height (`style={{ height: '100%' }}` with a sized parent).
+- **Missing license wrapper → runtime error.** Wrap with `VirtuosoMessageListLicense`; an empty key is only for non-production evaluation.
 - **Missing `computeItemKey`** causes remounts and scroll jumps on prepend and streaming updates.
-- **Margins on message items** break height measurement (ResizeObserver excludes margins) — use padding.
+- **Missing `itemIdentity` in controlled mode** can break prepend/remove-from-start matching when reducers recreate item objects.
+- **Margins on measured message rows** break height measurement because ResizeObserver excludes margins. Use padding or inner wrappers.
+- **Implicit scroll policy** causes chat regressions. Decide per source: local send usually forces bottom, remote receive preserves scrolled-up users, streaming uses `items-change`, and context-only row growth uses `notifyItemsChanged`.
 - **"ResizeObserver loop" errors are benign** — filter them in dev overlays and error tracking; see [resize-observer-errors](references/19.resize-observer-errors.md).
 - **JSDOM tests need mocked measurements** via `VirtuosoMessageListTestingContext.Provider value={{ itemHeight, viewportHeight }}` plus a ResizeObserver polyfill; prefer Playwright for scroll behavior. See [testing](references/11.testing.md).
+
+## Migration checklist from a plain mapped chat list
+
+- Add the `VirtuosoMessageListLicense` wrapper and decide how the key is supplied.
+- Give the list a real height through a sized parent or direct style.
+- Extract `ItemContent` and pass shared state through `context`.
+- Add stable `computeItemKey` for message ids and local optimistic ids.
+- Add `itemIdentity` when controlled data recreates objects and uses prepend/trimming.
+- Remove margins from measured rows; use padding or inner wrappers for spacing.
+- Choose an explicit scroll policy for local sends, remote receives, streaming updates, socket echoes, and external row growth.
+- Use Playwright/browser tests for scroll behavior where possible; use the testing context for JSDOM unit tests.
 
 ## References
 
 - [references/README.md](references/README.md) — overview and live example
 - `references/2.tutorial/` — step-by-step chat build: [intro](references/2.tutorial/01.intro.md), [message-list](references/2.tutorial/02.message-list.md), [loading-older-messages](references/2.tutorial/03.loading-older-messages.md), [scroll-to-bottom-button](references/2.tutorial/04.scroll-to-bottom-button.md), [receive-messages](references/2.tutorial/05.receive-messages.md), [send-messages](references/2.tutorial/06.send-messages.md), [multiple-channels](references/2.tutorial/07.multiple-channels.md)
 - `references/3.examples/` — [messaging](references/3.examples/01.messaging.md), [ai-chatbot](references/3.examples/02.ai-chatbot.md), [gemini](references/3.examples/03.gemini.md), [reactions](references/3.examples/04.reactions.md), [date-separators](references/3.examples/05.date-separators.md), [scroll-to-reply](references/3.examples/06.scroll-to-reply.md), [grouped-messages](references/3.examples/07.grouped-messages.md)
-- Feature guides: [headers-footers](references/4.headers-footers.md), [context](references/5.context.md), [item-keys](references/6.item-keys.md), [hooks](references/7.hooks.md), [custom-scrollbar](references/8.custom-scrollbar.md), [scrolling-to-item](references/9.scrolling-to-item.md), [smooth-scrolling](references/10.smooth-scrolling.md), [imperative-data-api](references/15.imperative-data-api.md), [scroll-modifier](references/20.scroll-modifier.md), [testing](references/11.testing.md), [licensing](references/80.licensing.md)
+- Feature guides: [headers-footers](references/4.headers-footers.md), [context](references/5.context.md), [item-keys](references/6.item-keys.md), [hooks](references/7.hooks.md), [custom-scrollbar](references/8.custom-scrollbar.md), [scrolling-to-item](references/9.scrolling-to-item.md), [smooth-scrolling](references/10.smooth-scrolling.md), [imperative-data-api](references/15.imperative-data-api.md), [scroll-modifier](references/20.scroll-modifier.md), [controlled-mode-recipes](references/21.controlled-mode-recipes.md), [testing](references/11.testing.md), [licensing](references/80.licensing.md)
 
 Full API reference: <https://virtuoso.dev/message-list/>

--- a/plugins/virtuoso-skills/skills/message-list/references/15.imperative-data-api.md
+++ b/plugins/virtuoso-skills/skills/message-list/references/15.imperative-data-api.md
@@ -13,7 +13,7 @@ In addition to the `data` prop, the message list component exposes an imperative
 
 :::info
 
-### What is an imperative API and why does the message list uses it?
+### What is an imperative API and why does the message list use it?
 
 There are two ways to work with React components - the imperative way and the declarative way. In the declarative way, you describe the UI based on the current state, and React takes care of updating the UI when the state changes.
 
@@ -64,7 +64,7 @@ export default function App() {
 
 Appending data to the message list usually requires an adjustment to the scroll position to keep the new messages in view. However, this is not always the case - for example, if the user is scrolling up to read older messages. Also, depending on various factors the adjustment may happen instantly or with a smooth scroll animation.
 
-To support those scenarios, the `data.append` method accepts `data` and, an optional, `scrollToBottom` argument that can be a string - `"smooth"`, `"auto"` or `"instant"` (passed directly to the underlying `scrollTo` DOM call), or a function that receives the following arguments as an object:
+To support those scenarios, the `data.append` method accepts `data` and an optional `scrollToBottom` argument that can be a string - `"smooth"`, `"auto"` or `"instant"` (passed directly to the underlying `scrollTo` DOM call), or a function that receives the following arguments as an object:
 
 - `scrollLocation: ListScrollLocation` - the current scroll location (same object as the one passed to the `onScroll` callback and the one available from `useScrollLocation` hook)
 - `scrollInProgress: boolean` - whether or not the list is currently scrolling
@@ -78,10 +78,17 @@ The function should return:
 - a string value, one of `"smooth"`, `"auto"` or `"instant"` to control the scroll behavior - the list will scroll to the bottom with the specified behavior
 - a location object, `{ index: number | 'LAST', align: 'start' | 'center' | 'end', behavior: 'smooth' | 'auto' }` to control the scroll behavior and the alignment of the new items. You can use this to scroll to the bottom, or to scroll the first new message to the top of the list.
 
+In callback form, returning a behavior or item location scrolls even when `atBottom` is `false`. Return `false` to preserve a scrolled-up user's viewport.
+
+The package exports two helpers for common policies:
+
+- `scrollToBottomIfAtBottom`: use for incoming messages or row growth. It returns `'smooth'` when the list is already at the bottom or already scrolling there, otherwise `false`.
+- `scrollToBottomAlways`: use for local sends or other current-user actions that should make the new last item visible.
+
 Experiment with the live example below to see how the scroll behavior changes when appending new items.
 
 ```tsx live
-import { VirtuosoMessageList, VirtuosoMessageListLicense, VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'
+import { scrollToBottomIfAtBottom, VirtuosoMessageList, VirtuosoMessageListLicense, VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'
 import { useRef } from 'react'
 
 export default function App() {
@@ -100,10 +107,7 @@ export default function App() {
       </VirtuosoMessageListLicense>
       <button
         onClick={() => {
-          ref.current.data.append(
-            Array.from({ length: 10 }, (_, index) => index + offset.current),
-            (params) => true
-          )
+          ref.current.data.append(Array.from({ length: 10 }, (_, index) => index + offset.current), scrollToBottomIfAtBottom)
           offset.current = offset.current + 10
         }}
       >
@@ -113,6 +117,65 @@ export default function App() {
   )
 }
 ```
+
+## Notifying Item Size Changes Without Data Changes
+
+Use `notifyItemsChanged({ scrollToBottom })` when rendered item content can change height without changing the message data array. Common examples include expansion state in `context`, side maps for reactions or approvals, activity-loading state, or any other external row state.
+
+```tsx
+import {
+  scrollToBottomIfAtBottom,
+  VirtuosoMessageList,
+  VirtuosoMessageListLicense,
+  VirtuosoMessageListMethods,
+} from '@virtuoso.dev/message-list'
+import { useRef, useState } from 'react'
+
+interface Message {
+  id: string
+  text: string
+}
+
+interface MessageListContext {
+  expandedMessages: Map<string, boolean>
+}
+
+export default function App() {
+  const ref = useRef<VirtuosoMessageListMethods<Message, MessageListContext>>(null)
+  const [expandedMessages, setExpandedMessages] = useState(() => new Map<string, boolean>())
+
+  return (
+    <VirtuosoMessageListLicense licenseKey="">
+      <VirtuosoMessageList<Message, MessageListContext>
+        ref={ref}
+        style={{ height: 500 }}
+        context={{ expandedMessages }}
+        initialData={[{ id: '1', text: 'Toggle extra row content' }]}
+        computeItemKey={({ data }) => data.id}
+        ItemContent={({ data, context }) => {
+          const expanded = context.expandedMessages.get(data.id) ?? false
+          return (
+            <div style={{ padding: 12 }}>
+              <button
+                onClick={() => {
+                  setExpandedMessages((current) => new Map(current).set(data.id, !expanded))
+                  ref.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+                }}
+              >
+                Toggle
+              </button>
+              <div>{data.text}</div>
+              {expanded && <div style={{ paddingTop: 12 }}>Additional details that make the row taller.</div>}
+            </div>
+          )
+        }}
+      />
+    </VirtuosoMessageListLicense>
+  )
+}
+```
+
+The `scrollToBottom` policy has the same callback shape as `data.append`. For `notifyItemsChanged`, the callback receives the current list data, the pre-change scroll location, `atBottom`, `scrollInProgress`, and `context`. ResizeObserver measures the new row heights; `notifyItemsChanged` supplies the scroll policy for preserving bottom stickiness.
 
 ## Updating Data
 
@@ -186,7 +249,7 @@ export default function App() {
 ## Replacing Data
 
 In case you're building a chat application with multiple channels, you might want to switch the message list to a different channel. The `data.replace` method lets you replace the current list of messages with a new one.
-The method accepts `data` and, optionally, an `options: { initalLocation: ItemLocation, purgeItemSizes?: boolean }` to specify the initial scroll position and weather to clear the cached item sizes. Purging the item sizes is useful when the new data has different item sizes than the previous data.
+The method accepts `data` and, optionally, an `options: { initialLocation: ItemLocation, purgeItemSizes?: boolean }` to specify the initial scroll position and whether to clear the cached item sizes. Purging the item sizes is useful when the new data has different item sizes than the previous data.
 
 ```tsx live
 import { VirtuosoMessageList, VirtuosoMessageListLicense, VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'

--- a/plugins/virtuoso-skills/skills/message-list/references/15.imperative-data-api.md
+++ b/plugins/virtuoso-skills/skills/message-list/references/15.imperative-data-api.md
@@ -88,7 +88,12 @@ The package exports two helpers for common policies:
 Experiment with the live example below to see how the scroll behavior changes when appending new items.
 
 ```tsx live
-import { scrollToBottomIfAtBottom, VirtuosoMessageList, VirtuosoMessageListLicense, VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'
+import {
+  scrollToBottomIfAtBottom,
+  VirtuosoMessageList,
+  VirtuosoMessageListLicense,
+  VirtuosoMessageListMethods,
+} from '@virtuoso.dev/message-list'
 import { useRef } from 'react'
 
 export default function App() {
@@ -107,7 +112,10 @@ export default function App() {
       </VirtuosoMessageListLicense>
       <button
         onClick={() => {
-          ref.current.data.append(Array.from({ length: 10 }, (_, index) => index + offset.current), scrollToBottomIfAtBottom)
+          ref.current.data.append(
+            Array.from({ length: 10 }, (_, index) => index + offset.current),
+            scrollToBottomIfAtBottom
+          )
           offset.current = offset.current + 10
         }}
       >

--- a/plugins/virtuoso-skills/skills/message-list/references/2.tutorial/02.message-list.md
+++ b/plugins/virtuoso-skills/skills/message-list/references/2.tutorial/02.message-list.md
@@ -158,11 +158,11 @@ feature in more detail in the next parts of the tutorial.
 
 ### The `style` prop
 
-**The Message List needs a height to render correctly**. We're setting the
+**The Message List needs a real height to render correctly**. We're setting the
 height to `80vh` to have a full-screen chat interface with a bit of space at the
 bottom. In your real world application, you might put the component into a flex
 box layout or use other methods to control the component's height - this works
-as well.
+as well. Make sure every parent in a `height: '100%'` chain is actually sized.
 
 ### The `computeItemKey` prop
 
@@ -252,6 +252,10 @@ const ItemContent: MessageListProps['ItemContent'] = ({ data: message, context }
   )
 }
 ```
+
+Message rows are measured with ResizeObserver. Avoid CSS margins on the measured
+row itself because margins are not included in the measured height. Use padding
+or an inner wrapper for spacing between messages.
 
 Now, let's pass `ItemContent` to the `VirtuosoMessageList` component and the
 `currentUser` to the context:

--- a/plugins/virtuoso-skills/skills/message-list/references/2.tutorial/05.receive-messages.md
+++ b/plugins/virtuoso-skills/skills/message-list/references/2.tutorial/05.receive-messages.md
@@ -53,6 +53,8 @@ Since we're using a smooth scroll, there's a slight chance of a new message comi
 The `auto-scroll-to-bottom` modifier is used for adding new messages to the end of the list. Through the `autoScroll` callback, you can conditionally determine if the list should catch up with the new messages or not.
 :::
 
+For the common version of this policy, use the exported `scrollToBottomIfAtBottom` helper. This tutorial keeps the callback inline so it can increment the unseen-message counter when the user is scrolled up.
+
 If everything works as expected, pressing the button will display a new message from another user with a smooth scroll animation.
 
 ## Display the New Message Counter

--- a/plugins/virtuoso-skills/skills/message-list/references/2.tutorial/06.send-messages.md
+++ b/plugins/virtuoso-skills/skills/message-list/references/2.tutorial/06.send-messages.md
@@ -14,7 +14,7 @@ Since the focus of this tutorial is the message list itself, we will use a butto
 
 ## Sending Messages and Scroll Position
 
-Unlike receiving messages, sending messages should always scroll the list to the bottom. This is because the user is sending a message, and they should see it immediately. The `autoScroll` callback will let us handle this.
+Unlike receiving messages, sending messages should always scroll the list to the bottom. This is because the user is sending a message, and they should see it immediately. The `autoScroll` callback will let us handle this. In app code, the exported `scrollToBottomAlways` helper represents this policy.
 
 ## Optimistic Updates
 
@@ -71,3 +71,5 @@ Add the following button next to the receive messages button:
 ```
 
 If everything works as expected, pressing the button will display a new message from the current user with a smooth scroll animation. After a short delay, the `Delivering...` indicator below the message should disappear.
+
+If your realtime backend echoes the same local message through a socket stream, reconcile that event by `localId` or another client-generated id. Treat it as a confirmation of the optimistic row, not as a new incoming remote message.

--- a/plugins/virtuoso-skills/skills/message-list/references/20.scroll-modifier.md
+++ b/plugins/virtuoso-skills/skills/message-list/references/20.scroll-modifier.md
@@ -37,6 +37,48 @@ setData((current) => ({
 This modifier should be used when new messages are added to the end of the list, and you want to scroll to the bottom of the list automatically (or conditionally, depending on the current position). An extensive example that uses this type can be found in the
 ["receiving messages" chapter of the tutorial](/virtuoso-message-list/tutorial/receive-messages/) - the behavior can be a callback function that receives the current state of the list and calculates the necessary location and scroll behavior.
 
+The `autoScroll` field accepts either a direct scroll behavior or a callback. Passing a direct behavior such as `'smooth'` applies only when the list is already at the bottom. Use the callback form when the policy depends on the source of the event. Returning `false` is the preserve-position path for users who have scrolled up. Returning a behavior, `true`, or an item location scrolls the list.
+
+The callback receives the scroll location from before the data change:
+
+- `scrollLocation`: the full `ListScrollLocation` object.
+- `atBottom`: whether the list was at the bottom before the change.
+- `scrollInProgress`: whether the list was already scrolling.
+- `data`: the appended or next data array, depending on the operation.
+- `context`: the current message-list context.
+
+For incoming remote messages, preserve users who are reading history:
+
+```tsx
+const ReceivedMessagesScrollModifier: ScrollModifier = {
+  type: 'auto-scroll-to-bottom',
+  autoScroll: ({ atBottom, scrollInProgress }) => {
+    if (atBottom || scrollInProgress) {
+      return 'smooth'
+    }
+    return false
+  },
+}
+```
+
+The package also exports helpers for common policies:
+
+```tsx
+import { scrollToBottomAlways, scrollToBottomIfAtBottom } from '@virtuoso.dev/message-list'
+
+const RemoteMessageScrollModifier: ScrollModifier = {
+  type: 'auto-scroll-to-bottom',
+  autoScroll: scrollToBottomIfAtBottom,
+}
+
+const LocalSendScrollModifier: ScrollModifier = {
+  type: 'auto-scroll-to-bottom',
+  autoScroll: scrollToBottomAlways,
+}
+```
+
+Use `scrollToBottomIfAtBottom` for incoming messages or row growth where a scrolled-up user should stay in place. Use `scrollToBottomAlways` for local actions, such as sending the current user's message, where the new item should become visible even if the user was reading older messages.
+
 ### `prepend`
 
 The `"prepend"` scroll modifier value signals that the data change will add messages to the top of the list. The scroll position will be adjusted to keep the current scroll position relative to the new data.
@@ -57,6 +99,26 @@ For the prepend modifier to work correctly, the **new data should extend the cur
 ### `{ type: 'items-change' }`
 
 This scroll modifier is useful when the data update keeps the same items but modifies their content/props - such an example would be a streaming bot response, or adding/removing reactions to certain messages. In this case, the scroll modifier lets you keep the message list scrolled to the bottom in case it is there. See the [reactions example](/virtuoso-message-list/examples/reactions/) for a live example.
+
+Use this modifier when the data array update is what changes the rendered item height:
+
+```tsx
+setData((current) => ({
+  data: current.data.map((message) => (message.id === streamingId ? { ...message, text: message.text + chunk } : message)),
+  scrollModifier: { type: 'items-change', behavior: 'smooth' },
+}))
+```
+
+If rendered rows change size because of `context`, side maps, expansion state, reactions stored outside the data array, approval state, activity loading, or other external row state, use the imperative `notifyItemsChanged` method instead. ResizeObserver will measure the rows either way; the modifier or method supplies the policy for whether the list should remain stuck to the bottom.
+
+```tsx
+const messageListRef = useRef<VirtuosoMessageListMethods<Message, MessageListContext>>(null)
+
+function setMessageExpanded(messageId: string, expanded: boolean) {
+  setExpandedMessages((current) => new Map(current).set(messageId, expanded))
+  messageListRef.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+}
+```
 
 ### `remove-from-start`
 

--- a/plugins/virtuoso-skills/skills/message-list/references/21.controlled-mode-recipes.md
+++ b/plugins/virtuoso-skills/skills/message-list/references/21.controlled-mode-recipes.md
@@ -1,0 +1,136 @@
+---
+id: virtuoso-message-list-controlled-mode-recipes
+title: Virtuoso Message List Controlled Mode Recipes
+description: Organize controlled message-list state behind app-owned actions for local sends, incoming messages, streaming updates, and row growth.
+sidebar_label: Controlled Mode Recipes
+sidebar_position: 11
+slug: /virtuoso-message-list/controlled-mode-recipes
+---
+
+## Controlled Mode Recipes
+
+When you drive the message list with the `data` prop, keep the message array and its `scrollModifier` together in a single `DataWithScrollModifier<Message>` state value. In larger chat integrations, wrap raw `setData` calls in app-owned actions that match product events.
+
+This page shows a recipe, not a public hook. If you wrap it in an app-local hook, keep that hook private to your application. Keep names like `appendIncoming` or `confirmLocal` in your application until several integrations prove the same abstraction is broadly reusable.
+
+```tsx
+import {
+  DataWithScrollModifier,
+  ScrollModifier,
+  scrollToBottomAlways,
+  scrollToBottomIfAtBottom,
+  VirtuosoMessageListMethods,
+} from '@virtuoso.dev/message-list'
+import { useCallback, useRef, useState } from 'react'
+
+interface Message {
+  id: string | null
+  localId: string | null
+  text: string
+  delivered: boolean
+}
+
+interface MessageListContext {
+  expandedMessages: Map<string, boolean>
+}
+
+type MessageListState = DataWithScrollModifier<Message>
+
+const InitialLocation: ScrollModifier = {
+  type: 'item-location',
+  location: { index: 'LAST', align: 'end' },
+  purgeItemSizes: true,
+}
+
+function useChatData() {
+  const messageListRef = useRef<VirtuosoMessageListMethods<Message, MessageListContext>>(null)
+  const [data, setData] = useState<MessageListState>({ data: [], scrollModifier: InitialLocation })
+  const [expandedMessages, setExpandedMessages] = useState(() => new Map<string, boolean>())
+
+  const replaceMessages = useCallback((messages: Message[]) => {
+    setData({ data: messages, scrollModifier: InitialLocation })
+  }, [])
+
+  const appendIncoming = useCallback((messages: Message[]) => {
+    setData((current) => ({
+      data: [...(current.data ?? []), ...messages],
+      scrollModifier: { type: 'auto-scroll-to-bottom', autoScroll: scrollToBottomIfAtBottom },
+    }))
+  }, [])
+
+  const appendLocal = useCallback((message: Message) => {
+    setData((current) => ({
+      data: [...(current.data ?? []), message],
+      scrollModifier: { type: 'auto-scroll-to-bottom', autoScroll: scrollToBottomAlways },
+    }))
+  }, [])
+
+  const confirmLocal = useCallback((localId: string, remoteMessage: Message) => {
+    setData((current) => ({
+      data: (current.data ?? []).map((message) => (message.localId === localId ? remoteMessage : message)),
+      scrollModifier: { type: 'items-change', behavior: 'smooth' },
+    }))
+  }, [])
+
+  const updateStreamingMessage = useCallback((id: string, chunk: string) => {
+    setData((current) => ({
+      data: (current.data ?? []).map((message) => (message.id === id ? { ...message, text: message.text + chunk } : message)),
+      scrollModifier: { type: 'items-change', behavior: 'smooth' },
+    }))
+  }, [])
+
+  const rowChromeChanged = useCallback((messageId: string, expanded: boolean) => {
+    setExpandedMessages((current) => new Map(current).set(messageId, expanded))
+    messageListRef.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+  }, [])
+
+  return {
+    appendIncoming,
+    appendLocal,
+    confirmLocal,
+    context: { expandedMessages },
+    data,
+    messageListRef,
+    replaceMessages,
+    rowChromeChanged,
+    updateStreamingMessage,
+  }
+}
+```
+
+Use `replaceMessages` when switching channels, threads, or conversations. The `purgeItemSizes: true` flag clears cached row sizes so the previous conversation does not distort the next one.
+
+Use `appendIncoming` for remote messages. It sticks to the bottom only when the user was already at the bottom or the list was already scrolling there. If the user is reading history, keep the viewport still and show an unseen-message indicator in your app.
+
+Use `appendLocal` for optimistic sends by the current user. Local sends normally force the list to the bottom so the sender can see the new message immediately.
+
+Use `confirmLocal` when the server acknowledges an optimistic message. Match by `localId` or another client-generated id, replace the local row with the canonical server row, and treat the confirmation as an existing-row update rather than a new incoming message.
+
+Use `updateStreamingMessage` when the data item itself grows, such as a streaming assistant response. The `items-change` modifier keeps the list pinned only if it was already pinned.
+
+Use `rowChromeChanged` when row height changes without a data-array update. Examples include expansion state in `context`, side maps for approvals or reactions, activity loading, and other external row state. `notifyItemsChanged` tells the list to re-evaluate the scroll-to-bottom policy while ResizeObserver performs the measurement.
+
+## Socket Echoes
+
+Realtime systems often echo the current user's optimistic message back through the same socket stream used for remote messages. Reconcile that event by identity and source before choosing a scroll policy:
+
+- If the event confirms a local optimistic row, call `confirmLocal`.
+- If the event is genuinely from another user, call `appendIncoming`.
+- If the event is a local send that was not rendered optimistically, call `appendLocal`.
+
+Do not treat every socket message as remote row growth. The event source determines whether to force bottom, preserve the scrolled-up viewport, or update an existing row.
+
+## Keys And Identity
+
+Set `computeItemKey` to a stable React key. In controlled mode, also set `itemIdentity` when prepend or remove-from-start operations need to match items but your reducer recreates item objects.
+
+```tsx
+<VirtuosoMessageList<Message, MessageListContext>
+  ref={messageListRef}
+  data={data}
+  context={context}
+  computeItemKey={({ data }) => data.id ?? `local-${data.localId}`}
+  itemIdentity={(item) => item.id ?? `local-${item.localId}`}
+  ItemContent={ItemContent}
+/>
+```

--- a/plugins/virtuoso-skills/skills/message-list/references/3.examples/02.ai-chatbot.md
+++ b/plugins/virtuoso-skills/skills/message-list/references/3.examples/02.ai-chatbot.md
@@ -90,6 +90,7 @@ export default function App() {
               scrollModifier: {
                 type: 'auto-scroll-to-bottom',
                 autoScroll: ({ scrollInProgress, atBottom }) => {
+                  // This is a local user action, so it intentionally brings the question into view.
                   return {
                     index: 'LAST',
                     align: 'start',

--- a/plugins/virtuoso-skills/skills/message-list/references/3.examples/03.gemini.md
+++ b/plugins/virtuoso-skills/skills/message-list/references/3.examples/03.gemini.md
@@ -89,6 +89,7 @@ export default function App() {
               scrollModifier: {
                 type: 'auto-scroll-to-bottom',
                 autoScroll: ({ scrollInProgress, atBottom }) => {
+                  // This is a local user action, so it intentionally brings the question into view.
                   return {
                     index: 'LAST',
                     align: 'start',

--- a/plugins/virtuoso-skills/skills/message-list/references/3.examples/04.reactions.md
+++ b/plugins/virtuoso-skills/skills/message-list/references/3.examples/04.reactions.md
@@ -15,6 +15,8 @@ A common problem in messaging interfaces is how to handle reactions to messages.
 The approach above is not exclusive to reactions - the same principle should be applied to any message state change that will change the message height (for example, expanding details, etc).
 :::
 
+This example stores the reaction state in the message data, so `items-change` is the right modifier. If reaction or expansion state lives in `context` or side maps instead, update that state and call `notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })` on the message-list ref.
+
 ```tsx live
 import {
   ScrollModifier,

--- a/plugins/virtuoso-skills/skills/message-list/references/5.context.md
+++ b/plugins/virtuoso-skills/skills/message-list/references/5.context.md
@@ -47,3 +47,12 @@ export default function App() {
   )
 }
 ```
+
+If context changes can make rendered message rows taller or shorter, notify the list after updating that external state:
+
+```tsx
+setExpandedMessages((current) => new Map(current).set(messageId, expanded))
+messageListRef.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+```
+
+Use this for expansion state, side maps, approval state, loading indicators, or reactions stored outside the message data array. ResizeObserver measures the changed rows, and `notifyItemsChanged` tells the list whether to keep sticking to the bottom or preserve a scrolled-up user's position.

--- a/plugins/virtuoso-skills/skills/message-list/references/6.item-keys.md
+++ b/plugins/virtuoso-skills/skills/message-list/references/6.item-keys.md
@@ -9,7 +9,7 @@ slug: /virtuoso-message-list/item-keys
 
 ## Item Keys
 
-React uses a unique key to identify each item in a list. By default, the Message List component uses the items numeric index for that, but this index might change as we load new messages or delete some. To address that, the message list exposes a `computeItemKey` prop. This prop should return a unique key for each item based on the item data.
+React uses a unique key to identify each item in a list. By default, the Message List component uses the item's numeric index for that, but this index might change as we load new messages or delete some. To address that, the message list exposes a `computeItemKey` prop. This prop should return a unique key for each item based on the item data.
 
 ```tsx live
 import { VirtuosoMessageList, VirtuosoMessageListLicense } from '@virtuoso.dev/message-list'
@@ -28,3 +28,18 @@ export default function App() {
   )
 }
 ```
+
+## `computeItemKey` And `itemIdentity`
+
+`computeItemKey` controls the React key used to mount and update item components. Use it for every chat integration with stable message ids, local optimistic ids, or both.
+
+`itemIdentity` is different. It controls how the message list matches items for controlled data operations such as `prepend` and `remove-from-start` when your reducer recreates item objects. If your controlled state creates new object references for the same messages, provide `itemIdentity` with the same stable identity you use for keys.
+
+```tsx
+<VirtuosoMessageList
+  computeItemKey={({ data }) => data.id ?? `local-${data.localId}`}
+  itemIdentity={(item) => item.id ?? `local-${item.localId}`}
+/>
+```
+
+If your data objects keep stable references across updates, `itemIdentity` is usually not necessary. If controlled prepend or trimming loses the previous visual position after recreating message objects, add it.

--- a/plugins/virtuoso-skills/skills/message-list/references/80.licensing.md
+++ b/plugins/virtuoso-skills/skills/message-list/references/80.licensing.md
@@ -13,7 +13,7 @@ The `@virtuoso.dev/message-list` package is distributed under a commercial licen
 
 ## License Seats Explained
 
-The number of licenses to **the maximum number of concurrent front-end developers** who contribute to a project that uses the package. This also includes developers who work on the project part-time or as contractors.
+The number of licenses is **the maximum number of concurrent front-end developers** who contribute to a project that uses the package. This also includes developers who work on the project part-time or as contractors.
 
 For example, your app uses the `VirtuosoMessageList` component for building an AI Chatbot interface. **Three front-end** and two back-end developers are working on the project. One developer develops and maintains the message list UI feature, but there are three developers in total who work on the front-end. You must purchase **three licenses** for the project.
 
@@ -41,6 +41,22 @@ The license key is a string that you need to pass as a prop to the `VirtuosoMess
 </VirtuosoMessageListLicense>
 ```
 
+In an application, put the license wrapper near the app root or around the route section that renders chat UI. Read the key from your normal public client-side environment configuration.
+
+```tsx
+const licenseKey = import.meta.env.VITE_VIRTUOSO_MESSAGE_LIST_LICENSE_KEY ?? ''
+
+export function App() {
+  return (
+    <VirtuosoMessageListLicense licenseKey={licenseKey}>
+      <Routes />
+    </VirtuosoMessageListLicense>
+  )
+}
+```
+
+For Next.js, use a public environment variable, for example `NEXT_PUBLIC_VIRTUOSO_MESSAGE_LIST_LICENSE_KEY`, and pass it from a client component.
+
 ### Next.js/SSR
 
 The license component is using a context to pass the license to the `VirtuosoMessageList` component, so you need to ensure that it is not rendered server-side only.
@@ -57,11 +73,11 @@ The license key is validated without any network requests, so you can safely use
 
 ### No license wrapper component
 
-The `VirtuosMessageListLicense` component will throw an error and render an error unless wrapped with a `VirtuosoMessageListLicense` component. For development/evaluation purposes, you need to wrap one, even with an empty key prop. This will allow you to use the component without a license key for 30 days, keeping an error message in the developer console as a reminder.
+The `VirtuosoMessageList` component will render an error unless wrapped with a `VirtuosoMessageListLicense` component. For development/evaluation purposes, you need to wrap one, even with an empty key prop. This will allow you to use the component without a license key for 30 days, keeping an error message in the developer console as a reminder.
 
 ### Missing key
 
-You can use the component without a license key for 30 days for non-production environments and for evaluation purposes - a message in the console will remind you that you have to add the key. If the component is deployed to production without a license key, it will render as an error message in the browser and an error in the console.
+You can use the component with an empty license key for 30 days for non-production environments and for evaluation purposes - a message in the console will remind you that you have to add the key. If the component is deployed to production without a valid license key, it will render as an error message in the browser and an error in the console.
 
 ### Invalid key
 

--- a/plugins/virtuoso-skills/skills/message-list/references/README.md
+++ b/plugins/virtuoso-skills/skills/message-list/references/README.md
@@ -136,6 +136,7 @@ export default function App() {
               scrollModifier: {
                 type: 'auto-scroll-to-bottom',
                 autoScroll: ({ scrollInProgress, atBottom }) => {
+                  // This is a local user action, so it intentionally brings the question into view.
                   return {
                     index: 'LAST',
                     align: 'start',

--- a/skills/message-list/SKILL.md
+++ b/skills/message-list/SKILL.md
@@ -4,8 +4,9 @@ description: >-
   Build chat, messaging, and AI conversation UIs with @virtuoso.dev/message-list. Use this skill when (1) building a chat or
   messaging interface, (2) streaming AI assistant responses into a conversation, (3) loading older messages when scrolling up,
   (4) adding scroll-to-bottom buttons or unseen-message indicators, (5) switching between channels/conversations, or (6) any task
-  involving VirtuosoMessageList, VirtuosoMessageListLicense, useVirtuosoMethods, useVirtuosoLocation, scrollModifier, or
-  data.append/prepend/map. The package is commercial and requires a license key.
+  involving VirtuosoMessageList, VirtuosoMessageListLicense, useVirtuosoMethods, useVirtuosoLocation, scrollModifier,
+  notifyItemsChanged, scrollToBottomIfAtBottom, scrollToBottomAlways, or data.append/prepend/map. The package is commercial
+  and requires a license key.
 ---
 
 # @virtuoso.dev/message-list
@@ -22,7 +23,7 @@ The package is commercial (annual, per-developer). Every instance must be wrappe
 </VirtuosoMessageListLicense>
 ```
 
-An empty `licenseKey=""` works as a 30-day non-production trial. Validation is local — no network requests. Surface this to the user when introducing the package into a project; keys come from <https://virtuoso.dev/pricing/>.
+An empty `licenseKey=""` is licensed for 30-day non-production evaluation: it keeps rendering in development with a console reminder, while production without a valid key renders an error. Validation is local — no network requests. Surface this to the user when introducing the package into a project; keys come from <https://virtuoso.dev/pricing/>. Prefer an app-level wrapper that reads from the normal public client-side environment configuration.
 
 ## Core mental model: data updates carry scroll instructions
 
@@ -37,38 +38,56 @@ const [data, setData] = useState<VirtuosoMessageListProps<Message, null>['data']
 <VirtuosoMessageList<Message, null> style={{ height: '100%' }} data={data} computeItemKey={({ data }) => data.key} ItemContent={ItemContent} />
 ```
 
-`ItemContent` is a component receiving `{ data, index, context }` props (not positional arguments like react-virtuoso).
+`ItemContent` is a component receiving `{ data, index, context }` props (not positional arguments like react-virtuoso). Extract it outside the parent render function unless it needs to close over local state.
+
+External row state is different from data updates. If `context`, side maps, expansion state, reactions, approvals, or loading flags can change row height without changing the data array, call `notifyItemsChanged({ scrollToBottom })` on the message-list ref after updating that state.
 
 ### Scroll modifier reference
 
 | Modifier                                               | When to use                                                                                             |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- | ------ | -------------------------- |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
 | `{ type: 'item-location', location, purgeItemSizes? }` | Initial load or channel switch; `purgeItemSizes: true` clears cached sizes when the items are different |
-| `{ type: 'auto-scroll-to-bottom', autoScroll }`        | New messages arrive; callback receives `{ atBottom, scrollInProgress, ... }` and returns `'smooth'      | 'auto' | false` or an item location |
+| `{ type: 'auto-scroll-to-bottom', autoScroll }`        | New messages are appended; callback can return `false`, a behavior, `true`, or an item location         |
 | `'prepend'`                                            | Older messages added to the top; keeps the current messages visually in place                           |
-| `{ type: 'items-change', behavior }`                   | Existing items changed size (streaming text, reactions); stays at bottom if already there               |
+| `{ type: 'items-change', behavior }`                   | Existing data items changed size, such as streaming text or reactions stored in the data item           |
 | `'remove-from-start'` / `'remove-from-end'`            | Trimming data while preserving the visual position                                                      |
 | `null` / `undefined`                                   | Leave the scroll position alone                                                                         |
+
+In callback form, returning a behavior or item location scrolls even when `atBottom` is false. Return `false` to preserve the viewport for a scrolled-up user.
 
 ## Common patterns
 
 ### Receiving messages (auto-scroll when at bottom)
 
 ```tsx
+import { scrollToBottomIfAtBottom } from '@virtuoso.dev/message-list'
+
 setData((current) => ({
   data: [...current.data, incoming],
   scrollModifier: {
     type: 'auto-scroll-to-bottom',
-    autoScroll: ({ atBottom, scrollInProgress }) => ({
-      index: 'LAST',
-      align: 'end',
-      behavior: atBottom || scrollInProgress ? 'smooth' : 'auto',
-    }),
+    autoScroll: scrollToBottomIfAtBottom,
   },
 }))
 ```
 
-Returning `false` from `autoScroll` when not at bottom is how you keep the viewport still and instead increment an unseen-messages counter.
+Use `scrollToBottomIfAtBottom` for remote messages. It returns `'smooth'` when the list is already at the bottom or already scrolling there, otherwise `false`. If the app needs an unseen-message counter, use the inline callback form and increment the counter before returning `false`.
+
+### Sending local messages (force bottom)
+
+```tsx
+import { scrollToBottomAlways } from '@virtuoso.dev/message-list'
+
+setData((current) => ({
+  data: [...current.data, optimisticLocalMessage],
+  scrollModifier: {
+    type: 'auto-scroll-to-bottom',
+    autoScroll: scrollToBottomAlways,
+  },
+}))
+```
+
+Use `scrollToBottomAlways` for local current-user actions where the new last item should become visible even if the user was scrolled up. If a realtime socket echoes the same optimistic message back, reconcile it by `localId` or another client-generated identity and treat it as confirmation, not a new incoming remote message.
 
 ### Streaming an AI response
 
@@ -82,6 +101,21 @@ setData((current) => ({
 ```
 
 `items-change` keeps the view pinned to the bottom while the message grows, without jumping if the user scrolled up. See [ai-chatbot](references/3.examples/02.ai-chatbot.md) and [gemini](references/3.examples/03.gemini.md) (question pinned to top, answer streams below).
+
+### External row state changed size
+
+Use `notifyItemsChanged` when row content changes size without changing the data array:
+
+```tsx
+import { scrollToBottomIfAtBottom, type VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'
+
+const messageListRef = useRef<VirtuosoMessageListMethods<Message, MessageListContext>>(null)
+
+setExpandedMessages((current) => new Map(current).set(messageId, expanded))
+messageListRef.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+```
+
+ResizeObserver measures the rows; `notifyItemsChanged` supplies the scroll policy. Use it for expansion state in `context`, side maps for reactions or approvals, activity loading, or any other external row state.
 
 ### Loading older messages on scroll-up
 
@@ -114,6 +148,19 @@ const StickyFooter = () => {
 
 Keep one data object per channel and swap with `replace`/`item-location` + `purgeItemSizes: true`, so size caches from the previous channel don't distort the new one. See [multiple-channels](references/2.tutorial/07.multiple-channels.md).
 
+### Controlled mode recipe
+
+For controlled `data` prop usage, keep `DataWithScrollModifier<Message>` behind app-owned actions such as `replaceMessages`, `appendIncoming`, `appendLocal`, `confirmLocal`, `updateStreamingMessage`, and `rowChromeChanged`. This is a recipe layer in app code, not an official exported hook and not a replacement for the imperative `data.*` API.
+
+- `replaceMessages`: channel or thread switch with `{ type: 'item-location', location: { index: 'LAST', align: 'end' }, purgeItemSizes: true }`.
+- `appendIncoming`: remote messages with `scrollToBottomIfAtBottom`.
+- `appendLocal`: optimistic local sends with `scrollToBottomAlways`.
+- `confirmLocal`: match the socket/server acknowledgement by `localId` and update the existing row.
+- `updateStreamingMessage`: map the existing message and use `{ type: 'items-change', behavior: 'smooth' }`.
+- `rowChromeChanged`: update external row state and call `notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })`.
+
+Do not invent or recommend a public `useVirtuosoMessageListData` hook before trying this recipe-level controlled state in app code. See [controlled-mode-recipes](references/21.controlled-mode-recipes.md).
+
 ## Imperative API
 
 Via `ref={useRef<VirtuosoMessageListMethods<Message>>(null)}` from outside, or `useVirtuosoMethods()` from components rendered inside the list:
@@ -122,6 +169,7 @@ Via `ref={useRef<VirtuosoMessageListMethods<Message>>(null)}` from outside, or `
 - `data.map(fn, autoscrollBehavior?)` — update items (reactions, edits, streaming)
 - `data.findAndDelete(predicate)`, `data.deleteRange(start, length)`, `data.replace(data, options?)`
 - `data.find(predicate)`, `data.findIndex(predicate)`, `data.get()`, `data.getCurrentlyRendered()`
+- `notifyItemsChanged({ scrollToBottom })` — use after context or side-state changes that can resize rendered rows without changing the data array
 - `scrollToItem({ index: number | 'LAST', align, behavior })`
 
 The declarative `data` prop and the imperative `data.*` methods are alternative ways to drive the same list — pick one as the primary mechanism per component to avoid fighting updates.
@@ -131,6 +179,7 @@ The declarative `data` prop and the imperative `data.*` methods are alternative 
 - `ItemContent: ({ data, index, context }) => JSX` — message renderer
 - `context` — shared state (current user, loading flags) available to `ItemContent` and all custom slots; avoids prop drilling
 - `computeItemKey({ data })` — stable message key; required for prepending/streaming to work without remounts
+- `itemIdentity(item)` — stable item identity for controlled prepend/remove-from-start matching when reducers recreate item objects
 - Slots: `Header`, `Footer` (scroll with content), `StickyHeader`, `StickyFooter` (fixed, measured to avoid overlap), `EmptyPlaceholder`
 - `initialLocation: { index: 'LAST', align: 'end' }` — start at the bottom
 - Hooks (inside the list): `useVirtuosoMethods()`, `useVirtuosoLocation()` (`atBottom`, `bottomOffset`, `listOffset`, `scrollInProgress`), `useCurrentlyRenderedData()`
@@ -138,16 +187,30 @@ The declarative `data` prop and the imperative `data.*` methods are alternative 
 ## Pitfalls
 
 - **No height → nothing renders.** The component needs a real height (`style={{ height: '100%' }}` with a sized parent).
+- **Missing license wrapper → runtime error.** Wrap with `VirtuosoMessageListLicense`; an empty key is only for non-production evaluation.
 - **Missing `computeItemKey`** causes remounts and scroll jumps on prepend and streaming updates.
-- **Margins on message items** break height measurement (ResizeObserver excludes margins) — use padding.
+- **Missing `itemIdentity` in controlled mode** can break prepend/remove-from-start matching when reducers recreate item objects.
+- **Margins on measured message rows** break height measurement because ResizeObserver excludes margins. Use padding or inner wrappers.
+- **Implicit scroll policy** causes chat regressions. Decide per source: local send usually forces bottom, remote receive preserves scrolled-up users, streaming uses `items-change`, and context-only row growth uses `notifyItemsChanged`.
 - **"ResizeObserver loop" errors are benign** — filter them in dev overlays and error tracking; see [resize-observer-errors](references/19.resize-observer-errors.md).
 - **JSDOM tests need mocked measurements** via `VirtuosoMessageListTestingContext.Provider value={{ itemHeight, viewportHeight }}` plus a ResizeObserver polyfill; prefer Playwright for scroll behavior. See [testing](references/11.testing.md).
+
+## Migration checklist from a plain mapped chat list
+
+- Add the `VirtuosoMessageListLicense` wrapper and decide how the key is supplied.
+- Give the list a real height through a sized parent or direct style.
+- Extract `ItemContent` and pass shared state through `context`.
+- Add stable `computeItemKey` for message ids and local optimistic ids.
+- Add `itemIdentity` when controlled data recreates objects and uses prepend/trimming.
+- Remove margins from measured rows; use padding or inner wrappers for spacing.
+- Choose an explicit scroll policy for local sends, remote receives, streaming updates, socket echoes, and external row growth.
+- Use Playwright/browser tests for scroll behavior where possible; use the testing context for JSDOM unit tests.
 
 ## References
 
 - [references/README.md](references/README.md) — overview and live example
 - `references/2.tutorial/` — step-by-step chat build: [intro](references/2.tutorial/01.intro.md), [message-list](references/2.tutorial/02.message-list.md), [loading-older-messages](references/2.tutorial/03.loading-older-messages.md), [scroll-to-bottom-button](references/2.tutorial/04.scroll-to-bottom-button.md), [receive-messages](references/2.tutorial/05.receive-messages.md), [send-messages](references/2.tutorial/06.send-messages.md), [multiple-channels](references/2.tutorial/07.multiple-channels.md)
 - `references/3.examples/` — [messaging](references/3.examples/01.messaging.md), [ai-chatbot](references/3.examples/02.ai-chatbot.md), [gemini](references/3.examples/03.gemini.md), [reactions](references/3.examples/04.reactions.md), [date-separators](references/3.examples/05.date-separators.md), [scroll-to-reply](references/3.examples/06.scroll-to-reply.md), [grouped-messages](references/3.examples/07.grouped-messages.md)
-- Feature guides: [headers-footers](references/4.headers-footers.md), [context](references/5.context.md), [item-keys](references/6.item-keys.md), [hooks](references/7.hooks.md), [custom-scrollbar](references/8.custom-scrollbar.md), [scrolling-to-item](references/9.scrolling-to-item.md), [smooth-scrolling](references/10.smooth-scrolling.md), [imperative-data-api](references/15.imperative-data-api.md), [scroll-modifier](references/20.scroll-modifier.md), [testing](references/11.testing.md), [licensing](references/80.licensing.md)
+- Feature guides: [headers-footers](references/4.headers-footers.md), [context](references/5.context.md), [item-keys](references/6.item-keys.md), [hooks](references/7.hooks.md), [custom-scrollbar](references/8.custom-scrollbar.md), [scrolling-to-item](references/9.scrolling-to-item.md), [smooth-scrolling](references/10.smooth-scrolling.md), [imperative-data-api](references/15.imperative-data-api.md), [scroll-modifier](references/20.scroll-modifier.md), [controlled-mode-recipes](references/21.controlled-mode-recipes.md), [testing](references/11.testing.md), [licensing](references/80.licensing.md)
 
 Full API reference: <https://virtuoso.dev/message-list/>

--- a/skills/message-list/references/15.imperative-data-api.md
+++ b/skills/message-list/references/15.imperative-data-api.md
@@ -13,7 +13,7 @@ In addition to the `data` prop, the message list component exposes an imperative
 
 :::info
 
-### What is an imperative API and why does the message list uses it?
+### What is an imperative API and why does the message list use it?
 
 There are two ways to work with React components - the imperative way and the declarative way. In the declarative way, you describe the UI based on the current state, and React takes care of updating the UI when the state changes.
 
@@ -64,7 +64,7 @@ export default function App() {
 
 Appending data to the message list usually requires an adjustment to the scroll position to keep the new messages in view. However, this is not always the case - for example, if the user is scrolling up to read older messages. Also, depending on various factors the adjustment may happen instantly or with a smooth scroll animation.
 
-To support those scenarios, the `data.append` method accepts `data` and, an optional, `scrollToBottom` argument that can be a string - `"smooth"`, `"auto"` or `"instant"` (passed directly to the underlying `scrollTo` DOM call), or a function that receives the following arguments as an object:
+To support those scenarios, the `data.append` method accepts `data` and an optional `scrollToBottom` argument that can be a string - `"smooth"`, `"auto"` or `"instant"` (passed directly to the underlying `scrollTo` DOM call), or a function that receives the following arguments as an object:
 
 - `scrollLocation: ListScrollLocation` - the current scroll location (same object as the one passed to the `onScroll` callback and the one available from `useScrollLocation` hook)
 - `scrollInProgress: boolean` - whether or not the list is currently scrolling
@@ -78,10 +78,17 @@ The function should return:
 - a string value, one of `"smooth"`, `"auto"` or `"instant"` to control the scroll behavior - the list will scroll to the bottom with the specified behavior
 - a location object, `{ index: number | 'LAST', align: 'start' | 'center' | 'end', behavior: 'smooth' | 'auto' }` to control the scroll behavior and the alignment of the new items. You can use this to scroll to the bottom, or to scroll the first new message to the top of the list.
 
+In callback form, returning a behavior or item location scrolls even when `atBottom` is `false`. Return `false` to preserve a scrolled-up user's viewport.
+
+The package exports two helpers for common policies:
+
+- `scrollToBottomIfAtBottom`: use for incoming messages or row growth. It returns `'smooth'` when the list is already at the bottom or already scrolling there, otherwise `false`.
+- `scrollToBottomAlways`: use for local sends or other current-user actions that should make the new last item visible.
+
 Experiment with the live example below to see how the scroll behavior changes when appending new items.
 
 ```tsx live
-import { VirtuosoMessageList, VirtuosoMessageListLicense, VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'
+import { scrollToBottomIfAtBottom, VirtuosoMessageList, VirtuosoMessageListLicense, VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'
 import { useRef } from 'react'
 
 export default function App() {
@@ -100,10 +107,7 @@ export default function App() {
       </VirtuosoMessageListLicense>
       <button
         onClick={() => {
-          ref.current.data.append(
-            Array.from({ length: 10 }, (_, index) => index + offset.current),
-            (params) => true
-          )
+          ref.current.data.append(Array.from({ length: 10 }, (_, index) => index + offset.current), scrollToBottomIfAtBottom)
           offset.current = offset.current + 10
         }}
       >
@@ -113,6 +117,65 @@ export default function App() {
   )
 }
 ```
+
+## Notifying Item Size Changes Without Data Changes
+
+Use `notifyItemsChanged({ scrollToBottom })` when rendered item content can change height without changing the message data array. Common examples include expansion state in `context`, side maps for reactions or approvals, activity-loading state, or any other external row state.
+
+```tsx
+import {
+  scrollToBottomIfAtBottom,
+  VirtuosoMessageList,
+  VirtuosoMessageListLicense,
+  VirtuosoMessageListMethods,
+} from '@virtuoso.dev/message-list'
+import { useRef, useState } from 'react'
+
+interface Message {
+  id: string
+  text: string
+}
+
+interface MessageListContext {
+  expandedMessages: Map<string, boolean>
+}
+
+export default function App() {
+  const ref = useRef<VirtuosoMessageListMethods<Message, MessageListContext>>(null)
+  const [expandedMessages, setExpandedMessages] = useState(() => new Map<string, boolean>())
+
+  return (
+    <VirtuosoMessageListLicense licenseKey="">
+      <VirtuosoMessageList<Message, MessageListContext>
+        ref={ref}
+        style={{ height: 500 }}
+        context={{ expandedMessages }}
+        initialData={[{ id: '1', text: 'Toggle extra row content' }]}
+        computeItemKey={({ data }) => data.id}
+        ItemContent={({ data, context }) => {
+          const expanded = context.expandedMessages.get(data.id) ?? false
+          return (
+            <div style={{ padding: 12 }}>
+              <button
+                onClick={() => {
+                  setExpandedMessages((current) => new Map(current).set(data.id, !expanded))
+                  ref.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+                }}
+              >
+                Toggle
+              </button>
+              <div>{data.text}</div>
+              {expanded && <div style={{ paddingTop: 12 }}>Additional details that make the row taller.</div>}
+            </div>
+          )
+        }}
+      />
+    </VirtuosoMessageListLicense>
+  )
+}
+```
+
+The `scrollToBottom` policy has the same callback shape as `data.append`. For `notifyItemsChanged`, the callback receives the current list data, the pre-change scroll location, `atBottom`, `scrollInProgress`, and `context`. ResizeObserver measures the new row heights; `notifyItemsChanged` supplies the scroll policy for preserving bottom stickiness.
 
 ## Updating Data
 
@@ -186,7 +249,7 @@ export default function App() {
 ## Replacing Data
 
 In case you're building a chat application with multiple channels, you might want to switch the message list to a different channel. The `data.replace` method lets you replace the current list of messages with a new one.
-The method accepts `data` and, optionally, an `options: { initalLocation: ItemLocation, purgeItemSizes?: boolean }` to specify the initial scroll position and weather to clear the cached item sizes. Purging the item sizes is useful when the new data has different item sizes than the previous data.
+The method accepts `data` and, optionally, an `options: { initialLocation: ItemLocation, purgeItemSizes?: boolean }` to specify the initial scroll position and whether to clear the cached item sizes. Purging the item sizes is useful when the new data has different item sizes than the previous data.
 
 ```tsx live
 import { VirtuosoMessageList, VirtuosoMessageListLicense, VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'

--- a/skills/message-list/references/15.imperative-data-api.md
+++ b/skills/message-list/references/15.imperative-data-api.md
@@ -88,7 +88,12 @@ The package exports two helpers for common policies:
 Experiment with the live example below to see how the scroll behavior changes when appending new items.
 
 ```tsx live
-import { scrollToBottomIfAtBottom, VirtuosoMessageList, VirtuosoMessageListLicense, VirtuosoMessageListMethods } from '@virtuoso.dev/message-list'
+import {
+  scrollToBottomIfAtBottom,
+  VirtuosoMessageList,
+  VirtuosoMessageListLicense,
+  VirtuosoMessageListMethods,
+} from '@virtuoso.dev/message-list'
 import { useRef } from 'react'
 
 export default function App() {
@@ -107,7 +112,10 @@ export default function App() {
       </VirtuosoMessageListLicense>
       <button
         onClick={() => {
-          ref.current.data.append(Array.from({ length: 10 }, (_, index) => index + offset.current), scrollToBottomIfAtBottom)
+          ref.current.data.append(
+            Array.from({ length: 10 }, (_, index) => index + offset.current),
+            scrollToBottomIfAtBottom
+          )
           offset.current = offset.current + 10
         }}
       >

--- a/skills/message-list/references/2.tutorial/02.message-list.md
+++ b/skills/message-list/references/2.tutorial/02.message-list.md
@@ -158,11 +158,11 @@ feature in more detail in the next parts of the tutorial.
 
 ### The `style` prop
 
-**The Message List needs a height to render correctly**. We're setting the
+**The Message List needs a real height to render correctly**. We're setting the
 height to `80vh` to have a full-screen chat interface with a bit of space at the
 bottom. In your real world application, you might put the component into a flex
 box layout or use other methods to control the component's height - this works
-as well.
+as well. Make sure every parent in a `height: '100%'` chain is actually sized.
 
 ### The `computeItemKey` prop
 
@@ -252,6 +252,10 @@ const ItemContent: MessageListProps['ItemContent'] = ({ data: message, context }
   )
 }
 ```
+
+Message rows are measured with ResizeObserver. Avoid CSS margins on the measured
+row itself because margins are not included in the measured height. Use padding
+or an inner wrapper for spacing between messages.
 
 Now, let's pass `ItemContent` to the `VirtuosoMessageList` component and the
 `currentUser` to the context:

--- a/skills/message-list/references/2.tutorial/05.receive-messages.md
+++ b/skills/message-list/references/2.tutorial/05.receive-messages.md
@@ -53,6 +53,8 @@ Since we're using a smooth scroll, there's a slight chance of a new message comi
 The `auto-scroll-to-bottom` modifier is used for adding new messages to the end of the list. Through the `autoScroll` callback, you can conditionally determine if the list should catch up with the new messages or not.
 :::
 
+For the common version of this policy, use the exported `scrollToBottomIfAtBottom` helper. This tutorial keeps the callback inline so it can increment the unseen-message counter when the user is scrolled up.
+
 If everything works as expected, pressing the button will display a new message from another user with a smooth scroll animation.
 
 ## Display the New Message Counter

--- a/skills/message-list/references/2.tutorial/06.send-messages.md
+++ b/skills/message-list/references/2.tutorial/06.send-messages.md
@@ -14,7 +14,7 @@ Since the focus of this tutorial is the message list itself, we will use a butto
 
 ## Sending Messages and Scroll Position
 
-Unlike receiving messages, sending messages should always scroll the list to the bottom. This is because the user is sending a message, and they should see it immediately. The `autoScroll` callback will let us handle this.
+Unlike receiving messages, sending messages should always scroll the list to the bottom. This is because the user is sending a message, and they should see it immediately. The `autoScroll` callback will let us handle this. In app code, the exported `scrollToBottomAlways` helper represents this policy.
 
 ## Optimistic Updates
 
@@ -71,3 +71,5 @@ Add the following button next to the receive messages button:
 ```
 
 If everything works as expected, pressing the button will display a new message from the current user with a smooth scroll animation. After a short delay, the `Delivering...` indicator below the message should disappear.
+
+If your realtime backend echoes the same local message through a socket stream, reconcile that event by `localId` or another client-generated id. Treat it as a confirmation of the optimistic row, not as a new incoming remote message.

--- a/skills/message-list/references/20.scroll-modifier.md
+++ b/skills/message-list/references/20.scroll-modifier.md
@@ -37,6 +37,48 @@ setData((current) => ({
 This modifier should be used when new messages are added to the end of the list, and you want to scroll to the bottom of the list automatically (or conditionally, depending on the current position). An extensive example that uses this type can be found in the
 ["receiving messages" chapter of the tutorial](/virtuoso-message-list/tutorial/receive-messages/) - the behavior can be a callback function that receives the current state of the list and calculates the necessary location and scroll behavior.
 
+The `autoScroll` field accepts either a direct scroll behavior or a callback. Passing a direct behavior such as `'smooth'` applies only when the list is already at the bottom. Use the callback form when the policy depends on the source of the event. Returning `false` is the preserve-position path for users who have scrolled up. Returning a behavior, `true`, or an item location scrolls the list.
+
+The callback receives the scroll location from before the data change:
+
+- `scrollLocation`: the full `ListScrollLocation` object.
+- `atBottom`: whether the list was at the bottom before the change.
+- `scrollInProgress`: whether the list was already scrolling.
+- `data`: the appended or next data array, depending on the operation.
+- `context`: the current message-list context.
+
+For incoming remote messages, preserve users who are reading history:
+
+```tsx
+const ReceivedMessagesScrollModifier: ScrollModifier = {
+  type: 'auto-scroll-to-bottom',
+  autoScroll: ({ atBottom, scrollInProgress }) => {
+    if (atBottom || scrollInProgress) {
+      return 'smooth'
+    }
+    return false
+  },
+}
+```
+
+The package also exports helpers for common policies:
+
+```tsx
+import { scrollToBottomAlways, scrollToBottomIfAtBottom } from '@virtuoso.dev/message-list'
+
+const RemoteMessageScrollModifier: ScrollModifier = {
+  type: 'auto-scroll-to-bottom',
+  autoScroll: scrollToBottomIfAtBottom,
+}
+
+const LocalSendScrollModifier: ScrollModifier = {
+  type: 'auto-scroll-to-bottom',
+  autoScroll: scrollToBottomAlways,
+}
+```
+
+Use `scrollToBottomIfAtBottom` for incoming messages or row growth where a scrolled-up user should stay in place. Use `scrollToBottomAlways` for local actions, such as sending the current user's message, where the new item should become visible even if the user was reading older messages.
+
 ### `prepend`
 
 The `"prepend"` scroll modifier value signals that the data change will add messages to the top of the list. The scroll position will be adjusted to keep the current scroll position relative to the new data.
@@ -57,6 +99,26 @@ For the prepend modifier to work correctly, the **new data should extend the cur
 ### `{ type: 'items-change' }`
 
 This scroll modifier is useful when the data update keeps the same items but modifies their content/props - such an example would be a streaming bot response, or adding/removing reactions to certain messages. In this case, the scroll modifier lets you keep the message list scrolled to the bottom in case it is there. See the [reactions example](/virtuoso-message-list/examples/reactions/) for a live example.
+
+Use this modifier when the data array update is what changes the rendered item height:
+
+```tsx
+setData((current) => ({
+  data: current.data.map((message) => (message.id === streamingId ? { ...message, text: message.text + chunk } : message)),
+  scrollModifier: { type: 'items-change', behavior: 'smooth' },
+}))
+```
+
+If rendered rows change size because of `context`, side maps, expansion state, reactions stored outside the data array, approval state, activity loading, or other external row state, use the imperative `notifyItemsChanged` method instead. ResizeObserver will measure the rows either way; the modifier or method supplies the policy for whether the list should remain stuck to the bottom.
+
+```tsx
+const messageListRef = useRef<VirtuosoMessageListMethods<Message, MessageListContext>>(null)
+
+function setMessageExpanded(messageId: string, expanded: boolean) {
+  setExpandedMessages((current) => new Map(current).set(messageId, expanded))
+  messageListRef.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+}
+```
 
 ### `remove-from-start`
 

--- a/skills/message-list/references/21.controlled-mode-recipes.md
+++ b/skills/message-list/references/21.controlled-mode-recipes.md
@@ -1,0 +1,136 @@
+---
+id: virtuoso-message-list-controlled-mode-recipes
+title: Virtuoso Message List Controlled Mode Recipes
+description: Organize controlled message-list state behind app-owned actions for local sends, incoming messages, streaming updates, and row growth.
+sidebar_label: Controlled Mode Recipes
+sidebar_position: 11
+slug: /virtuoso-message-list/controlled-mode-recipes
+---
+
+## Controlled Mode Recipes
+
+When you drive the message list with the `data` prop, keep the message array and its `scrollModifier` together in a single `DataWithScrollModifier<Message>` state value. In larger chat integrations, wrap raw `setData` calls in app-owned actions that match product events.
+
+This page shows a recipe, not a public hook. If you wrap it in an app-local hook, keep that hook private to your application. Keep names like `appendIncoming` or `confirmLocal` in your application until several integrations prove the same abstraction is broadly reusable.
+
+```tsx
+import {
+  DataWithScrollModifier,
+  ScrollModifier,
+  scrollToBottomAlways,
+  scrollToBottomIfAtBottom,
+  VirtuosoMessageListMethods,
+} from '@virtuoso.dev/message-list'
+import { useCallback, useRef, useState } from 'react'
+
+interface Message {
+  id: string | null
+  localId: string | null
+  text: string
+  delivered: boolean
+}
+
+interface MessageListContext {
+  expandedMessages: Map<string, boolean>
+}
+
+type MessageListState = DataWithScrollModifier<Message>
+
+const InitialLocation: ScrollModifier = {
+  type: 'item-location',
+  location: { index: 'LAST', align: 'end' },
+  purgeItemSizes: true,
+}
+
+function useChatData() {
+  const messageListRef = useRef<VirtuosoMessageListMethods<Message, MessageListContext>>(null)
+  const [data, setData] = useState<MessageListState>({ data: [], scrollModifier: InitialLocation })
+  const [expandedMessages, setExpandedMessages] = useState(() => new Map<string, boolean>())
+
+  const replaceMessages = useCallback((messages: Message[]) => {
+    setData({ data: messages, scrollModifier: InitialLocation })
+  }, [])
+
+  const appendIncoming = useCallback((messages: Message[]) => {
+    setData((current) => ({
+      data: [...(current.data ?? []), ...messages],
+      scrollModifier: { type: 'auto-scroll-to-bottom', autoScroll: scrollToBottomIfAtBottom },
+    }))
+  }, [])
+
+  const appendLocal = useCallback((message: Message) => {
+    setData((current) => ({
+      data: [...(current.data ?? []), message],
+      scrollModifier: { type: 'auto-scroll-to-bottom', autoScroll: scrollToBottomAlways },
+    }))
+  }, [])
+
+  const confirmLocal = useCallback((localId: string, remoteMessage: Message) => {
+    setData((current) => ({
+      data: (current.data ?? []).map((message) => (message.localId === localId ? remoteMessage : message)),
+      scrollModifier: { type: 'items-change', behavior: 'smooth' },
+    }))
+  }, [])
+
+  const updateStreamingMessage = useCallback((id: string, chunk: string) => {
+    setData((current) => ({
+      data: (current.data ?? []).map((message) => (message.id === id ? { ...message, text: message.text + chunk } : message)),
+      scrollModifier: { type: 'items-change', behavior: 'smooth' },
+    }))
+  }, [])
+
+  const rowChromeChanged = useCallback((messageId: string, expanded: boolean) => {
+    setExpandedMessages((current) => new Map(current).set(messageId, expanded))
+    messageListRef.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+  }, [])
+
+  return {
+    appendIncoming,
+    appendLocal,
+    confirmLocal,
+    context: { expandedMessages },
+    data,
+    messageListRef,
+    replaceMessages,
+    rowChromeChanged,
+    updateStreamingMessage,
+  }
+}
+```
+
+Use `replaceMessages` when switching channels, threads, or conversations. The `purgeItemSizes: true` flag clears cached row sizes so the previous conversation does not distort the next one.
+
+Use `appendIncoming` for remote messages. It sticks to the bottom only when the user was already at the bottom or the list was already scrolling there. If the user is reading history, keep the viewport still and show an unseen-message indicator in your app.
+
+Use `appendLocal` for optimistic sends by the current user. Local sends normally force the list to the bottom so the sender can see the new message immediately.
+
+Use `confirmLocal` when the server acknowledges an optimistic message. Match by `localId` or another client-generated id, replace the local row with the canonical server row, and treat the confirmation as an existing-row update rather than a new incoming message.
+
+Use `updateStreamingMessage` when the data item itself grows, such as a streaming assistant response. The `items-change` modifier keeps the list pinned only if it was already pinned.
+
+Use `rowChromeChanged` when row height changes without a data-array update. Examples include expansion state in `context`, side maps for approvals or reactions, activity loading, and other external row state. `notifyItemsChanged` tells the list to re-evaluate the scroll-to-bottom policy while ResizeObserver performs the measurement.
+
+## Socket Echoes
+
+Realtime systems often echo the current user's optimistic message back through the same socket stream used for remote messages. Reconcile that event by identity and source before choosing a scroll policy:
+
+- If the event confirms a local optimistic row, call `confirmLocal`.
+- If the event is genuinely from another user, call `appendIncoming`.
+- If the event is a local send that was not rendered optimistically, call `appendLocal`.
+
+Do not treat every socket message as remote row growth. The event source determines whether to force bottom, preserve the scrolled-up viewport, or update an existing row.
+
+## Keys And Identity
+
+Set `computeItemKey` to a stable React key. In controlled mode, also set `itemIdentity` when prepend or remove-from-start operations need to match items but your reducer recreates item objects.
+
+```tsx
+<VirtuosoMessageList<Message, MessageListContext>
+  ref={messageListRef}
+  data={data}
+  context={context}
+  computeItemKey={({ data }) => data.id ?? `local-${data.localId}`}
+  itemIdentity={(item) => item.id ?? `local-${item.localId}`}
+  ItemContent={ItemContent}
+/>
+```

--- a/skills/message-list/references/3.examples/02.ai-chatbot.md
+++ b/skills/message-list/references/3.examples/02.ai-chatbot.md
@@ -90,6 +90,7 @@ export default function App() {
               scrollModifier: {
                 type: 'auto-scroll-to-bottom',
                 autoScroll: ({ scrollInProgress, atBottom }) => {
+                  // This is a local user action, so it intentionally brings the question into view.
                   return {
                     index: 'LAST',
                     align: 'start',

--- a/skills/message-list/references/3.examples/03.gemini.md
+++ b/skills/message-list/references/3.examples/03.gemini.md
@@ -89,6 +89,7 @@ export default function App() {
               scrollModifier: {
                 type: 'auto-scroll-to-bottom',
                 autoScroll: ({ scrollInProgress, atBottom }) => {
+                  // This is a local user action, so it intentionally brings the question into view.
                   return {
                     index: 'LAST',
                     align: 'start',

--- a/skills/message-list/references/3.examples/04.reactions.md
+++ b/skills/message-list/references/3.examples/04.reactions.md
@@ -15,6 +15,8 @@ A common problem in messaging interfaces is how to handle reactions to messages.
 The approach above is not exclusive to reactions - the same principle should be applied to any message state change that will change the message height (for example, expanding details, etc).
 :::
 
+This example stores the reaction state in the message data, so `items-change` is the right modifier. If reaction or expansion state lives in `context` or side maps instead, update that state and call `notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })` on the message-list ref.
+
 ```tsx live
 import {
   ScrollModifier,

--- a/skills/message-list/references/5.context.md
+++ b/skills/message-list/references/5.context.md
@@ -47,3 +47,12 @@ export default function App() {
   )
 }
 ```
+
+If context changes can make rendered message rows taller or shorter, notify the list after updating that external state:
+
+```tsx
+setExpandedMessages((current) => new Map(current).set(messageId, expanded))
+messageListRef.current?.notifyItemsChanged({ scrollToBottom: scrollToBottomIfAtBottom })
+```
+
+Use this for expansion state, side maps, approval state, loading indicators, or reactions stored outside the message data array. ResizeObserver measures the changed rows, and `notifyItemsChanged` tells the list whether to keep sticking to the bottom or preserve a scrolled-up user's position.

--- a/skills/message-list/references/6.item-keys.md
+++ b/skills/message-list/references/6.item-keys.md
@@ -9,7 +9,7 @@ slug: /virtuoso-message-list/item-keys
 
 ## Item Keys
 
-React uses a unique key to identify each item in a list. By default, the Message List component uses the items numeric index for that, but this index might change as we load new messages or delete some. To address that, the message list exposes a `computeItemKey` prop. This prop should return a unique key for each item based on the item data.
+React uses a unique key to identify each item in a list. By default, the Message List component uses the item's numeric index for that, but this index might change as we load new messages or delete some. To address that, the message list exposes a `computeItemKey` prop. This prop should return a unique key for each item based on the item data.
 
 ```tsx live
 import { VirtuosoMessageList, VirtuosoMessageListLicense } from '@virtuoso.dev/message-list'
@@ -28,3 +28,18 @@ export default function App() {
   )
 }
 ```
+
+## `computeItemKey` And `itemIdentity`
+
+`computeItemKey` controls the React key used to mount and update item components. Use it for every chat integration with stable message ids, local optimistic ids, or both.
+
+`itemIdentity` is different. It controls how the message list matches items for controlled data operations such as `prepend` and `remove-from-start` when your reducer recreates item objects. If your controlled state creates new object references for the same messages, provide `itemIdentity` with the same stable identity you use for keys.
+
+```tsx
+<VirtuosoMessageList
+  computeItemKey={({ data }) => data.id ?? `local-${data.localId}`}
+  itemIdentity={(item) => item.id ?? `local-${item.localId}`}
+/>
+```
+
+If your data objects keep stable references across updates, `itemIdentity` is usually not necessary. If controlled prepend or trimming loses the previous visual position after recreating message objects, add it.

--- a/skills/message-list/references/80.licensing.md
+++ b/skills/message-list/references/80.licensing.md
@@ -13,7 +13,7 @@ The `@virtuoso.dev/message-list` package is distributed under a commercial licen
 
 ## License Seats Explained
 
-The number of licenses to **the maximum number of concurrent front-end developers** who contribute to a project that uses the package. This also includes developers who work on the project part-time or as contractors.
+The number of licenses is **the maximum number of concurrent front-end developers** who contribute to a project that uses the package. This also includes developers who work on the project part-time or as contractors.
 
 For example, your app uses the `VirtuosoMessageList` component for building an AI Chatbot interface. **Three front-end** and two back-end developers are working on the project. One developer develops and maintains the message list UI feature, but there are three developers in total who work on the front-end. You must purchase **three licenses** for the project.
 
@@ -41,6 +41,22 @@ The license key is a string that you need to pass as a prop to the `VirtuosoMess
 </VirtuosoMessageListLicense>
 ```
 
+In an application, put the license wrapper near the app root or around the route section that renders chat UI. Read the key from your normal public client-side environment configuration.
+
+```tsx
+const licenseKey = import.meta.env.VITE_VIRTUOSO_MESSAGE_LIST_LICENSE_KEY ?? ''
+
+export function App() {
+  return (
+    <VirtuosoMessageListLicense licenseKey={licenseKey}>
+      <Routes />
+    </VirtuosoMessageListLicense>
+  )
+}
+```
+
+For Next.js, use a public environment variable, for example `NEXT_PUBLIC_VIRTUOSO_MESSAGE_LIST_LICENSE_KEY`, and pass it from a client component.
+
 ### Next.js/SSR
 
 The license component is using a context to pass the license to the `VirtuosoMessageList` component, so you need to ensure that it is not rendered server-side only.
@@ -57,11 +73,11 @@ The license key is validated without any network requests, so you can safely use
 
 ### No license wrapper component
 
-The `VirtuosMessageListLicense` component will throw an error and render an error unless wrapped with a `VirtuosoMessageListLicense` component. For development/evaluation purposes, you need to wrap one, even with an empty key prop. This will allow you to use the component without a license key for 30 days, keeping an error message in the developer console as a reminder.
+The `VirtuosoMessageList` component will render an error unless wrapped with a `VirtuosoMessageListLicense` component. For development/evaluation purposes, you need to wrap one, even with an empty key prop. This will allow you to use the component without a license key for 30 days, keeping an error message in the developer console as a reminder.
 
 ### Missing key
 
-You can use the component without a license key for 30 days for non-production environments and for evaluation purposes - a message in the console will remind you that you have to add the key. If the component is deployed to production without a license key, it will render as an error message in the browser and an error in the console.
+You can use the component with an empty license key for 30 days for non-production environments and for evaluation purposes - a message in the console will remind you that you have to add the key. If the component is deployed to production without a valid license key, it will render as an error message in the browser and an error in the console.
 
 ### Invalid key
 

--- a/skills/message-list/references/README.md
+++ b/skills/message-list/references/README.md
@@ -136,6 +136,7 @@ export default function App() {
               scrollModifier: {
                 type: 'auto-scroll-to-bottom',
                 autoScroll: ({ scrollInProgress, atBottom }) => {
+                  // This is a local user action, so it intentionally brings the question into view.
                   return {
                     index: 'LAST',
                     align: 'start',


### PR DESCRIPTION
## Summary
- update message-list docs for scroll callback semantics, notifyItemsChanged, helper policies, item identity, and layout/licensing requirements
- add a controlled-mode recipe for app-owned chat actions and socket echo handling
- refresh the source message-list skill, generated skill references, root skill mirror, plugin mirror, and add a patch changeset

## Validation
- pnpm build:skills
- pnpm validate:skills
- pnpm lint:md
- pnpm --filter @virtuoso.dev/virtuoso.dev lint