### PR TITLE
fix: treat initialTopMostItemIndex { index: 0 } the same as 0

### DIFF
--- a/.changeset/initial-topmost-index-zero-object.md
+++ b/.changeset/initial-topmost-index-zero-object.md
@@ -1,0 +1,5 @@
+---
+"react-virtuoso": patch
+---
+
+Treat an `initialTopMostItemIndex` of `{ index: 0 }` the same as `0`. Previously the object form was considered a non-default initial location, which triggered a redundant initial scroll and delayed `followOutput` from engaging. Both forms now resolve to "start at the top".

--- a/packages/react-virtuoso/src/initialTopMostItemIndexSystem.ts
+++ b/packages/react-virtuoso/src/initialTopMostItemIndexSystem.ts
@@ -14,6 +14,10 @@ export function getInitialTopMostItemIndexNumber(location: FlatIndexLocationWith
   return index
 }
 
+export function initialTopMostItemIndexIsZero(location: FlatIndexLocationWithAlign | number): boolean {
+  return typeof location === 'number' ? location === 0 : location.index === 0
+}
+
 export const initialTopMostItemIndexSystem = u.system(
   ([{ defaultItemSize, listRefresh, sizes }, { scrollTop }, { scrollTargetReached, scrollToIndex }, { didMount }]) => {
     const scrolledToInitialItem = u.statefulStream(true)
@@ -24,7 +28,7 @@ export const initialTopMostItemIndexSystem = u.system(
       u.pipe(
         didMount,
         u.withLatestFrom(initialTopMostItemIndex),
-        u.filter(([_, location]) => location !== 0),
+        u.filter(([_, location]) => !initialTopMostItemIndexIsZero(location)),
         u.mapTo(false)
       ),
       scrolledToInitialItem
@@ -33,7 +37,7 @@ export const initialTopMostItemIndexSystem = u.system(
       u.pipe(
         didMount,
         u.withLatestFrom(initialTopMostItemIndex),
-        u.filter(([_, location]) => location !== 0),
+        u.filter(([_, location]) => !initialTopMostItemIndexIsZero(location)),
         u.mapTo(false)
       ),
       initialItemFinalLocationReached

--- a/packages/react-virtuoso/test/initialTopMostItemIndexIsZero.test.ts
+++ b/packages/react-virtuoso/test/initialTopMostItemIndexIsZero.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { initialTopMostItemIndexIsZero } from '../src/initialTopMostItemIndexSystem'
+
+describe('initialTopMostItemIndexIsZero', () => {
+  it('treats the numeric 0 as zero', () => {
+    expect(initialTopMostItemIndexIsZero(0)).toBe(true)
+  })
+
+  it('treats { index: 0 } the same as the numeric 0', () => {
+    expect(initialTopMostItemIndexIsZero({ index: 0 })).toBe(true)
+    expect(initialTopMostItemIndexIsZero({ align: 'start', index: 0 })).toBe(true)
+  })
+
+  it('reports a non-zero numeric index', () => {
+    expect(initialTopMostItemIndexIsZero(5)).toBe(false)
+  })
+
+  it('reports a non-zero location index', () => {
+    expect(initialTopMostItemIndexIsZero({ index: 5 })).toBe(false)
+  })
+
+  it("does not treat 'LAST' as zero", () => {
+    expect(initialTopMostItemIndexIsZero({ index: 'LAST' })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem
The `didMount` filters in `initialTopMostItemIndexSystem` compared the raw `initialTopMostItemIndex` value against the number `0`:

```ts
u.filter(([_, location]) => location !== 0)
```

When the prop is passed in object form — `initialTopMostItemIndex={{ index: 0 }}` — the comparison is `{ index: 0 } !== 0`, which is always `true`. So `{ index: 0 }` is treated as a non-default initial location: it triggers a redundant initial scroll-to-top and flips `scrolledToInitialItem` to `false`, which in turn delays `followOutput` from engaging. The numeric `0` and the object `{ index: 0 }` should behave identically.

## Fix
Add a small `initialTopMostItemIndexIsZero` helper that recognizes both the numeric and object zero, and use it in the two filters:

```ts
export function initialTopMostItemIndexIsZero(location: FlatIndexLocationWithAlign | number): boolean {
  return typeof location === 'number' ? location === 0 : location.index === 0
}
```

`{ index: 'LAST' }` and any non-zero index are unaffected and still trigger the initial scroll.

## Tests
Added `test/initialTopMostItemIndexIsZero.test.ts` covering numeric `0`, `{ index: 0 }` (with and without extra fields), non-zero numeric and object indexes, and `'LAST'`.