### PR TITLE
fix: harden scroll-target and initial-index handling

### DIFF
--- a/.changeset/clamp-initial-topmost-index.md
+++ b/.changeset/clamp-initial-topmost-index.md
@@ -1,5 +1,0 @@
----
-"react-virtuoso": patch
----
-
-Clamp the initial top-most item index to the available range. An out-of-range `initialTopMostItemIndex` (for example after the data set shrinks) no longer starts the list at a blank or mid-list position.

--- a/.changeset/clamp-initial-topmost-index.md
+++ b/.changeset/clamp-initial-topmost-index.md
@@ -1,0 +1,5 @@
+---
+"react-virtuoso": patch
+---
+
+Clamp the initial top-most item index to the available range. An out-of-range `initialTopMostItemIndex` (for example after the data set shrinks) no longer starts the list at a blank or mid-list position.

--- a/.changeset/scroll-target-and-initial-index-fixes.md
+++ b/.changeset/scroll-target-and-initial-index-fixes.md
@@ -1,9 +1,9 @@
 ---
-"react-virtuoso": patch
+'react-virtuoso': patch
 ---
 
 Harden scroll-target and initial-index handling:
 
 - Clamp the initial top-most item index to the available range, so an out-of-range `initialTopMostItemIndex` (for example after the data set shrinks) no longer starts the list at a blank or mid-list position.
 - Stop mutating the location object passed to `scrollToIndex`; `normalizeIndexLocation` now applies its defaults to a shallow copy.
-- Treat an `initialTopMostItemIndex` of `{ index: 0 }` the same as `0`, avoiding a redundant initial scroll and a delayed `followOutput`.
+- Treat a default-positioned `initialTopMostItemIndex` of `{ index: 0 }` the same as `0`, avoiding a redundant initial scroll and a delayed `followOutput`.

--- a/.changeset/scroll-target-and-initial-index-fixes.md
+++ b/.changeset/scroll-target-and-initial-index-fixes.md
@@ -1,0 +1,9 @@
+---
+"react-virtuoso": patch
+---
+
+Harden scroll-target and initial-index handling:
+
+- Clamp the initial top-most item index to the available range, so an out-of-range `initialTopMostItemIndex` (for example after the data set shrinks) no longer starts the list at a blank or mid-list position.
+- Stop mutating the location object passed to `scrollToIndex`; `normalizeIndexLocation` now applies its defaults to a shallow copy.
+- Treat an `initialTopMostItemIndex` of `{ index: 0 }` the same as `0`, avoiding a redundant initial scroll and a delayed `followOutput`.

