### PR TITLE
fix: avoid mutating the location passed to scrollToIndex

### DIFF
--- a/.changeset/normalize-index-location-clone.md
+++ b/.changeset/normalize-index-location-clone.md
@@ -1,0 +1,5 @@
+---
+"react-virtuoso": patch
+---
+
+Stop mutating the location object passed to `scrollToIndex`. `normalizeIndexLocation` now applies its defaults to a shallow copy, so a shared or memoized location object is no longer altered (and re-published with mutated defaults on scroll retries).

--- a/packages/react-virtuoso/src/scrollToIndexSystem.ts
+++ b/packages/react-virtuoso/src/scrollToIndexSystem.ts
@@ -11,7 +11,7 @@ export type IndexLocation = IndexLocationWithAlign | number
 const SUPPORTS_SCROLL_TO_OPTIONS = typeof document !== 'undefined' && 'scrollBehavior' in document.documentElement.style
 
 export function normalizeIndexLocation(location: IndexLocation) {
-  const result: IndexLocationWithAlign = typeof location === 'number' ? { index: location } : location
+  const result: IndexLocationWithAlign = typeof location === 'number' ? { index: location } : { ...location }
 
   if (!result.align) {
     result.align = 'start'

--- a/packages/react-virtuoso/test/scrollToIndexSystem.test.ts
+++ b/packages/react-virtuoso/test/scrollToIndexSystem.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeIndexLocation } from '../src/scrollToIndexSystem'
+
+describe('normalizeIndexLocation', () => {
+  it('does not mutate the passed location object', () => {
+    const location = { index: 5 }
+    normalizeIndexLocation(location)
+    expect(location).toEqual({ index: 5 })
+  })
+
+  it('returns a new object with the defaults applied', () => {
+    const location = { index: 5 }
+    const result = normalizeIndexLocation(location)
+    expect(result).not.toBe(location)
+    expect(result).toEqual({ align: 'start', behavior: 'auto', index: 5, offset: 0 })
+  })
+
+  it('preserves explicitly provided fields', () => {
+    const result = normalizeIndexLocation({ align: 'center', index: 2, offset: 10 })
+    expect(result.align).toBe('center')
+    expect(result.offset).toBe(10)
+    expect(result.index).toBe(2)
+  })
+
+  it('wraps a numeric location into an object with defaults', () => {
+    expect(normalizeIndexLocation(7)).toEqual({ align: 'start', behavior: 'auto', index: 7, offset: 0 })
+  })
+})


### PR DESCRIPTION
## Problem
`normalizeIndexLocation` applied its `align` / `behavior` / `offset` defaults directly onto the caller's location object:

```ts
const result = typeof location === 'number' ? { index: location } : location
result.align = 'start' // mutates the caller's object
```

When a `scrollToIndex` consumer passes a shared or memoized location object (common in React), that object is mutated as a side effect. It also matters internally: on a scroll retry the same object is re-published, now carrying the previously-applied defaults.

## Fix
Apply the defaults to a shallow copy:

```ts
const result = typeof location === 'number' ? { index: location } : { ...location }
```

Behavior is unchanged for callers; the input object is simply left untouched.

## Tests
Added `test/scrollToIndexSystem.test.ts` asserting the input object is not mutated, that a fresh object with defaults is returned, that explicit fields are preserved, and that numeric locations are wrapped correctly.