### PR TITLE
fix/clamp-out-of-range-scroll-index

### DIFF
--- a/.changeset/fuzzy-plants-push.md
+++ b/.changeset/fuzzy-plants-push.md
@@ -1,0 +1,5 @@
+---
+"react-virtuoso": patch
+---
+
+Clamp out-of-range scroll target indexes to the last available item.

--- a/packages/react-virtuoso/src/sizeSystem.ts
+++ b/packages/react-virtuoso/src/sizeSystem.ts
@@ -141,7 +141,7 @@ export function originalIndexFromLocation(location: FlatOrGroupedLocation, sizes
   }
   const numericIndex = location.index === 'LAST' ? lastIndex : location.index
   let result = originalIndexFromItemIndex(numericIndex, sizes)
-  result = Math.max(0, result, Math.min(lastIndex, result))
+  result = Math.max(0, Math.min(lastIndex, result))
   return result
 }
 

--- a/packages/react-virtuoso/test/sizeSystem.test.ts
+++ b/packages/react-virtuoso/test/sizeSystem.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { ranges, walk } from '../src/AATree'
-import { initialSizeState, offsetOf, rangesWithinOffsets, sizeStateReducer, sizeSystem, sizeTreeToRanges } from '../src/sizeSystem'
+import {
+  initialSizeState,
+  offsetOf,
+  originalIndexFromLocation,
+  rangesWithinOffsets,
+  sizeStateReducer,
+  sizeSystem,
+  sizeTreeToRanges,
+} from '../src/sizeSystem'
 import { getValue, init, publish, subscribe } from '../src/urx'
 
 import type { AANode } from '../src/AATree'
@@ -744,3 +752,24 @@ describe.only('benchmarks', () => {
   })
 })
    */
+
+describe('originalIndexFromLocation', () => {
+  const sizes = initialSizeState()
+  const lastIndex = 49
+
+  it('clamps an out-of-range index down to the last index', () => {
+    expect(originalIndexFromLocation({ index: 200 }, sizes, lastIndex)).toBe(lastIndex)
+  })
+
+  it('clamps a negative index up to zero', () => {
+    expect(originalIndexFromLocation({ index: -5 }, sizes, lastIndex)).toBe(0)
+  })
+
+  it('returns an in-range index unchanged', () => {
+    expect(originalIndexFromLocation({ index: 20 }, sizes, lastIndex)).toBe(20)
+  })
+
+  it("resolves 'LAST' to the last index", () => {
+    expect(originalIndexFromLocation({ index: 'LAST' }, sizes, lastIndex)).toBe(lastIndex)
+  })
+})


### PR DESCRIPTION
<!-- PR TITLE (paste into the title field) -->
# fix: clamp out-of-range index in originalIndexFromLocation

<!-- PR DESCRIPTION (paste into the body field) -->

## Summary

`originalIndexFromLocation` (in `sizeSystem.ts`) is meant to clamp a requested
index into the valid range `[0, lastIndex]`. The upper bound is never enforced,
so any index greater than `lastIndex` is returned as-is. This makes
`scrollToIndex` / `initialTopMostItemIndex` overshoot far past the end when given
an out-of-range index, instead of landing on the last item.

## Root cause

```ts
// packages/react-virtuoso/src/sizeSystem.ts
result = Math.max(0, result, Math.min(lastIndex, result))
```

The intent is a clamp: `Math.min(lastIndex, result)` caps the top and
`Math.max(0, ...)` caps the bottom. But the raw `result` is also passed to
`Math.max`, so when `result > lastIndex` it wins and the cap is defeated.

Worked example — list of 50 items (`lastIndex = 49`), requesting index `200`:

| Step | Expression | Result |
|------|------------|--------|
| Cap top | `Math.min(49, 200)` | `49` |
| Take max | `Math.max(0, 200, 49)` | `200` ← out of range |

Expected `49`, got `200`. The computed offset then points to a non-existent
item, producing a large scroll offset that overshoots the end of the list.

## Fix

Remove the stray `result` from `Math.max` so the upper bound is actually applied:

```ts
result = Math.max(0, Math.min(lastIndex, result))
```

Now: cap the top with `Math.min`, then floor with `Math.max(0, ...)`.

## Behavior

| Input index (lastIndex = 49) | Before | After |
|------------------------------|--------|-------|
| `200` (over range) | `200` | `49` |
| `-5` (under range) | `0` | `0` |
| `20` (in range) | `20` | `20` |
| `'LAST'` | `49` | `49` |

Only out-of-range-high indices change; all valid inputs behave exactly as before.

## Testing

Added unit tests for `originalIndexFromLocation` in `test/sizeSystem.test.ts`
covering over-range, under-range, in-range, and `'LAST'`.