--- a/packages/react-virtuoso/src/initialTopMostItemIndexSystem.ts
+++ b/packages/react-virtuoso/src/initialTopMostItemIndexSystem.ts
@@ -15,7 +15,15 @@ export function getInitialTopMostItemIndexNumber(location: FlatIndexLocationWith
 }
 
 export function initialTopMostItemIndexIsZero(location: FlatIndexLocationWithAlign | number): boolean {
-  return typeof location === 'number' ? location === 0 : location.index === 0
+  if (typeof location === 'number') {
+    return location === 0
+  }
+
+  return (
+    location.index === 0 &&
+    (location.align === undefined || location.align === 'start') &&
+    (location.offset === undefined || location.offset === 0)
+  )
 }
 
 export const initialTopMostItemIndexSystem = u.system(

--- a/packages/react-virtuoso/src/initialTopMostItemIndexSystem.ts
+++ b/packages/react-virtuoso/src/initialTopMostItemIndexSystem.ts
@@ -11,7 +11,7 @@ import type { FlatIndexLocationWithAlign } from './interfaces'
 export function getInitialTopMostItemIndexNumber(location: FlatIndexLocationWithAlign | number, totalCount: number): number {
   const lastIndex = totalCount - 1
   const index = typeof location === 'number' ? location : location.index === 'LAST' ? lastIndex : location.index
-  return index
+  return Math.max(0, Math.min(index, lastIndex))
 }
 
 export const initialTopMostItemIndexSystem = u.system(

--- a/packages/react-virtuoso/src/initialTopMostItemIndexSystem.ts
+++ b/packages/react-virtuoso/src/initialTopMostItemIndexSystem.ts
@@ -14,6 +14,10 @@ export function getInitialTopMostItemIndexNumber(location: FlatIndexLocationWith
   return Math.max(0, Math.min(index, lastIndex))
 }
 
+export function initialTopMostItemIndexIsZero(location: FlatIndexLocationWithAlign | number): boolean {
+  return typeof location === 'number' ? location === 0 : location.index === 0
+}
+
 export const initialTopMostItemIndexSystem = u.system(
   ([{ defaultItemSize, listRefresh, sizes }, { scrollTop }, { scrollTargetReached, scrollToIndex }, { didMount }]) => {
     const scrolledToInitialItem = u.statefulStream(true)
@@ -24,7 +28,7 @@ export const initialTopMostItemIndexSystem = u.system(
       u.pipe(
         didMount,
         u.withLatestFrom(initialTopMostItemIndex),
-        u.filter(([_, location]) => location !== 0),
+        u.filter(([_, location]) => !initialTopMostItemIndexIsZero(location)),
         u.mapTo(false)
       ),
       scrolledToInitialItem
@@ -33,7 +37,7 @@ export const initialTopMostItemIndexSystem = u.system(
       u.pipe(
         didMount,
         u.withLatestFrom(initialTopMostItemIndex),
-        u.filter(([_, location]) => location !== 0),
+        u.filter(([_, location]) => !initialTopMostItemIndexIsZero(location)),
         u.mapTo(false)
       ),
       initialItemFinalLocationReached

--- a/packages/react-virtuoso/src/scrollToIndexSystem.ts
+++ b/packages/react-virtuoso/src/scrollToIndexSystem.ts
@@ -11,7 +11,7 @@ export type IndexLocation = IndexLocationWithAlign | number
 const SUPPORTS_SCROLL_TO_OPTIONS = typeof document !== 'undefined' && 'scrollBehavior' in document.documentElement.style
 
 export function normalizeIndexLocation(location: IndexLocation) {
-  const result: IndexLocationWithAlign = typeof location === 'number' ? { index: location } : location
+  const result: IndexLocationWithAlign = typeof location === 'number' ? { index: location } : { ...location }
 
   if (!result.align) {
     result.align = 'start'

--- a/packages/react-virtuoso/test/initialTopMostItemIndexIsZero.test.ts
+++ b/packages/react-virtuoso/test/initialTopMostItemIndexIsZero.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { initialTopMostItemIndexIsZero } from '../src/initialTopMostItemIndexSystem'
+
+describe('initialTopMostItemIndexIsZero', () => {
+  it('treats the numeric 0 as zero', () => {
+    expect(initialTopMostItemIndexIsZero(0)).toBe(true)
+  })
+
+  it('treats { index: 0 } the same as the numeric 0', () => {
+    expect(initialTopMostItemIndexIsZero({ index: 0 })).toBe(true)
+    expect(initialTopMostItemIndexIsZero({ align: 'start', index: 0 })).toBe(true)
+  })
+
+  it('reports a non-zero numeric index', () => {
+    expect(initialTopMostItemIndexIsZero(5)).toBe(false)
+  })
+
+  it('reports a non-zero location index', () => {
+    expect(initialTopMostItemIndexIsZero({ index: 5 })).toBe(false)
+  })
+
+  it("does not treat 'LAST' as zero", () => {
+    expect(initialTopMostItemIndexIsZero({ index: 'LAST' })).toBe(false)
+  })
+})

--- a/packages/react-virtuoso/test/initialTopMostItemIndexIsZero.test.ts
+++ b/packages/react-virtuoso/test/initialTopMostItemIndexIsZero.test.ts
@@ -10,6 +10,13 @@ describe('initialTopMostItemIndexIsZero', () => {
   it('treats { index: 0 } the same as the numeric 0', () => {
     expect(initialTopMostItemIndexIsZero({ index: 0 })).toBe(true)
     expect(initialTopMostItemIndexIsZero({ align: 'start', index: 0 })).toBe(true)
+    expect(initialTopMostItemIndexIsZero({ behavior: 'smooth', index: 0 })).toBe(true)
+  })
+
+  it('does not treat zero index locations with explicit positioning as zero', () => {
+    expect(initialTopMostItemIndexIsZero({ align: 'center', index: 0 })).toBe(false)
+    expect(initialTopMostItemIndexIsZero({ align: 'end', index: 0 })).toBe(false)
+    expect(initialTopMostItemIndexIsZero({ index: 0, offset: 40 })).toBe(false)
   })
 
   it('reports a non-zero numeric index', () => {

--- a/packages/react-virtuoso/test/initialTopMostItemIndexSystem.test.ts
+++ b/packages/react-virtuoso/test/initialTopMostItemIndexSystem.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { getInitialTopMostItemIndexNumber } from '../src/initialTopMostItemIndexSystem'
+
+describe('getInitialTopMostItemIndexNumber', () => {
+  const totalCount = 50
+  const lastIndex = totalCount - 1
+
+  it('clamps an out-of-range numeric index down to the last index', () => {
+    expect(getInitialTopMostItemIndexNumber(200, totalCount)).toBe(lastIndex)
+  })
+
+  it('clamps an out-of-range location index down to the last index', () => {
+    expect(getInitialTopMostItemIndexNumber({ index: 200 }, totalCount)).toBe(lastIndex)
+  })
+
+  it('clamps a negative index up to zero', () => {
+    expect(getInitialTopMostItemIndexNumber(-5, totalCount)).toBe(0)
+    expect(getInitialTopMostItemIndexNumber({ index: -5 }, totalCount)).toBe(0)
+  })
+
+  it('returns an in-range index unchanged', () => {
+    expect(getInitialTopMostItemIndexNumber(20, totalCount)).toBe(20)
+    expect(getInitialTopMostItemIndexNumber({ index: 20 }, totalCount)).toBe(20)
+  })
+
+  it("resolves 'LAST' to the last index", () => {
+    expect(getInitialTopMostItemIndexNumber({ index: 'LAST' }, totalCount)).toBe(lastIndex)
+  })
+
+  it('clamps to zero for an empty list', () => {
+    expect(getInitialTopMostItemIndexNumber({ index: 5 }, 0)).toBe(0)
+  })
+})

--- a/packages/react-virtuoso/test/listSystem.test.ts
+++ b/packages/react-virtuoso/test/listSystem.test.ts
@@ -160,6 +160,37 @@ describe('list engine', () => {
         }, 100)
       })
     })
+
+    it('applies initial location options when the initial index is zero', () => {
+      const SIZE = 30
+      const OFFSET = 40
+      const { fixedItemHeight, initialTopMostItemIndex, listState, propsReady, scrollTo, scrollTop, totalCount, viewportHeight } =
+        init(listSystem)
+
+      publish(initialTopMostItemIndex, { index: 0, offset: OFFSET })
+      publish(scrollTop, 0)
+      publish(viewportHeight, 200)
+      publish(totalCount, 1000)
+      publish(propsReady, true)
+      publish(fixedItemHeight, SIZE)
+      expect(getValue(listState)).toMatchObject({
+        items: [],
+      })
+
+      const sub = vi.fn()
+      subscribe(scrollTo, sub)
+
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          expect(sub).toHaveBeenCalledWith({
+            behavior: 'auto',
+            top: OFFSET,
+          })
+
+          resolve(true)
+        }, 100)
+      })
+    })
   })
 
   describe('scroll to index', () => {

--- a/packages/react-virtuoso/test/scrollToIndexSystem.test.ts
+++ b/packages/react-virtuoso/test/scrollToIndexSystem.test.ts
@@ -18,9 +18,7 @@ describe('normalizeIndexLocation', () => {
 
   it('preserves explicitly provided fields', () => {
     const result = normalizeIndexLocation({ align: 'center', index: 2, offset: 10 })
-    expect(result.align).toBe('center')
-    expect(result.offset).toBe(10)
-    expect(result.index).toBe(2)
+    expect(result).toMatchObject({ align: 'center', index: 2, offset: 10 })
   })
 
   it('wraps a numeric location into an object with defaults', () => {

--- a/packages/react-virtuoso/test/scrollToIndexSystem.test.ts
+++ b/packages/react-virtuoso/test/scrollToIndexSystem.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeIndexLocation } from '../src/scrollToIndexSystem'
+
+describe('normalizeIndexLocation', () => {
+  it('does not mutate the passed location object', () => {
+    const location = { index: 5 }
+    normalizeIndexLocation(location)
+    expect(location).toEqual({ index: 5 })
+  })
+
+  it('returns a new object with the defaults applied', () => {
+    const location = { index: 5 }
+    const result = normalizeIndexLocation(location)
+    expect(result).not.toBe(location)
+    expect(result).toEqual({ align: 'start', behavior: 'auto', index: 5, offset: 0 })
+  })
+
+  it('preserves explicitly provided fields', () => {
+    const result = normalizeIndexLocation({ align: 'center', index: 2, offset: 10 })
+    expect(result.align).toBe('center')
+    expect(result.offset).toBe(10)
+    expect(result.index).toBe(2)
+  })
+
+  it('wraps a numeric location into an object with defaults', () => {
+    expect(normalizeIndexLocation(7)).toEqual({ align: 'start', behavior: 'auto', index: 7, offset: 0 })
+  })
+})


### PR DESCRIPTION
Per the request to group the related scroll-target / initial-index fixes, this PR now bundles all three. They touch the same scroll path and are described together in a single changeset.

## 1. Clamp the initial top-most item index
`getInitialTopMostItemIndexNumber` returned the raw index without bounds checking. An out-of-range `initialTopMostItemIndex` (e.g. after the data set shrinks, or a restored index that no longer fits `totalCount`) started the initial render at a blank or mid-list position. This is the initial-render counterpart of the scroll-target clamp added in #1442. Fix: clamp to `[0, lastIndex]`.

## 2. Don't mutate the location passed to scrollToIndex
`normalizeIndexLocation` applied its `align` / `behavior` / `offset` defaults directly onto the caller's location object, so a shared or memoized object was mutated (and re-published on retries). Fix: apply defaults to a shallow copy.

## 3. Treat initialTopMostItemIndex `{ index: 0 }` the same as `0`
The `didMount` filters compared the raw value against the number `0`, so the object form `{ index: 0 }` was treated as a non-default location — triggering a redundant initial scroll and delaying `followOutput`. Fix: add `initialTopMostItemIndexIsZero` and use it in both filters. `'LAST'` and non-zero indexes are unaffected.

## Tests
- `test/initialTopMostItemIndexSystem.test.ts` — clamping of `getInitialTopMostItemIndexNumber`.
- `test/scrollToIndexSystem.test.ts` — `normalizeIndexLocation` immutability and defaults.
- `test/initialTopMostItemIndexIsZero.test.ts` — numeric vs object zero, non-zero, and `'LAST'`.

Closes #1445, closes #1446.