### PR TITLE
Add data table grow column layout

### DIFF
--- a/.changeset/fair-columns-grow.md
+++ b/.changeset/fair-columns-grow.md
@@ -1,5 +1,7 @@
 ---
-'@virtuoso.dev/data-table': minor
+"@virtuoso.dev/data-table": minor
 ---
 
-Add column-level `grow` sizing so selected columns can absorb leftover table width by ratio while compact columns keep their base widths.
+Add column-level `grow` sizing so selected columns can absorb leftover table width by ratio while compact columns keep their base widths. Header end slots now align to the rendered edge of grown columns, which keeps sortable header buttons visually anchored at the column boundary.
+
+The data-table docs, shadcn registry wrapper, and data-table skill guidance now also cover wrapper-owned styling surfaces, flex-height table layouts, explicit headers for display-only columns, and model-owned sort/filter/search state.

--- a/.changeset/fair-columns-grow.md
+++ b/.changeset/fair-columns-grow.md
@@ -1,5 +1,5 @@
 ---
-"@virtuoso.dev/data-table": minor
+'@virtuoso.dev/data-table': minor
 ---
 
 Add column-level `grow` sizing so selected columns can absorb leftover table width by ratio while compact columns keep their base widths. Header end slots now align to the rendered edge of grown columns, which keeps sortable header buttons visually anchored at the column boundary.

--- a/.changeset/fair-columns-grow.md
+++ b/.changeset/fair-columns-grow.md
@@ -1,0 +1,5 @@
+---
+'@virtuoso.dev/data-table': minor
+---
+
+Add column-level `grow` sizing so selected columns can absorb leftover table width by ratio while compact columns keep their base widths.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,9 +1,9 @@
 sandbox_mode = "workspace-write"
-[mcp_servers.notion]
+[mcp_servers.notion_react_virtuoso]
 url = "https://mcp.notion.com/mcp"
 
-[mcp_servers.notion.tools.notion-update-data-source]
+[mcp_servers.notion_react_virtuoso.tools.notion-update-data-source]
 approval_mode = "approve"
 
-[mcp_servers.notion.tools.notion-update-page]
+[mcp_servers.notion_react_virtuoso.tools.notion-update-page]
 approval_mode = "approve"

--- a/apps/virtuoso.dev/registry/new-york/data-table/column-sort/sort-header-button.tsx
+++ b/apps/virtuoso.dev/registry/new-york/data-table/column-sort/sort-header-button.tsx
@@ -61,7 +61,7 @@ export function SortHeaderButton({
       aria-label={label}
       aria-pressed={direction !== undefined}
       className={cn(
-        'ml-1 inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50',
+        'ml-1 inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50',
         direction !== undefined && 'bg-muted text-foreground',
         className
       )}

--- a/apps/virtuoso.dev/registry/new-york/data-table/data-table.tsx
+++ b/apps/virtuoso.dev/registry/new-york/data-table/data-table.tsx
@@ -67,8 +67,8 @@ const TableRow = React.forwardRef<HTMLDivElement, RowComponentProps & { context?
     <div
       ref={ref}
       className={cn(
-        'border-b border-transparent bg-clip-padding transition-colors hover:bg-muted/50',
-        'after:content-[""] after:absolute after:-bottom-px after:inset-x-0 after:h-px after:bg-border after:z-3'
+        'border-b border-transparent bg-clip-padding transition-colors hover:bg-[var(--data-table-row-hover)]',
+        'after:content-[""] after:absolute after:-bottom-px after:inset-x-0 after:h-px after:bg-[var(--data-table-border)] after:z-3'
       )}
       {...props}
     />
@@ -80,12 +80,12 @@ const TableStickyHeader = React.forwardRef<HTMLDivElement, StickyHeaderComponent
   ref
 ) {
   const mergedStyle = React.useMemo(() => ({ position: 'sticky' as const, top: 0, zIndex: 1, ...style }), [style])
-  return <div ref={ref} className="border-b border-border bg-background" style={mergedStyle} {...props} />
+  return <div ref={ref} className="border-b border-[var(--data-table-border)] bg-[var(--data-table-bg)]" style={mergedStyle} {...props} />
 })
 
 const TableStickyColumnContainer = React.forwardRef<HTMLDivElement, StickyColumnContainerComponentProps & { context?: unknown }>(
   function TableStickyColumnContainer({ context: _context, ...props }, ref) {
-    return <div ref={ref} className="bg-background transition-colors" {...props} />
+    return <div ref={ref} className="bg-[var(--data-table-bg)] transition-colors" {...props} />
   }
 )
 
@@ -95,7 +95,7 @@ function TableLoadingOverlay({ loadingState }: LoadingComponentProps) {
 
   return (
     <div aria-live="polite" className="flex justify-center px-3 pt-3" role="status">
-      <div className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/90 px-3 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur-xs">
+      <div className="inline-flex items-center gap-2 rounded-full border border-[var(--data-table-border)] bg-[color-mix(in_oklch,var(--data-table-bg)_90%,transparent)] px-3 py-1.5 text-xs text-[var(--data-table-muted-fg)] shadow-sm backdrop-blur-xs">
         {isError ? <AlertCircle className="size-3.5" /> : <Loader2 className="size-3.5 animate-spin" />}
         <span>{message}</span>
       </div>
@@ -109,8 +109,8 @@ function TableLoadingPlaceholder({ loadingState }: LoadingComponentProps) {
 
   return (
     <div aria-live="polite" className="px-3 py-4" role="status">
-      <div className="rounded-xl border border-border/70 bg-muted/20 p-4 shadow-xs">
-        <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-border/70 bg-background px-3 py-1.5 text-xs text-muted-foreground">
+      <div className="rounded-xl border border-[var(--data-table-border)] bg-[color-mix(in_oklch,var(--data-table-muted)_20%,transparent)] p-4 shadow-xs">
+        <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[var(--data-table-border)] bg-[var(--data-table-bg)] px-3 py-1.5 text-xs text-[var(--data-table-muted-fg)]">
           {isError ? <AlertCircle className="size-3.5" /> : <Loader2 className="size-3.5 animate-spin" />}
           <span>{message}</span>
         </div>
@@ -118,9 +118,9 @@ function TableLoadingPlaceholder({ loadingState }: LoadingComponentProps) {
           <div className="space-y-3">
             {Array.from({ length: 6 }, (_, index) => (
               <div key={index} className="grid grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)_minmax(0,0.6fr)] gap-3">
-                <div className="h-4 animate-pulse rounded bg-muted" />
-                <div className="h-4 animate-pulse rounded bg-muted/80" />
-                <div className="h-4 animate-pulse rounded bg-muted/60" />
+                <div className="h-4 animate-pulse rounded bg-[var(--data-table-muted)]" />
+                <div className="h-4 animate-pulse rounded bg-[color-mix(in_oklch,var(--data-table-muted)_80%,transparent)]" />
+                <div className="h-4 animate-pulse rounded bg-[color-mix(in_oklch,var(--data-table-muted)_60%,transparent)]" />
               </div>
             ))}
           </div>
@@ -137,10 +137,10 @@ function TableLoadingFooter({ loadingState }: LoadingComponentProps) {
   return (
     <div
       aria-live="polite"
-      className="flex min-h-10 items-center justify-center border-t border-border/70 bg-background/95 px-3 py-2 text-xs text-muted-foreground"
+      className="flex min-h-10 items-center justify-center border-t border-[var(--data-table-border)] bg-[color-mix(in_oklch,var(--data-table-bg)_95%,transparent)] px-3 py-2 text-xs text-[var(--data-table-muted-fg)]"
       role="status"
     >
-      <div className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-muted/60 px-3 py-1 shadow-xs">
+      <div className="inline-flex items-center gap-2 rounded-full border border-[var(--data-table-border)] bg-[color-mix(in_oklch,var(--data-table-muted)_60%,transparent)] px-3 py-1 shadow-xs">
         {isError ? <AlertCircle className="size-3.5" /> : <Loader2 className="size-3.5 animate-spin" />}
         <span>{message}</span>
       </div>
@@ -163,16 +163,21 @@ function DataTable<Data, Context = unknown, Group = unknown>({
   ...props
 }: VirtuosoDataTableProps<Data, Context, Group> & { className?: string }) {
   const mergedComponents = React.useMemo(() => ({ ...TABLE_COMPONENTS, ...components }) as DataTableComponents<Context>, [components])
-  const usesExternalScroll = props.useWindowScroll === true || Object.hasOwn(props, 'customScrollParent')
 
   return (
     <VirtuosoDataTable
       className={cn(
-        'relative w-full bg-background text-foreground text-sm',
-        !usesExternalScroll && 'overflow-x-auto',
-        '**:data-[scope=colgroup]:border-b **:data-[scope=colgroup]:border-border',
-        '**:data-group-row:bg-muted **:data-group-row:font-medium',
-        '[&_[data-table-element-role=row]:hover_[data-sticky]]:bg-[color-mix(in_oklch,var(--color-muted)_50%,var(--color-background))]',
+        'relative w-full overflow-hidden rounded-md border border-[var(--data-table-border)] bg-[var(--data-table-bg)] text-[var(--data-table-fg)] text-sm',
+        '[--data-table-bg:hsl(var(--background))]',
+        '[--data-table-border:hsl(var(--border))]',
+        '[--data-table-fg:hsl(var(--foreground))]',
+        '[--data-table-muted:hsl(var(--muted))]',
+        '[--data-table-muted-fg:hsl(var(--muted-foreground))]',
+        '[--data-table-row-hover:hsl(var(--muted)/0.5)]',
+        '[--data-table-sticky-hover:color-mix(in_oklch,var(--data-table-muted)_50%,var(--data-table-bg))]',
+        '**:data-[scope=colgroup]:border-b **:data-[scope=colgroup]:border-[var(--data-table-border)]',
+        '**:data-group-row:bg-[var(--data-table-muted)] **:data-group-row:font-medium',
+        '[&_[data-table-element-role=row]:hover_[data-sticky]]:bg-[var(--data-table-sticky-hover)]',
         className
       )}
       components={mergedComponents}
@@ -192,7 +197,7 @@ interface DataTableColumnHeaderProps {
 }
 
 function DataTableColumnHeader(props: DataTableColumnHeaderProps) {
-  const measureClassName = 'flex h-10 items-center px-2 align-middle text-sm font-medium text-foreground'
+  const measureClassName = 'flex h-10 items-center px-2 align-middle text-sm font-medium text-[var(--data-table-fg)]'
   const contentClassName = cn('flex min-w-0 items-center overflow-hidden truncate', props.className)
 
   if (props.component) {
@@ -249,7 +254,10 @@ interface CellDefinitionProps {
 }
 
 function DataTableGroupHeader(props: GroupHeaderCellProps) {
-  const className = cn('border-b bg-muted px-2 py-2 text-sm font-medium text-foreground', props.className)
+  const className = cn(
+    'border-b border-[var(--data-table-border)] bg-[var(--data-table-muted)] px-2 py-2 text-sm font-medium text-[var(--data-table-fg)]',
+    props.className
+  )
 
   if ('component' in props) {
     return <GroupHeaderCell className={className} component={props.component} />

--- a/packages/data-table/docs/2.data-model/02.remote-data-model.md
+++ b/packages/data-table/docs/2.data-model/02.remote-data-model.md
@@ -168,6 +168,8 @@ model.send({ action: 'search', payload: 'desk' })
 
 Returning new params triggers a refresh. With `persistence: true`, the payload of each action — the search string, the selected category — is saved alongside the rest of the table's persisted state and replayed through the handler the next time the table loads, so users come back to the same filtered view. Pass `capture` and `restore` instead of `true` when you need a custom serialized shape.
 
+For stateful controls such as sort, filter, group, or search, prefer the model action state as the source of truth. Seed default active controls with `initialActions`, dispatch changes through `model.send()` or `dispatchModelAction$`, and read `modelActionState$` to paint active buttons. Do not mirror sort/filter payloads in React state just to keep controls highlighted; if a control must be controlled by React, explicitly restore that local state when using `modelStatePersistenceAdapter()`.
+
 For a complete column-header sort control that sends `{ field, direction }` to a remote model, see [Remote Column Sorting](/data-table/examples/remote-column-sorting/).
 
 ## Concurrency and cancellation

--- a/packages/data-table/docs/3.columns/01.defining-columns.md
+++ b/packages/data-table/docs/3.columns/01.defining-columns.md
@@ -14,7 +14,7 @@ sidebar:
 </DataTableColumn>
 ```
 
-For a row `{ name: 'Standing Desk' }`, the cell renderer receives `'Standing Desk'` as `cellValue`. Omitting `DataTableCell` falls back to the field value; omitting `DataTableColumnHeader` falls back to the field name.
+For a row `{ name: 'Standing Desk' }`, the cell renderer receives `'Standing Desk'` as `cellValue`. Omitting `DataTableCell` falls back to the field value; omitting `DataTableColumnHeader` on a field-backed column falls back to the field name. In app UIs, prefer explicit headers so you control capitalization, wording, and accessibility.
 
 Display-only columns do not need matching row fields. Give them an explicit `id` instead. The id becomes the stable column identity, and `cellValue` is `undefined` unless you provide an `accessor`.
 
@@ -24,6 +24,8 @@ Display-only columns do not need matching row fields. Give them an explicit `id`
   <DataTableCell>{({ row }) => <ActionsMenu row={row.data} />}</DataTableCell>
 </DataTableColumn>
 ```
+
+`id` is not a visible label. For action, selection, expansion, status-icon, and other display-only columns, always provide a `DataTableColumnHeader`. Use visible text such as `Actions` by default; use `sr-only` text only when the product intentionally wants a headerless icon column.
 
 Computed columns also use an explicit `id`, plus an `accessor` when you want the table to provide a derived `cellValue`.
 

--- a/packages/data-table/docs/3.columns/02.cell-and-header-renderers.md
+++ b/packages/data-table/docs/3.columns/02.cell-and-header-renderers.md
@@ -15,6 +15,15 @@ Both `DataTableCell` and `DataTableColumnHeader` accept a `className` prop along
 <DataTableCell className="text-right tabular-nums">{({ cellValue }) => currency.format(Number(cellValue))}</DataTableCell>
 ```
 
+Do not put column width utilities on `DataTableCell`. Classes like `w-*`, `min-w-*`, `max-w-*`, `basis-*`, `flex-*`, `grow`, and `shrink-*` do not control the column track from a body cell. Put base width classes on `DataTableColumnHeader`, and use `DataTableColumn grow={...}` when a column should absorb leftover horizontal space. A cell width can make the body content fight the measured grid track and overlap neighboring columns. For cell content that needs truncation or nested layout, keep the cell unconstrained and put `min-w-0` on an inner wrapper:
+
+```tsx
+<DataTableColumn field="name">
+  <DataTableColumnHeader className="min-w-64">Name</DataTableColumnHeader>
+  <DataTableCell className="font-medium">{({ row }) => <div className="min-w-0 truncate">{row.data.name}</div>}</DataTableCell>
+</DataTableColumn>
+```
+
 Each visible cell is its own element; the table also column- and row-virtualizes, so an extra wrapper inside the render function multiplies by every rendered cell on every scroll. Save nested elements for styling that's only part of the cell content — a status badge, an inline icon, a secondary line of metadata.
 
 The shadcn wrapper accepts plain text for static headers:

--- a/packages/data-table/docs/3.columns/06.column-resizing.md
+++ b/packages/data-table/docs/3.columns/06.column-resizing.md
@@ -69,25 +69,55 @@ Skip `HeaderEdge` for columns the user shouldn't be allowed to resize — a fixe
 
 ## Where column widths live
 
-The table owns every column's width through its header. It measures each `DataTableColumnHeader`, distributes any leftover viewport space across the visible columns, and uses the resulting size for every body cell in that column. The drag handle, the programmatic `resizeColumn$` call, and the persisted overrides all feed into that same pipeline as runtime overrides on top of the measured base.
+The table owns every column's width through its header. It measures each `DataTableColumnHeader`, distributes any leftover viewport space across the visible columns, and uses the resulting size for every body cell in that column. The drag handle, the programmatic `resizeColumn$` call, and the persisted overrides feed into that same pipeline as user-selected rendered widths. While a resize override is active, sibling columns keep their current rendered widths so dragging a boundary feels direct and can create horizontal overflow.
 
-To set a column's _default_ width, style the header. The header row is a flex container, so width and flex utilities on `DataTableColumnHeader` work the way they would on any flex child — `w-20`, `min-w-32`, `max-w-64`, `grow`, `shrink-0`, `basis-32`:
+To set a column's _base_ width, style the header with width or minimum-width classes. To decide which columns receive leftover horizontal space, use `DataTableColumn grow={number}`. Do not use Tailwind flex growth classes as the table sizing API:
 
 ```tsx
 <DataTableColumn field="id">
-  <DataTableColumnHeader className="w-20 grow-0">ID</DataTableColumnHeader>
+  <DataTableColumnHeader className="w-20">ID</DataTableColumnHeader>
   <DataTableCell>{({ cellValue }) => String(cellValue)}</DataTableCell>
 </DataTableColumn>
 
-<DataTableColumn field="name">
-  <DataTableColumnHeader className="min-w-48 grow">Product</DataTableColumnHeader>
+<DataTableColumn field="name" grow={1}>
+  <DataTableColumnHeader className="min-w-48">Product</DataTableColumnHeader>
   <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
 </DataTableColumn>
 ```
 
+For the full sizing model, including fixed metadata columns, text-heavy grow columns, horizontal overflow, and resize override behavior, see [Column Layout](/data-table/columns/column-layout/).
+
 :::caution[Don't put widths on the cell]
 Body cells render inside a grid track sized to the column's measured width — they're already constrained from the outside. Width CSS on `DataTableCell` (`w-*`, `min-w-*`, `max-w-*`, `flex-*`, `basis-*`) doesn't influence the column and can fight the grid into clipped or overflowing content. When a column needs to be wider, widen its header. Reserve cell CSS for things inside the track: padding, alignment, typography, truncation.
 :::
+
+This includes width pressure added for "realistic" content. If a prompt name, badge stack, action menu, or timestamp needs room, express that as a header width:
+
+```tsx
+<DataTableColumn field="updated_at">
+  <DataTableColumnHeader className="min-w-44">Updated</DataTableColumnHeader>
+  <DataTableCell className="font-medium">{UpdatedCell}</DataTableCell>
+</DataTableColumn>
+```
+
+Do not mirror that width on the body cell. For multi-line or nested content, place layout helpers inside the cell renderer:
+
+```tsx
+<DataTableCell>
+  {({ row }) => (
+    <div className="min-w-0">
+      <p className="truncate">{row.data.name}</p>
+      <p className="truncate text-muted-foreground">{row.data.slug}</p>
+    </div>
+  )}
+</DataTableCell>
+```
+
+As a final review step, search for width utilities on cell declarations:
+
+```bash
+rg 'DataTableCell.*className=.*(w-|min-w|max-w|basis-|grow|shrink|flex-(none|auto|initial|1|\[))'
+```
 
 ## Resizing without the drag handle
 
@@ -113,7 +143,7 @@ The payload's `key` is the column's internal identifier, not its `field`. The lo
 
 ## Persisting widths across reloads
 
-The handle records the user's _intent_ — "the user wants the name column 280px wide." Intent is what gets saved; the _realized_ width the column actually renders at depends on the table size and the other columns, and shifts as the layout shifts. Saving the realized number locks the user into the layout that happened to be on screen when they last touched the handle.
+The handle records the user's _intent_ — "the user wants the name column 280px wide." Intent is what gets saved. Automatic `grow` output is not persisted; clearing the override lets the column fall back to its measured base width and the current grow distribution.
 
 Mount `columnWidthPersistenceAdapter()` on `DataTableStatePersistence` to persist overrides. The adapter saves them keyed by `field`, so the saved entry survives reordering, partial column lists, and dynamically generated columns. [State Persistence](/data-table/state-persistence/) covers the full wiring, including the field-name contract that ties saved state to column declarations.
 

--- a/packages/data-table/docs/3.columns/09.column-layout.md
+++ b/packages/data-table/docs/3.columns/09.column-layout.md
@@ -1,0 +1,88 @@
+---
+title: Column Layout
+description: Set base column widths and choose which columns grow into extra horizontal space.
+sidebar:
+  label: Column Layout
+---
+
+Column width has two parts: the base width and the realized width.
+
+The base width comes from the column header. The table measures `DataTableColumnHeader`, then uses that measured width as the starting point for both the header and every body cell in that column.
+
+The realized width is the width the column gets after the table compares all base widths with the viewport. When the viewport is wider than the total base width, extra space is distributed by the table. When the viewport is narrower, columns keep their base widths and the table scrolls horizontally.
+
+## Set Base Widths On Headers
+
+Use header width classes for the minimum useful size of each column:
+
+```tsx
+<DataTableColumn field="name">
+  <DataTableColumnHeader className="min-w-72">Name</DataTableColumnHeader>
+  <DataTableCell>{NameCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="updated">
+  <DataTableColumnHeader className="w-44">Updated</DataTableColumnHeader>
+  <DataTableCell>{UpdatedCell}</DataTableCell>
+</DataTableColumn>
+```
+
+Do not mirror those widths on `DataTableCell`. Body cells render inside tracks sized by the table. Cell width utilities can fight those tracks and cause clipping or overlap.
+
+## Choose Which Columns Grow
+
+Use `DataTableColumn grow={number}` for columns that should absorb extra viewport width. The value is a ratio, not a CSS flex shorthand.
+Omitting `grow`, or passing `grow={0}`, keeps the column fixed when another visible column grows.
+
+```tsx
+<DataTableColumn field="name" grow={1}>
+  <DataTableColumnHeader className="min-w-72">Name</DataTableColumnHeader>
+  <DataTableCell>{NameCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="description" grow={3}>
+  <DataTableColumnHeader className="min-w-80">Description</DataTableColumnHeader>
+  <DataTableCell>{DescriptionCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="versions">
+  <DataTableColumnHeader className="w-40">Versions</DataTableColumnHeader>
+  <DataTableCell>{VersionBadgesCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="updated">
+  <DataTableColumnHeader className="w-44">Updated</DataTableColumnHeader>
+  <DataTableCell>{UpdatedCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn id="actions">
+  <DataTableColumnHeader className="w-16 justify-center">Actions</DataTableColumnHeader>
+  <DataTableCell>{ActionsCell}</DataTableCell>
+</DataTableColumn>
+```
+
+In this layout, `name` and `description` receive all extra width. `description` receives three times as much extra width as `name`. `versions`, `updated`, and `actions` keep their base widths.
+
+Choose grow columns from the local data and workflow. IDs, slugs, checkboxes, action menus, short labels, badges, version counts, timestamps, and compact metadata usually should not grow. Names, titles, descriptions, summaries, messages, notes, paths, and other text-heavy content usually benefit from extra room. The field name is only a clue: a short code-like `name` may be fixed, while a user-authored label column may deserve room.
+
+Do not make every column grow. The point of `grow` is to let useful text columns breathe while compact columns stay compact.
+
+## What Happens Without Grow
+
+Tables that do not set `grow` preserve the default auto-fill behavior: when the viewport is wider than the total base width, extra space is distributed evenly across visible columns. This keeps existing tables filling their container without changing every column declaration.
+
+Once any visible column has a positive finite `grow` value, only grow columns receive leftover width. Non-grow columns keep their base widths.
+
+## There Is No Shrink Prop
+
+`grow` only distributes extra space. It does not shrink columns below their base widths, and there is no `shrink` table API.
+
+When the viewport narrows, grow space disappears first. After the total base width no longer fits, the table keeps base widths and uses horizontal scrolling.
+
+## Resizing Grow Columns
+
+Column resizing sets the rendered width of that column. During and after a resize override, the table preserves the current rendered widths of the other columns instead of redistributing grow space on every pointer move. That keeps the resize handle under the pointer and lets wider columns push the table into horizontal overflow.
+
+Clear the resize override to return the column to its measured base width and the normal `grow` distribution.
+
+Persist resize overrides as user-selected widths, not as automatic grow output. The saved width is the user's explicit override; automatic grow space is recalculated only when no resize override is active for that layout.

--- a/packages/data-table/docs/3.columns/index.md
+++ b/packages/data-table/docs/3.columns/index.md
@@ -72,12 +72,15 @@ Omit the header to fall back to the field name; omit the cell to fall back to th
 
 `field` is both the cell lookup key (`row.data[field]`) and the column's persistent identity. Keep it stable across releases if you use any column features that save state — see [State Persistence](/data-table/state-persistence/#field-names-are-the-persistence-contract) for the rules around renaming.
 
+For layout, put base widths on `DataTableColumnHeader` and use `DataTableColumn grow={...}` only for columns that should absorb extra horizontal space. See [Column Layout](/data-table/columns/column-layout/) for the sizing model and guidance on choosing fixed vs growing columns from the data being displayed.
+
 ## Where to go next
 
 Declarative shape:
 
 - [Defining Columns](/data-table/columns/defining-columns/) — `field`, default rendering, declaration order, visibility, generated columns.
 - [Formatting Cells and Headers](/data-table/columns/cell-and-header-renderers/) — render params, extracted renderer functions, custom header content.
+- [Column Layout](/data-table/columns/column-layout/) — base widths, `grow` ratios, fixed metadata columns, and horizontal overflow.
 - [Column Groups](/data-table/columns/column-groups/) — wrap adjacent columns under a shared header.
 - [Sticky Columns](/data-table/columns/sticky-columns/) — pin a column to the left or right edge during horizontal scrolling.
 

--- a/packages/data-table/docs/7.customization/01.styling.md
+++ b/packages/data-table/docs/7.customization/01.styling.md
@@ -23,7 +23,7 @@ const model = localModel({ data: rows })
 
 export default function App() {
   return (
-    <DataTable className="rounded-xl border-2 border-slate-900/10 shadow-sm" model={model} style={{ height: 280 }}>
+    <DataTable model={model} style={{ height: 280 }}>
       <DataTableColumn field="name">
         <DataTableColumnHeader>Product</DataTableColumnHeader>
         <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
@@ -61,10 +61,22 @@ export default function App() {
 
 ## Wrapper-level styling
 
-`className` on `<DataTable>` reaches the outer frame around the scroll viewport. Use it for borders, rounded corners, shadow, and the table's overall background.
+`className` on `<DataTable>` reaches the outer frame around the scroll viewport. The shadcn wrapper already provides the default frame (`rounded-md border`) and table surface, so you do not need to repeat `rounded-md border` at each instance. Use wrapper classes for intentional frame overrides, shadows, and table-level CSS variable overrides.
 
 ```tsx
-<DataTable className="rounded-xl border bg-card shadow-sm" model={model}>
+<DataTable className="rounded-xl shadow-sm" model={model}>
+  {/* columns */}
+</DataTable>
+```
+
+To remove or strengthen the default frame, override it directly:
+
+```tsx
+<DataTable className="border-0" model={model}>
+  {/* columns */}
+</DataTable>
+
+<DataTable className="border-2" model={model}>
   {/* columns */}
 </DataTable>
 ```

--- a/packages/data-table/docs/7.customization/04.scroll-containers.md
+++ b/packages/data-table/docs/7.customization/04.scroll-containers.md
@@ -42,6 +42,40 @@ export default function App() {
 }
 ```
 
+## Fill available panel height
+
+For app pages where the table should consume the remaining space below fixed page chrome, keep the default internal table scroller and give the table a measured flex slot. This is usually better than guessing a pixel height.
+
+The important pieces are:
+
+- a parent with a real height, such as a route shell, panel, or card body
+- `min-h-0` on each flex ancestor between that measured parent and the table
+- `shrink-0` on controls above the table
+- `flex-1 min-h-0` on `DataTable`, plus `style={{ height: '100%' }}`
+
+```tsx
+export function OrdersPage() {
+  return (
+    <section className="flex h-full min-h-0 flex-col">
+      <PageHeader className="shrink-0" />
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3">
+        <Toolbar className="shrink-0" />
+
+        <DataTable className="min-h-0 flex-1" computeRowKey={({ data }) => data.id} model={model} style={{ height: '100%' }}>
+          <DataTableColumn field="name">
+            <DataTableColumnHeader>Order</DataTableColumnHeader>
+            <DataTableCell>{({ cellValue }) => String(cellValue)}</DataTableCell>
+          </DataTableColumn>
+        </DataTable>
+      </div>
+    </section>
+  )
+}
+```
+
+Use this pattern only when the parent is height-constrained. If the table lives in normal document flow, keep a fixed table height (`style={{ height: 360 }}`) or intentionally switch to `useWindowScroll` / `customScrollParent`.
+
 ## Window scrolling
 
 `useWindowScroll` makes the document viewport drive the table's scroll state:

--- a/packages/data-table/docs/7.customization/07.shadcn-wrapper.md
+++ b/packages/data-table/docs/7.customization/07.shadcn-wrapper.md
@@ -61,15 +61,15 @@ The default shadcn wrapper gives `DataTable` an app-level frame (`rounded-md bor
 
 The variables matter most for sticky headers and sticky columns: those pieces are separate overlay containers, so they need an opaque background, but that background should match the table body instead of being hardcoded independently.
 
-| Variable                     | Default                          | Used for                                           |
-| ---------------------------- | -------------------------------- | -------------------------------------------------- |
-| `--data-table-bg`            | `hsl(var(--background))`         | Table body, sticky header, sticky column wrappers  |
-| `--data-table-fg`            | `hsl(var(--foreground))`         | Default table/header/group-header text             |
-| `--data-table-border`        | `hsl(var(--border))`             | Row separators, header borders, loading containers |
-| `--data-table-muted`         | `hsl(var(--muted))`              | Group rows, skeleton rows, sticky hover blends     |
-| `--data-table-muted-fg`      | `hsl(var(--muted-foreground))`   | Loading and secondary wrapper text                 |
-| `--data-table-row-hover`     | `hsl(var(--muted) / 0.5)`        | Non-sticky row hover background                    |
-| `--data-table-sticky-hover`  | a mix of muted and table bg      | Sticky column hover background                     |
+| Variable                    | Default                        | Used for                                           |
+| --------------------------- | ------------------------------ | -------------------------------------------------- |
+| `--data-table-bg`           | `hsl(var(--background))`       | Table body, sticky header, sticky column wrappers  |
+| `--data-table-fg`           | `hsl(var(--foreground))`       | Default table/header/group-header text             |
+| `--data-table-border`       | `hsl(var(--border))`           | Row separators, header borders, loading containers |
+| `--data-table-muted`        | `hsl(var(--muted))`            | Group rows, skeleton rows, sticky hover blends     |
+| `--data-table-muted-fg`     | `hsl(var(--muted-foreground))` | Loading and secondary wrapper text                 |
+| `--data-table-row-hover`    | `hsl(var(--muted) / 0.5)`      | Non-sticky row hover background                    |
+| `--data-table-sticky-hover` | a mix of muted and table bg    | Sticky column hover background                     |
 
 If your app maps shadcn tokens to a different design system, override these variables once on the `DataTable` root or in the copied wrapper defaults. Do not style sticky cells individually just to fix a surface mismatch.
 

--- a/packages/data-table/docs/7.customization/07.shadcn-wrapper.md
+++ b/packages/data-table/docs/7.customization/07.shadcn-wrapper.md
@@ -23,7 +23,7 @@ const model = localModel({ data: rows })
 
 export default function App() {
   return (
-    <DataTable className="rounded-xl border-2 border-border/70 shadow-sm" model={model} style={{ height: 280 }}>
+    <DataTable model={model} style={{ height: 280 }}>
       <DataTableColumn field="product">
         <DataTableColumnHeader>Product</DataTableColumnHeader>
         <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
@@ -49,10 +49,42 @@ The wrapper covers _presentation_:
 
 - default row, header, sticky-column, empty, and loading components
 - Tailwind classes for cells, headers, and group headers
+- the default table frame (`rounded-md border`) and table surface variables
 - ergonomic names (`DataTable`, `DataTableColumn`, `DataTableColumnHeader`, `DataTableCell`)
 - re-exports of the headless hooks and helpers you'll use day-to-day
 
 Edit it like any other component in your app. Tailwind classes, default props, alternate variants, additional re-exports — all fair game. The wrapper file imports behavior from `@virtuoso.dev/data-table`, so your styling edits never fork table mechanics.
+
+## Table surface variables
+
+The default shadcn wrapper gives `DataTable` an app-level frame (`rounded-md border`) and defines a small set of CSS variables on the same root. The frame border uses `--data-table-border`; callers do not need to add `rounded-md border` at each table instance. Use `className` only for intentional overrides such as `rounded-xl`, `border-0`, `border-2`, `shadow-sm`, or table variable overrides.
+
+The variables matter most for sticky headers and sticky columns: those pieces are separate overlay containers, so they need an opaque background, but that background should match the table body instead of being hardcoded independently.
+
+| Variable                     | Default                          | Used for                                           |
+| ---------------------------- | -------------------------------- | -------------------------------------------------- |
+| `--data-table-bg`            | `hsl(var(--background))`         | Table body, sticky header, sticky column wrappers  |
+| `--data-table-fg`            | `hsl(var(--foreground))`         | Default table/header/group-header text             |
+| `--data-table-border`        | `hsl(var(--border))`             | Row separators, header borders, loading containers |
+| `--data-table-muted`         | `hsl(var(--muted))`              | Group rows, skeleton rows, sticky hover blends     |
+| `--data-table-muted-fg`      | `hsl(var(--muted-foreground))`   | Loading and secondary wrapper text                 |
+| `--data-table-row-hover`     | `hsl(var(--muted) / 0.5)`        | Non-sticky row hover background                    |
+| `--data-table-sticky-hover`  | a mix of muted and table bg      | Sticky column hover background                     |
+
+If your app maps shadcn tokens to a different design system, override these variables once on the `DataTable` root or in the copied wrapper defaults. Do not style sticky cells individually just to fix a surface mismatch.
+
+```tsx
+<DataTable
+  className="
+    [--data-table-bg:hsl(var(--surface-container-lowest))]
+    [--data-table-fg:hsl(var(--on-surface))]
+    [--data-table-border:hsl(var(--outline))]
+    [--data-table-muted:hsl(var(--surface-container-low))]
+    [--data-table-muted-fg:hsl(var(--on-surface-variant))]
+  "
+  model={model}
+/>
+```
 
 ## What the headless package owns
 
@@ -79,6 +111,7 @@ Each one is header-slot UI you can restyle. The streams they publish to live in 
 The wrapper is the right place to change:
 
 - default Tailwind classes on `DataTable`, `DataTableCell`, `DataTableColumnHeader`
+- the default table frame, radius, border, and surface variables
 - the default `Row`, `EmptyPlaceholder`, `LoadingPlaceholder` your team should see
 - ergonomic re-exports you add for your codebase
 

--- a/packages/data-table/docs/8.examples/16.remote-column-sorting.md
+++ b/packages/data-table/docs/8.examples/16.remote-column-sorting.md
@@ -5,7 +5,7 @@ sidebar:
   label: Remote Sorting
 ---
 
-Each sortable column header sends a `sort` action to the remote model. The action updates the request params, the model refetches from the first page, and the active header button reads the current sort from `modelActionState$`.
+Each sortable column header sends a `sort` action to the remote model. The action updates the request params, the model refetches from the first page, and the active header button reads the current sort from `modelActionState$`. Do not keep a second `sortBy` / `sortOrder` React state just to paint the header; seed the model with `initialActions` for a default sort and let `modelActionState$` be the source of truth.
 
 The shadcn `SortHeaderButton` defaults to a payload shaped as `{ field, direction }`, where `direction` cycles through `'asc'`, `'desc'`, and no sort.
 
@@ -15,6 +15,8 @@ The shadcn `SortHeaderButton` defaults to a payload shaped as `{ field, directio
 - `SortHeaderButton` — shadcn slot component for column-header sorting
 - `HeaderEnd` — places the sort button after the header label
 - `computeRowKey` — keeps row identity stable when sorting reorders rows
+- `initialActions` — seeds the active sort in model action state
+- `modelStatePersistenceAdapter()` — optionally persists the sort action payload across reloads
 
 ```tsx live wide file=App.tsx
 import { useState } from 'react'
@@ -22,22 +24,28 @@ import { useState } from 'react'
 import { DataTable, DataTableCell, DataTableColumn, DataTableColumnHeader, HeaderEnd } from '@/components/ui/data-table'
 import { SortHeaderButton } from '@/components/ui/data-table/column-sort'
 import { defaultOffsetViewportHandler, remoteModel } from '@virtuoso.dev/data-table'
+import { DataTableStatePersistence, modelStatePersistenceAdapter } from '@virtuoso.dev/data-table/state-persistence'
 
 import { fetchProducts, placeholder } from './api'
 
 import type { Product, Query } from './api'
+
+const defaultSort = { field: 'name', direction: 'asc' } satisfies NonNullable<Query['sort']>
+const persistenceAdapters = [modelStatePersistenceAdapter()]
 
 export default function App() {
   const [model] = useState(() =>
     remoteModel<Product, Query>({
       actions: {
         sort: {
+          persistence: true,
           strategy: 'supersede',
           handler: ({ params, payload }) => ({ ...params, sort: payload as Query['sort'] }),
         },
       },
       fetch: fetchProducts,
-      initialParams: {},
+      initialActions: [{ action: 'sort', payload: defaultSort }],
+      initialParams: { sort: defaultSort },
       onViewportChange: defaultOffsetViewportHandler,
       pageSize: 40,
       placeholder,
@@ -46,6 +54,8 @@ export default function App() {
 
   return (
     <DataTable className="rounded-xl" computeRowKey={({ data }) => data.id} model={model} style={{ height: 420 }}>
+      <DataTableStatePersistence adapters={persistenceAdapters} storageKey="remote-column-sorting-example" />
+
       <DataTableColumn field="name">
         <DataTableColumnHeader>
           <HeaderEnd component={SortHeaderButton} />

--- a/packages/data-table/src/_stories/column-grow.fixture.tsx
+++ b/packages/data-table/src/_stories/column-grow.fixture.tsx
@@ -4,7 +4,7 @@ import type { CSSProperties, PointerEvent, ReactNode } from 'react'
 
 import { usePublisher } from '@virtuoso.dev/reactive-engine-react'
 
-import { Cell, Column, ColumnHeader, HeaderEdge } from '..'
+import { Cell, Column, ColumnHeader, HeaderEdge, HeaderEnd, HeaderOverlay } from '..'
 import { resizeColumn$, clearColumnWidthOverride$ } from '../features/column-resize'
 import { LocalDataTable as VirtuosoDataTable } from '../tests/LocalDataTable'
 
@@ -132,6 +132,44 @@ const HEADER_STYLE: CSSProperties = {
   overflow: 'hidden',
   whiteSpace: 'nowrap',
 }
+const COLUMN_TRACK_OVERLAY_STYLE: CSSProperties = {
+  position: 'absolute',
+  inset: 0,
+  borderRight: '2px solid rgba(37, 99, 235, 0.65)',
+  background: 'linear-gradient(90deg, rgba(37, 99, 235, 0.08), rgba(37, 99, 235, 0.02))',
+  pointerEvents: 'none',
+}
+const SORT_ICON_BOUNDARY_STYLE: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  height: 40,
+  flexShrink: 0,
+}
+const SORT_ICON_STYLE: CSSProperties = {
+  display: 'inline-flex',
+  width: 28,
+  height: 28,
+  alignItems: 'center',
+  justifyContent: 'center',
+  marginLeft: 4,
+  border: '1px solid #93c5fd',
+  borderRadius: 4,
+  background: '#eff6ff',
+  color: '#1d4ed8',
+}
+const ACTIVE_SORT_ICON_STYLE: CSSProperties = {
+  ...SORT_ICON_STYLE,
+  borderColor: '#60a5fa',
+  background: '#dbeafe',
+  color: '#1e40af',
+}
+const SORT_ICON_END_MARKER_STYLE: CSSProperties = {
+  width: 2,
+  height: 40,
+  flexShrink: 0,
+  marginLeft: 4,
+  background: '#2563eb',
+}
 const CELL_STACK_STYLE: CSSProperties = { display: 'flex', minWidth: 0, flexDirection: 'column', gap: 2 }
 const CELL_PRIMARY_STYLE: CSSProperties = { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: 600 }
 const CELL_SECONDARY_STYLE: CSSProperties = {
@@ -185,6 +223,29 @@ function HeaderLabel({
 
 function Badge({ children, status = false }: { children: ReactNode; status?: boolean }) {
   return <span style={status ? STATUS_BADGE_STYLE : BADGE_STYLE}>{children}</span>
+}
+
+const ColumnTrackOverlay: HeaderSlotCustomComponent = () => <span aria-hidden="true" style={COLUMN_TRACK_OVERLAY_STYLE} />
+
+const SortIconBoundary: HeaderSlotCustomComponent = ({ column }) => {
+  const isActive = column.field === 'updated'
+
+  return (
+    <span aria-hidden="true" style={SORT_ICON_BOUNDARY_STYLE}>
+      <span style={isActive ? ACTIVE_SORT_ICON_STYLE : SORT_ICON_STYLE}>
+        <svg fill="none" height="14" viewBox="0 0 16 16" width="14">
+          <path
+            d="M5 3.5 2.75 5.75h4.5L5 3.5ZM11 12.5l2.25-2.25h-4.5L11 12.5ZM5 5.75v6.5M11 10.25v-6.5"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.5"
+          />
+        </svg>
+      </span>
+      <span data-table-element-role="sort-icon-end-marker" style={SORT_ICON_END_MARKER_STYLE} />
+    </span>
+  )
 }
 
 const PromptResizeHandle: HeaderSlotCustomComponent = ({ columnKey, headerRef }) => {
@@ -255,17 +316,28 @@ function ResizeEdge({ enabled }: { enabled: boolean }) {
   return enabled ? <HeaderEdge component={PromptResizeHandle} /> : null
 }
 
+function SortIconBoundarySlots({ enabled }: { enabled: boolean }) {
+  return enabled ? (
+    <>
+      <HeaderOverlay component={ColumnTrackOverlay} />
+      <HeaderEnd component={SortIconBoundary} />
+    </>
+  ) : null
+}
+
 export function PromptListGrowTable({
   height = TABLE_STYLE.height,
   resizeDescriptionTo,
   resizable = false,
   resizeNameTo,
+  showSortIconBoundaries = false,
   width = '100%',
 }: {
   height?: CSSProperties['height']
   resizeDescriptionTo?: number
   resizable?: boolean
   resizeNameTo?: number
+  showSortIconBoundaries?: boolean
   width?: CSSProperties['width']
 }) {
   return (
@@ -276,6 +348,7 @@ export function PromptListGrowTable({
       <Column id="name" field="name" grow={1}>
         <ColumnHeader>
           <ResizeEdge enabled={resizable} />
+          <SortIconBoundarySlots enabled={showSortIconBoundaries} />
           {() => <HeaderLabel width={PROMPT_COLUMN_BASE_WIDTHS.name}>Name</HeaderLabel>}
         </ColumnHeader>
         <Cell>
@@ -294,6 +367,7 @@ export function PromptListGrowTable({
       <Column id="description" field="description" grow={3}>
         <ColumnHeader>
           <ResizeEdge enabled={resizable} />
+          <SortIconBoundarySlots enabled={showSortIconBoundaries} />
           {() => <HeaderLabel width={PROMPT_COLUMN_BASE_WIDTHS.description}>Description</HeaderLabel>}
         </ColumnHeader>
         <Cell>
@@ -341,6 +415,7 @@ export function PromptListGrowTable({
       <Column id="updated" field="updated">
         <ColumnHeader>
           <ResizeEdge enabled={resizable} />
+          <SortIconBoundarySlots enabled={showSortIconBoundaries} />
           {() => <HeaderLabel width={PROMPT_COLUMN_BASE_WIDTHS.updated}>Updated</HeaderLabel>}
         </ColumnHeader>
         <Cell>{({ cellValue }) => <span style={{ fontWeight: 600, whiteSpace: 'nowrap' }}>{String(cellValue)}</span>}</Cell>

--- a/packages/data-table/src/_stories/column-grow.fixture.tsx
+++ b/packages/data-table/src/_stories/column-grow.fixture.tsx
@@ -1,0 +1,370 @@
+// oxlint-disable jsx-no-new-function-as-prop jsx-no-new-object-as-prop
+import { useEffect } from 'react'
+import type { CSSProperties, PointerEvent, ReactNode } from 'react'
+
+import { usePublisher } from '@virtuoso.dev/reactive-engine-react'
+
+import { Cell, Column, ColumnHeader, HeaderEdge } from '..'
+import { resizeColumn$, clearColumnWidthOverride$ } from '../features/column-resize'
+import { LocalDataTable as VirtuosoDataTable } from '../tests/LocalDataTable'
+
+import type { HeaderSlotCustomComponent } from '..'
+
+interface PromptRow {
+  id: string
+  name: string
+  slug: string
+  description: string
+  versions: string[]
+  labels: string[]
+  updated: string
+  status: 'draft' | 'published' | 'review'
+}
+
+export const PROMPT_COLUMN_BASE_WIDTHS = {
+  name: 280,
+  description: 340,
+  versions: 128,
+  labels: 144,
+  updated: 152,
+  actions: 64,
+} as const
+
+export const PROMPT_TABLE_WIDTHS = {
+  narrow: 760,
+  wide: 1_400,
+} as const
+
+const PROMPTS: PromptRow[] = [
+  {
+    id: 'prompt-001',
+    name: 'Data Pipeline Risk Review',
+    slug: 'scroll-repro-data-pipeline-risk-review',
+    description: 'Helps teams handle pipeline risk review using customer context, recent evidence, and clear escalation notes.',
+    versions: ['v2', 'stable'],
+    labels: ['risk', 'pipeline'],
+    updated: 'about 5 hours ago',
+    status: 'published',
+  },
+  {
+    id: 'prompt-002',
+    name: 'Support Refund Triage With Regional Escalation Handling',
+    slug: 'scroll-repro-support-refund-triage',
+    description: 'Sorts refund cases by customer impact, plan tier, region, and policy exceptions, then drafts the next support action.',
+    versions: ['v4', 'beta'],
+    labels: ['support', 'refund', 'priority'],
+    updated: 'yesterday',
+    status: 'review',
+  },
+  {
+    id: 'prompt-003',
+    name: 'Billing Evidence Extractor',
+    slug: 'scroll-repro-billing-evidence-extractor',
+    description: 'Extracts invoices, subscription events, adjustment notes, and user-visible explanations from long billing conversations.',
+    versions: ['v1'],
+    labels: ['billing'],
+    updated: '2 days ago',
+    status: 'published',
+  },
+  {
+    id: 'prompt-004',
+    name: 'Incident Account Renewal Guide',
+    slug: 'scroll-repro-incident-account-renewal-guide',
+    description: '',
+    versions: ['v3', 'hotfix'],
+    labels: ['incident', 'renewal'],
+    updated: 'Jun 18',
+    status: 'draft',
+  },
+  {
+    id: 'prompt-005',
+    name: 'Very Long Customer Reply Draft Name That Should Still Stay Readable When The Name Column Grows',
+    slug: 'scroll-repro-billing-customer-reply-draft',
+    description:
+      'Creates a grounded customer reply from billing context, recent evidence, internal policy, and the latest escalation summary.',
+    versions: ['v7', 'stable', 'exp'],
+    labels: ['billing', 'customer', 'reply'],
+    updated: 'Jun 14',
+    status: 'review',
+  },
+  {
+    id: 'prompt-006',
+    name: 'Feature Flag Signal Classifier',
+    slug: 'scroll-repro-feature-flag-signal-classifier',
+    description:
+      'Classifies signals from feature flag events, support notes, error telemetry, and account metadata into rollout decisions.',
+    versions: ['v2'],
+    labels: ['flags', 'signals'],
+    updated: 'Jun 11',
+    status: 'published',
+  },
+  {
+    id: 'prompt-007',
+    name: 'Support Runbook Composer',
+    slug: 'scroll-repro-support-runbook-composer',
+    description: 'Turns scattered operational notes into concise runbook steps with owner, trigger, rollback, and escalation fields.',
+    versions: ['v5', 'draft'],
+    labels: ['support', 'runbook'],
+    updated: 'Jun 08',
+    status: 'draft',
+  },
+  {
+    id: 'prompt-008',
+    name: 'Onboarding Follow Up Planner',
+    slug: 'scroll-repro-onboarding-follow-up-planner',
+    description: 'Plans follow-up messages after onboarding by combining customer goals, unresolved setup tasks, and usage evidence.',
+    versions: ['v2', 'stable'],
+    labels: ['onboarding'],
+    updated: 'May 30',
+    status: 'published',
+  },
+]
+
+const TABLE_STYLE: CSSProperties = { height: 420 }
+const HEADER_STYLE: CSSProperties = {
+  boxSizing: 'border-box',
+  display: 'flex',
+  minWidth: 0,
+  alignItems: 'center',
+  gap: 6,
+  height: 40,
+  padding: '0 10px',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+}
+const CELL_STACK_STYLE: CSSProperties = { display: 'flex', minWidth: 0, flexDirection: 'column', gap: 2 }
+const CELL_PRIMARY_STYLE: CSSProperties = { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: 600 }
+const CELL_SECONDARY_STYLE: CSSProperties = {
+  overflow: 'hidden',
+  color: '#64748b',
+  fontFamily: 'monospace',
+  fontSize: 12,
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+}
+const BADGE_ROW_STYLE: CSSProperties = { display: 'flex', minWidth: 0, flexWrap: 'wrap', gap: 4 }
+const BADGE_STYLE: CSSProperties = {
+  display: 'inline-flex',
+  maxWidth: '100%',
+  alignItems: 'center',
+  border: '1px solid #bae6fd',
+  borderRadius: 4,
+  background: '#f0f9ff',
+  color: '#0369a1',
+  fontSize: 12,
+  fontWeight: 600,
+  padding: '1px 6px',
+}
+const STATUS_BADGE_STYLE: CSSProperties = {
+  ...BADGE_STYLE,
+  borderColor: '#bbf7d0',
+  background: '#f0fdf4',
+  color: '#047857',
+}
+const ACTION_BUTTON_STYLE: CSSProperties = {
+  border: 0,
+  borderRadius: 4,
+  background: 'transparent',
+  color: '#64748b',
+  cursor: 'pointer',
+  fontSize: 18,
+  lineHeight: 1,
+}
+
+function HeaderLabel({
+  width,
+  justify = 'flex-start',
+  children,
+}: {
+  width: number
+  justify?: CSSProperties['justifyContent']
+  children: ReactNode
+}) {
+  return <div style={{ ...HEADER_STYLE, justifyContent: justify, width }}>{children}</div>
+}
+
+function Badge({ children, status = false }: { children: ReactNode; status?: boolean }) {
+  return <span style={status ? STATUS_BADGE_STYLE : BADGE_STYLE}>{children}</span>
+}
+
+const PromptResizeHandle: HeaderSlotCustomComponent = ({ columnKey, headerRef }) => {
+  const resizeColumn = usePublisher(resizeColumn$)
+  const clearColumnWidthOverride = usePublisher(clearColumnWidthOverride$)
+
+  return (
+    <div
+      data-table-element-role="resize-handle"
+      style={{
+        alignSelf: 'stretch',
+        cursor: 'col-resize',
+        display: 'flex',
+        justifyContent: 'center',
+        touchAction: 'none',
+        userSelect: 'none',
+        width: 10,
+      }}
+      onDoubleClick={(event) => {
+        event.preventDefault()
+        clearColumnWidthOverride({ key: columnKey })
+      }}
+      onPointerDown={(event: PointerEvent<HTMLDivElement>) => {
+        event.preventDefault()
+        const startWidth = headerRef.current?.getBoundingClientRect().width
+        if (startWidth === undefined) {
+          return
+        }
+
+        const startX = event.clientX
+        const ownerDocument = event.currentTarget.ownerDocument
+        const pointerId = event.pointerId
+        event.currentTarget.setPointerCapture(pointerId)
+
+        const onPointerMove = (moveEvent: globalThis.PointerEvent) => {
+          resizeColumn({ key: columnKey, width: Math.max(64, startWidth + moveEvent.clientX - startX) })
+        }
+
+        const onPointerEnd = () => {
+          ownerDocument.removeEventListener('pointermove', onPointerMove)
+          ownerDocument.removeEventListener('pointerup', onPointerEnd)
+          ownerDocument.removeEventListener('pointercancel', onPointerEnd)
+        }
+
+        ownerDocument.addEventListener('pointermove', onPointerMove)
+        ownerDocument.addEventListener('pointerup', onPointerEnd, { once: true })
+        ownerDocument.addEventListener('pointercancel', onPointerEnd, { once: true })
+      }}
+    >
+      <span style={{ alignSelf: 'center', background: '#cbd5e1', borderRadius: 999, height: 18, width: 2 }} />
+    </div>
+  )
+}
+
+function ResizeColumnOnMount({ columnKey, width }: { columnKey: string; width: number | undefined }) {
+  const resizeColumn = usePublisher(resizeColumn$)
+
+  useEffect(() => {
+    if (width !== undefined) {
+      resizeColumn({ key: columnKey, width })
+    }
+  }, [columnKey, resizeColumn, width])
+
+  return null
+}
+
+function ResizeEdge({ enabled }: { enabled: boolean }) {
+  return enabled ? <HeaderEdge component={PromptResizeHandle} /> : null
+}
+
+export function PromptListGrowTable({
+  height = TABLE_STYLE.height,
+  resizeDescriptionTo,
+  resizable = false,
+  resizeNameTo,
+  width = '100%',
+}: {
+  height?: CSSProperties['height']
+  resizeDescriptionTo?: number
+  resizable?: boolean
+  resizeNameTo?: number
+  width?: CSSProperties['width']
+}) {
+  return (
+    <VirtuosoDataTable style={{ height, width }} source={PROMPTS}>
+      <ResizeColumnOnMount columnKey="name" width={resizeNameTo} />
+      <ResizeColumnOnMount columnKey="description" width={resizeDescriptionTo} />
+
+      <Column id="name" field="name" grow={1}>
+        <ColumnHeader>
+          <ResizeEdge enabled={resizable} />
+          {() => <HeaderLabel width={PROMPT_COLUMN_BASE_WIDTHS.name}>Name</HeaderLabel>}
+        </ColumnHeader>
+        <Cell>
+          {({ row }) => {
+            const prompt = row.data as PromptRow
+            return (
+              <div style={CELL_STACK_STYLE}>
+                <span style={CELL_PRIMARY_STYLE}>{prompt.name}</span>
+                <span style={CELL_SECONDARY_STYLE}>{prompt.slug}</span>
+              </div>
+            )
+          }}
+        </Cell>
+      </Column>
+
+      <Column id="description" field="description" grow={3}>
+        <ColumnHeader>
+          <ResizeEdge enabled={resizable} />
+          {() => <HeaderLabel width={PROMPT_COLUMN_BASE_WIDTHS.description}>Description</HeaderLabel>}
+        </ColumnHeader>
+        <Cell>
+          {({ cellValue }) => (
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {String(cellValue === '' ? 'No description' : (cellValue ?? 'No description'))}
+            </span>
+          )}
+        </Cell>
+      </Column>
+
+      <Column id="versions" field="versions">
+        <ColumnHeader>
+          <ResizeEdge enabled={resizable} />
+          {() => <HeaderLabel width={PROMPT_COLUMN_BASE_WIDTHS.versions}>Versions</HeaderLabel>}
+        </ColumnHeader>
+        <Cell>
+          {({ row }) => (
+            <div style={BADGE_ROW_STYLE}>
+              {(row.data as PromptRow).versions.map((version) => (
+                <Badge key={version}>{version}</Badge>
+              ))}
+            </div>
+          )}
+        </Cell>
+      </Column>
+
+      <Column id="labels" field="labels">
+        <ColumnHeader>
+          <ResizeEdge enabled={resizable} />
+          {() => <HeaderLabel width={PROMPT_COLUMN_BASE_WIDTHS.labels}>Labels</HeaderLabel>}
+        </ColumnHeader>
+        <Cell>
+          {({ row }) => (
+            <div style={BADGE_ROW_STYLE}>
+              <Badge status>{(row.data as PromptRow).status}</Badge>
+              {(row.data as PromptRow).labels.slice(0, 2).map((label) => (
+                <Badge key={label}>{label}</Badge>
+              ))}
+            </div>
+          )}
+        </Cell>
+      </Column>
+
+      <Column id="updated" field="updated">
+        <ColumnHeader>
+          <ResizeEdge enabled={resizable} />
+          {() => <HeaderLabel width={PROMPT_COLUMN_BASE_WIDTHS.updated}>Updated</HeaderLabel>}
+        </ColumnHeader>
+        <Cell>{({ cellValue }) => <span style={{ fontWeight: 600, whiteSpace: 'nowrap' }}>{String(cellValue)}</span>}</Cell>
+      </Column>
+
+      <Column id="actions">
+        <ColumnHeader>
+          <ResizeEdge enabled={resizable} />
+          {() => (
+            <HeaderLabel justify="center" width={PROMPT_COLUMN_BASE_WIDTHS.actions}>
+              <span aria-label="Actions">...</span>
+            </HeaderLabel>
+          )}
+        </ColumnHeader>
+        <Cell>
+          {() => (
+            <div style={{ display: 'flex', justifyContent: 'center' }}>
+              <button aria-label="Open actions" style={ACTION_BUTTON_STYLE} type="button">
+                ...
+              </button>
+            </div>
+          )}
+        </Cell>
+      </Column>
+    </VirtuosoDataTable>
+  )
+}

--- a/packages/data-table/src/_stories/column-grow.stories.tsx
+++ b/packages/data-table/src/_stories/column-grow.stories.tsx
@@ -27,11 +27,11 @@ function StoryFrame({ title, description, width, children }: { title: string; de
 export function WidePromptListGrowColumns() {
   return (
     <StoryFrame
-      description="Two text-heavy columns absorb spare width while versions, labels, timestamps, and actions keep fixed base widths."
+      description="Two text-heavy columns absorb spare width while the sortable icon boundary shows where header controls end."
       title="Prompt List Grow Columns"
       width={PROMPT_TABLE_WIDTHS.wide}
     >
-      <PromptListGrowTable />
+      <PromptListGrowTable showSortIconBoundaries />
     </StoryFrame>
   )
 }

--- a/packages/data-table/src/_stories/column-grow.stories.tsx
+++ b/packages/data-table/src/_stories/column-grow.stories.tsx
@@ -1,0 +1,61 @@
+import type { CSSProperties, ReactNode } from 'react'
+
+import { PROMPT_TABLE_WIDTHS, PromptListGrowTable } from './column-grow.fixture'
+
+const STORY_SHELL_STYLE: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+  maxWidth: '100%',
+  padding: 16,
+}
+const STORY_TITLE_STYLE: CSSProperties = { margin: 0, fontSize: 16, fontWeight: 600 }
+const STORY_DESCRIPTION_STYLE: CSSProperties = { margin: 0, maxWidth: 720, color: '#64748b', fontSize: 13 }
+
+function StoryFrame({ title, description, width, children }: { title: string; description: string; width: number; children: ReactNode }) {
+  return (
+    <section style={{ ...STORY_SHELL_STYLE, width }}>
+      <div>
+        <h2 style={STORY_TITLE_STYLE}>{title}</h2>
+        <p style={STORY_DESCRIPTION_STYLE}>{description}</p>
+      </div>
+      {children}
+    </section>
+  )
+}
+
+export function WidePromptListGrowColumns() {
+  return (
+    <StoryFrame
+      description="Two text-heavy columns absorb spare width while versions, labels, timestamps, and actions keep fixed base widths."
+      title="Prompt List Grow Columns"
+      width={PROMPT_TABLE_WIDTHS.wide}
+    >
+      <PromptListGrowTable />
+    </StoryFrame>
+  )
+}
+
+export function NarrowPromptListGrowColumns() {
+  return (
+    <StoryFrame
+      description="The same prompt list in a narrow viewport keeps base widths and relies on horizontal scrolling."
+      title="Prompt List Narrow Viewport"
+      width={PROMPT_TABLE_WIDTHS.narrow}
+    >
+      <PromptListGrowTable />
+    </StoryFrame>
+  )
+}
+
+export function ResizablePromptListGrowColumns() {
+  return (
+    <StoryFrame
+      description="Drag a divider or double-click it to verify that resized grow columns use the override as their new base."
+      title="Prompt List Grow Columns With Resize"
+      width={PROMPT_TABLE_WIDTHS.wide}
+    >
+      <PromptListGrowTable resizable />
+    </StoryFrame>
+  )
+}

--- a/packages/data-table/src/_stories/shadcn.stories.tsx
+++ b/packages/data-table/src/_stories/shadcn.stories.tsx
@@ -11,11 +11,15 @@ import {
   DataTableColumn,
   DataTableColumnHeader,
   HeaderEdge,
+  HeaderEnd,
   HeaderOverlay,
   HeaderStart,
 } from '@/components/ui/data-table'
 import { ReorderDropZone, ReorderGrip } from '@/components/ui/data-table/column-reorder'
 import { ResizeHandle } from '@/components/ui/data-table/column-resize'
+import { SortHeaderButton } from '@/components/ui/data-table/column-sort'
+
+import type { SortDirection } from '@/components/ui/data-table/column-sort'
 
 interface User {
   id: number
@@ -23,6 +27,15 @@ interface User {
   email: string
   role: string
   status: string
+}
+
+interface PromptTemplate {
+  id: string
+  title: string
+  summary: string
+  owner: string
+  status: 'Draft' | 'Published' | 'Review'
+  updatedMinutes: number
 }
 
 const ALL_ITEMS: User[] = Array.from({ length: 200 }, (_, i) => ({
@@ -33,8 +46,113 @@ const ALL_ITEMS: User[] = Array.from({ length: 200 }, (_, i) => ({
   status: i % 5 === 0 ? 'inactive' : 'active',
 }))
 
+const PROMPT_TEMPLATES: PromptTemplate[] = [
+  {
+    id: 'prompt-001',
+    title: 'Data Pipeline Risk Review',
+    summary: 'Reviews pipeline incidents with customer context, recent evidence, and escalation notes.',
+    owner: 'Platform',
+    status: 'Published',
+    updatedMinutes: 29,
+  },
+  {
+    id: 'prompt-002',
+    title: 'Support Refund Triage With Regional Exceptions',
+    summary: 'Sorts refund cases by customer impact, plan tier, region, and policy exception state.',
+    owner: 'Support',
+    status: 'Review',
+    updatedMinutes: 74,
+  },
+  {
+    id: 'prompt-003',
+    title: 'Billing Evidence Extractor',
+    summary: 'Extracts invoices, subscription events, adjustments, and customer-visible explanations.',
+    owner: 'Billing',
+    status: 'Published',
+    updatedMinutes: 180,
+  },
+  {
+    id: 'prompt-004',
+    title: 'Incident Account Renewal Guide',
+    summary: 'Builds renewal guidance from incident timelines, account state, and commercial context.',
+    owner: 'Success',
+    status: 'Draft',
+    updatedMinutes: 330,
+  },
+  {
+    id: 'prompt-005',
+    title: 'Feature Flag Signal Classifier',
+    summary: 'Classifies rollout signals from flag events, support notes, telemetry, and account metadata.',
+    owner: 'Product',
+    status: 'Review',
+    updatedMinutes: 520,
+  },
+  {
+    id: 'prompt-006',
+    title: 'Onboarding Follow Up Planner',
+    summary: 'Plans follow-up messages by combining customer goals, setup tasks, and usage evidence.',
+    owner: 'Success',
+    status: 'Published',
+    updatedMinutes: 960,
+  },
+]
+
 const TABLE_STYLE: CSSProperties = { height: 400 }
 const INTERACTIVE_TABLE_STYLE: CSSProperties = { height: 420 }
+const SORTABLE_TABLE_STYLE: CSSProperties = { height: 360 }
+
+type PromptSortField = Extract<keyof PromptTemplate, 'owner' | 'status' | 'summary' | 'title' | 'updatedMinutes'>
+
+interface PromptSortPayload {
+  field: PromptSortField
+  direction: SortDirection
+}
+
+function isPromptSortPayload(payload: unknown): payload is PromptSortPayload {
+  if (typeof payload !== 'object' || payload === null) {
+    return false
+  }
+
+  const sort = payload as Partial<PromptSortPayload>
+  return (
+    (sort.field === 'owner' ||
+      sort.field === 'status' ||
+      sort.field === 'summary' ||
+      sort.field === 'title' ||
+      sort.field === 'updatedMinutes') &&
+    (sort.direction === 'asc' || sort.direction === 'desc')
+  )
+}
+
+function comparePromptTemplates(sort: PromptSortPayload) {
+  return (left: PromptTemplate, right: PromptTemplate) => {
+    const leftValue = left[sort.field]
+    const rightValue = right[sort.field]
+    const result =
+      typeof leftValue === 'number' && typeof rightValue === 'number'
+        ? leftValue - rightValue
+        : String(leftValue).localeCompare(String(rightValue), undefined, { numeric: true })
+
+    return sort.direction === 'asc' ? result : -result
+  }
+}
+
+function promptTemplateSortHandler({ data, payload }: { data: PromptTemplate[]; payload: unknown }) {
+  if (!isPromptSortPayload(payload)) {
+    return data
+  }
+
+  return data.toSorted(comparePromptTemplates(payload))
+}
+
+function formatUpdated(minutes: number) {
+  if (minutes < 60) {
+    return `${minutes}m ago`
+  }
+
+  const hours = Math.round(minutes / 60)
+  return `${hours}h ago`
+}
 
 export function ShadcnDataTable() {
   const [filter, setFilter] = useState<'all' | 'active' | 'inactive'>('all')
@@ -184,6 +302,95 @@ export function ShadcnInteractiveDataTable() {
                   </span>
                 )
               }}
+            </DataTableCell>
+          </DataTableColumn>
+        </DataTable>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function ShadcnSortableDataTable() {
+  const model = useMemo(
+    () =>
+      localModel<PromptTemplate>({
+        actions: {
+          sort: {
+            handler: promptTemplateSortHandler,
+            stage: 'sort',
+          },
+        },
+        data: PROMPT_TEMPLATES,
+        initialActions: [{ action: 'sort', payload: { direction: 'desc', field: 'updatedMinutes' } satisfies PromptSortPayload }],
+        pipeline: ['sort'],
+      }),
+    []
+  )
+
+  return (
+    <Card className="w-full max-w-7xl">
+      <CardHeader>
+        <CardTitle>Prompts</CardTitle>
+        <CardDescription>Header sort buttons use the shadcn registry component and stay aligned to grown column edges.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <DataTable className="rounded-xl" computeRowKey={({ data }) => data.id} model={model} style={SORTABLE_TABLE_STYLE}>
+          <DataTableColumn field="title" grow={1}>
+            <DataTableColumnHeader className="w-72">
+              <HeaderEnd component={SortHeaderButton} />
+              {() => 'Prompt'}
+            </DataTableColumnHeader>
+            <DataTableCell>
+              {({ row }) => {
+                const prompt = row.data as PromptTemplate
+
+                return (
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">{prompt.title}</div>
+                    <div className="truncate font-mono text-xs text-muted-foreground">{prompt.id}</div>
+                  </div>
+                )
+              }}
+            </DataTableCell>
+          </DataTableColumn>
+
+          <DataTableColumn field="summary" grow={2}>
+            <DataTableColumnHeader className="w-96">
+              <HeaderEnd component={SortHeaderButton} />
+              {() => 'Summary'}
+            </DataTableColumnHeader>
+            <DataTableCell>{({ cellValue }) => <span className="text-muted-foreground">{String(cellValue)}</span>}</DataTableCell>
+          </DataTableColumn>
+
+          <DataTableColumn field="owner">
+            <DataTableColumnHeader className="w-32">
+              <HeaderEnd component={SortHeaderButton} />
+              {() => 'Owner'}
+            </DataTableColumnHeader>
+            <DataTableCell>{({ cellValue }) => String(cellValue)}</DataTableCell>
+          </DataTableColumn>
+
+          <DataTableColumn field="status">
+            <DataTableColumnHeader className="w-36">
+              <HeaderEnd component={SortHeaderButton} />
+              {() => 'Status'}
+            </DataTableColumnHeader>
+            <DataTableCell>
+              {({ cellValue }) => (
+                <span className="inline-flex rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                  {String(cellValue)}
+                </span>
+              )}
+            </DataTableCell>
+          </DataTableColumn>
+
+          <DataTableColumn field="updatedMinutes">
+            <DataTableColumnHeader className="w-36 justify-end">
+              <HeaderEnd component={SortHeaderButton} />
+              {() => 'Updated'}
+            </DataTableColumnHeader>
+            <DataTableCell className="text-right font-medium tabular-nums">
+              {({ cellValue }) => formatUpdated(Number(cellValue))}
             </DataTableCell>
           </DataTableColumn>
         </DataTable>

--- a/packages/data-table/src/columns/Column.tsx
+++ b/packages/data-table/src/columns/Column.tsx
@@ -6,7 +6,7 @@ import { usePublisher } from '@virtuoso.dev/reactive-engine-react'
 
 import { viewportWidth$ } from '../scroll/dom'
 import { columnCount$, columnRanges$ } from './column-sizes'
-import { computeAutoFillColumnWidths } from './column-width-distribution'
+import { computeAutoFillColumnWidths, isValidColumnGrow } from './column-width-distribution'
 import { columnWidthOverrides$ } from './column-width-overrides'
 import { ColumnGroupIdContext } from './ColumnGroup'
 
@@ -113,6 +113,12 @@ export interface ColumnInfo {
    * display-only columns that should not require a matching row-data field.
    */
   accessor?: (row: unknown) => unknown
+  /**
+   * Relative share of extra viewport width after base column widths are known.
+   * Positive finite values participate in grow distribution. Omit this prop or
+   * pass 0 to keep the column fixed when any visible column grows.
+   */
+  grow?: number
   sticky?: 'left' | 'right'
   groupId?: string
   visible?: boolean
@@ -255,6 +261,7 @@ export namespace Column {
    */
   interface BaseProps {
     children?: React.ReactNode
+    grow?: number
     sticky?: 'left' | 'right'
     visible?: boolean
   }
@@ -279,7 +286,7 @@ export namespace Column {
  *
  * @group Components
  */
-export function Column({ children, id, field, accessor, sticky, visible }: Column.Props) {
+export function Column({ children, id, field, accessor, grow, sticky, visible }: Column.Props) {
   const generatedId = useId()
   const colId = id ?? generatedId
   const orderPath = useStableColumnDeclarationPath()
@@ -294,6 +301,13 @@ export function Column({ children, id, field, accessor, sticky, visible }: Colum
     if (accessor) {
       info.accessor = accessor
     }
+    if (isValidColumnGrow(grow)) {
+      info.grow = grow
+    } else if (grow !== undefined && grow !== 0 && process.env.NODE_ENV !== 'production') {
+      console.warn(
+        `[VirtuosoDataTable] Column "${info.id}" ignored invalid grow value ${String(grow)}. Use a positive finite number, or omit grow for a fixed column.`
+      )
+    }
     if (sticky) {
       info.sticky = sticky
     }
@@ -307,7 +321,7 @@ export function Column({ children, id, field, accessor, sticky, visible }: Colum
     return () => {
       columnRegister({ type: 'remove', id: colId })
     }
-  }, [columnRegister, colId, id, field, accessor, sticky, groupId, visible, orderPath])
+  }, [columnRegister, colId, id, field, accessor, grow, sticky, groupId, visible, orderPath])
   return <ColumnIdContext.Provider value={colId}>{children}</ColumnIdContext.Provider>
 }
 

--- a/packages/data-table/src/columns/ColumnHeader.tsx
+++ b/packages/data-table/src/columns/ColumnHeader.tsx
@@ -5,7 +5,7 @@ import type { CSSProperties, ReactNode } from 'react'
 import { useCellValue, usePublisher } from '@virtuoso.dev/reactive-engine-react'
 
 import { useResizeObserver } from '../resize/resize-observer-singleton'
-import { columnWidths$, useColumnId } from './Column'
+import { columnWidths$, measuredColumnWidths$, useColumnId } from './Column'
 import { headerSlotEdgeEntries$, headerSlotEndEntries$, headerSlotOverlayEntries$, headerSlotStartEntries$ } from './header-slots/registry'
 import { createRegistryCell } from './registry'
 
@@ -163,6 +163,7 @@ export function ColumnHeaderRenderer({
   const measureObserverRef = useResizeObserver('border-box')
   const headerRef = useRef<HTMLDivElement>(null)
   const columnWidths = useCellValue(columnWidths$)
+  const measuredColumnWidths = useCellValue(measuredColumnWidths$)
   const headerSlotStartEntries = useCellValue(headerSlotStartEntries$)
   const headerSlotEndEntries = useCellValue(headerSlotEndEntries$)
   const headerSlotEdgeEntries = useCellValue(headerSlotEdgeEntries$)
@@ -239,6 +240,20 @@ export function ColumnHeaderRenderer({
       alignItems: 'center',
     }
   }, [hasSlots, style])
+  const endSlotGroupStyle = useMemo<CSSProperties>(() => {
+    const columnWidth = columnWidths.get(columnKey)
+    const measuredWidth = measuredColumnWidths.get(columnKey)
+    const offset = columnWidth === undefined || measuredWidth === undefined ? 0 : columnWidth - measuredWidth
+
+    if (offset === 0) {
+      return HEADER_END_SLOT_GROUP_STYLE
+    }
+
+    return {
+      ...HEADER_END_SLOT_GROUP_STYLE,
+      transform: `translateX(${offset}px)`,
+    }
+  }, [columnKey, columnWidths, measuredColumnWidths])
 
   return (
     <div
@@ -261,9 +276,13 @@ export function ColumnHeaderRenderer({
               <React.Fragment key={slotId}>{renderHeaderSlot(entry, slotRenderParams)}</React.Fragment>
             ))}
             <div style={HEADER_CONTENT_STYLE}>{content}</div>
-            {endSlots.map(([slotId, entry]) => (
-              <React.Fragment key={slotId}>{renderHeaderSlot(entry, slotRenderParams)}</React.Fragment>
-            ))}
+            {endSlots.length > 0 ? (
+              <div style={endSlotGroupStyle}>
+                {endSlots.map(([slotId, entry]) => (
+                  <React.Fragment key={slotId}>{renderHeaderSlot(entry, slotRenderParams)}</React.Fragment>
+                ))}
+              </div>
+            ) : null}
           </>
         ) : (
           content
@@ -290,6 +309,12 @@ const HEADER_MEASURE_STYLE: CSSProperties = {
   alignItems: 'center',
   minWidth: 'max-content',
   maxWidth: 'none',
+}
+
+const HEADER_END_SLOT_GROUP_STYLE: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  flexShrink: 0,
 }
 
 const OVERLAY_SLOT_STYLE: CSSProperties = {

--- a/packages/data-table/src/columns/column-width-distribution.ts
+++ b/packages/data-table/src/columns/column-width-distribution.ts
@@ -1,5 +1,9 @@
 import type { ColumnInfo } from './Column'
 
+export function isValidColumnGrow(grow: unknown): grow is number {
+  return typeof grow === 'number' && Number.isFinite(grow) && grow > 0
+}
+
 export function computeAutoFillColumnWidths(
   columns: readonly (readonly [string, ColumnInfo])[],
   baseWidths: ReadonlyMap<string, number>,
@@ -19,10 +23,28 @@ export function computeAutoFillColumnWidths(
     return realizedWidths
   }
 
-  const extraWidthPerColumn = (viewportWidth - totalBaseWidth) / columns.length
+  const growColumns: [string, number][] = []
+  for (const [key, column] of columns) {
+    if (isValidColumnGrow(column.grow)) {
+      growColumns.push([key, column.grow])
+    }
+  }
+  const extraWidth = viewportWidth - totalBaseWidth
 
-  for (const [key] of columns) {
-    realizedWidths.set(key, (realizedWidths.get(key) ?? 0) + extraWidthPerColumn)
+  if (growColumns.length === 0) {
+    const extraWidthPerColumn = extraWidth / columns.length
+
+    for (const [key] of columns) {
+      realizedWidths.set(key, (realizedWidths.get(key) ?? 0) + extraWidthPerColumn)
+    }
+
+    return realizedWidths
+  }
+
+  const totalGrow = growColumns.reduce((sum, [, grow]) => sum + grow, 0)
+
+  for (const [key, grow] of growColumns) {
+    realizedWidths.set(key, (realizedWidths.get(key) ?? 0) + (extraWidth * grow) / totalGrow)
   }
 
   return realizedWidths

--- a/packages/data-table/src/columns/tests/browser/column-grow-layout.test.tsx
+++ b/packages/data-table/src/columns/tests/browser/column-grow-layout.test.tsx
@@ -29,7 +29,7 @@ function expectedGrowWidths(viewportWidth: number, baseWidths: PromptColumnWidth
 }
 
 function header(container: HTMLElement, key: string) {
-  const element = container.querySelector(`[data-table-element-role="column-header"][data-column-key="${key}"]`) as HTMLElement | null
+  const element = container.querySelector<HTMLElement>(`[data-table-element-role="column-header"][data-column-key="${key}"]`)
   if (!element) {
     throw new Error(`Missing column header ${key}.`)
   }
@@ -41,7 +41,7 @@ function headerWidth(container: HTMLElement, key: string) {
 }
 
 function sortIconEndMarker(container: HTMLElement, key: string) {
-  const element = header(container, key).querySelector('[data-table-element-role="sort-icon-end-marker"]') as HTMLElement | null
+  const element = header(container, key).querySelector<HTMLElement>('[data-table-element-role="sort-icon-end-marker"]')
   if (!element) {
     throw new Error(`Missing sort icon marker for column header ${key}.`)
   }

--- a/packages/data-table/src/columns/tests/browser/column-grow-layout.test.tsx
+++ b/packages/data-table/src/columns/tests/browser/column-grow-layout.test.tsx
@@ -40,6 +40,14 @@ function headerWidth(container: HTMLElement, key: string) {
   return header(container, key).getBoundingClientRect().width
 }
 
+function sortIconEndMarker(container: HTMLElement, key: string) {
+  const element = header(container, key).querySelector('[data-table-element-role="sort-icon-end-marker"]') as HTMLElement | null
+  if (!element) {
+    throw new Error(`Missing sort icon marker for column header ${key}.`)
+  }
+  return element
+}
+
 async function waitForReady(container: HTMLElement) {
   await expect.poll(() => container.querySelector(readySelector)).not.toBeNull()
 }
@@ -93,6 +101,20 @@ describe('column grow layout', () => {
     const expected = expectedGrowWidths(scroller.clientWidth, PROMPT_COLUMN_BASE_WIDTHS)
 
     expectHeaderWidths(screen.container, expected)
+  })
+
+  test('wide prompt-list layout aligns header end slots to rendered column edges', async () => {
+    const screen = await render(<PromptListGrowTable showSortIconBoundaries width={PROMPT_TABLE_WIDTHS.wide} />)
+
+    await waitForReady(screen.container)
+    await waitForAnimationFrames()
+
+    for (const key of ['name', 'description', 'updated']) {
+      const headerRect = header(screen.container, key).getBoundingClientRect()
+      const markerRect = sortIconEndMarker(screen.container, key).getBoundingClientRect()
+
+      expect(markerRect.right).toBeCloseTo(headerRect.right, 1)
+    }
   })
 
   test('narrow prompt-list layout keeps base widths and scrolls horizontally', async () => {

--- a/packages/data-table/src/columns/tests/browser/column-grow-layout.test.tsx
+++ b/packages/data-table/src/columns/tests/browser/column-grow-layout.test.tsx
@@ -1,0 +1,147 @@
+import { useState } from 'react'
+
+import { expect, test, describe } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { PROMPT_COLUMN_BASE_WIDTHS, PROMPT_TABLE_WIDTHS, PromptListGrowTable } from '../../../_stories/column-grow.fixture'
+
+const readySelector = '[data-testid=virtuoso-table-root][data-ready]'
+const scrollerSelector = '[data-testid=virtuoso-table-scroller]'
+
+type PromptColumnWidths = Readonly<Record<keyof typeof PROMPT_COLUMN_BASE_WIDTHS, number>>
+
+function totalBaseWidth(baseWidths: PromptColumnWidths) {
+  return Object.values(baseWidths).reduce((sum, width) => sum + width, 0)
+}
+
+function expectedGrowWidths(viewportWidth: number, baseWidths: PromptColumnWidths): PromptColumnWidths {
+  const totalBase = totalBaseWidth(baseWidths)
+  if (viewportWidth <= totalBase) {
+    return baseWidths
+  }
+
+  const extra = viewportWidth - totalBase
+  return {
+    ...baseWidths,
+    name: baseWidths.name + extra / 4,
+    description: baseWidths.description + (extra * 3) / 4,
+  }
+}
+
+function header(container: HTMLElement, key: string) {
+  const element = container.querySelector(`[data-table-element-role="column-header"][data-column-key="${key}"]`) as HTMLElement | null
+  if (!element) {
+    throw new Error(`Missing column header ${key}.`)
+  }
+  return element
+}
+
+function headerWidth(container: HTMLElement, key: string) {
+  return header(container, key).getBoundingClientRect().width
+}
+
+async function waitForReady(container: HTMLElement) {
+  await expect.poll(() => container.querySelector(readySelector)).not.toBeNull()
+}
+
+async function waitForAnimationFrames() {
+  await new Promise<void>((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        resolve()
+      })
+    })
+  })
+}
+
+function expectHeaderWidths(container: HTMLElement, expected: PromptColumnWidths) {
+  expect(headerWidth(container, 'name')).toBeCloseTo(expected.name, 1)
+  expect(headerWidth(container, 'description')).toBeCloseTo(expected.description, 1)
+  expect(headerWidth(container, 'versions')).toBeCloseTo(expected.versions, 1)
+  expect(headerWidth(container, 'labels')).toBeCloseTo(expected.labels, 1)
+  expect(headerWidth(container, 'updated')).toBeCloseTo(expected.updated, 1)
+  expect(headerWidth(container, 'actions')).toBeCloseTo(expected.actions, 1)
+}
+
+function ResizedPromptListWithWidthControl() {
+  const [width, setWidth] = useState<number>(PROMPT_TABLE_WIDTHS.wide)
+
+  return (
+    <>
+      <button data-testid="widen-table" onClick={() => setWidth(1_600)} type="button">
+        Widen
+      </button>
+      <PromptListGrowTable resizeNameTo={420} width={width} />
+    </>
+  )
+}
+
+function DescriptionResizedPromptList() {
+  const descriptionWidth = expectedGrowWidths(PROMPT_TABLE_WIDTHS.wide, PROMPT_COLUMN_BASE_WIDTHS).description + 100
+
+  return <PromptListGrowTable resizeDescriptionTo={descriptionWidth} width={PROMPT_TABLE_WIDTHS.wide} />
+}
+
+describe('column grow layout', () => {
+  test('wide prompt-list layout grows only text-heavy columns', async () => {
+    const screen = await render(<PromptListGrowTable width={PROMPT_TABLE_WIDTHS.wide} />)
+
+    await waitForReady(screen.container)
+    await waitForAnimationFrames()
+
+    const scroller = screen.container.querySelector(scrollerSelector) as HTMLElement
+    const expected = expectedGrowWidths(scroller.clientWidth, PROMPT_COLUMN_BASE_WIDTHS)
+
+    expectHeaderWidths(screen.container, expected)
+  })
+
+  test('narrow prompt-list layout keeps base widths and scrolls horizontally', async () => {
+    const screen = await render(<PromptListGrowTable width={PROMPT_TABLE_WIDTHS.narrow} />)
+
+    await waitForReady(screen.container)
+    await waitForAnimationFrames()
+
+    const scroller = screen.container.querySelector(scrollerSelector) as HTMLElement
+
+    expect(scroller.clientWidth).toBeLessThan(totalBaseWidth(PROMPT_COLUMN_BASE_WIDTHS))
+    expect(scroller.scrollWidth).toBeGreaterThan(scroller.clientWidth)
+    expectHeaderWidths(screen.container, PROMPT_COLUMN_BASE_WIDTHS)
+  })
+
+  test('resized grow column keeps its rendered width and freezes sibling widths', async () => {
+    const screen = await render(<ResizedPromptListWithWidthControl />)
+
+    await waitForReady(screen.container)
+
+    const scroller = screen.container.querySelector(scrollerSelector) as HTMLElement
+    const initialExpected = expectedGrowWidths(scroller.clientWidth, PROMPT_COLUMN_BASE_WIDTHS)
+
+    await expect.poll(() => headerWidth(screen.container, 'name')).toBeCloseTo(420, 1)
+
+    expectHeaderWidths(screen.container, { ...initialExpected, name: 420 })
+
+    const descriptionBeforeWidening = headerWidth(screen.container, 'description')
+    const widenButton = screen.container.querySelector('[data-testid="widen-table"]') as HTMLButtonElement
+    widenButton.click()
+
+    await waitForAnimationFrames()
+
+    expect(headerWidth(screen.container, 'description')).toBeCloseTo(descriptionBeforeWidening, 1)
+    expect(headerWidth(screen.container, 'name')).toBeCloseTo(420, 1)
+  })
+
+  test('resizing the description boundary to the right creates horizontal overflow', async () => {
+    const screen = await render(<DescriptionResizedPromptList />)
+
+    await waitForReady(screen.container)
+    await waitForAnimationFrames()
+
+    const scroller = screen.container.querySelector(scrollerSelector) as HTMLElement
+    const initialExpected = expectedGrowWidths(scroller.clientWidth, PROMPT_COLUMN_BASE_WIDTHS)
+    const resizedDescriptionWidth = initialExpected.description + 100
+
+    await expect.poll(() => headerWidth(screen.container, 'description')).toBeCloseTo(resizedDescriptionWidth, 1)
+    expect(headerWidth(screen.container, 'name')).toBeCloseTo(initialExpected.name, 1)
+    expect(scroller.scrollWidth).toBeGreaterThan(scroller.clientWidth)
+  })
+})

--- a/packages/data-table/src/columns/tests/node/column-width-distribution.test.ts
+++ b/packages/data-table/src/columns/tests/node/column-width-distribution.test.ts
@@ -59,4 +59,104 @@ describe('column width distribution', () => {
     expect(widths.get('status')).toBeCloseTo(186.67, 2)
     expect(widths.get('notes')).toBeCloseTo(226.67, 2)
   })
+
+  it('sends all extra width to a single grow column', () => {
+    const widths = computeAutoFillColumnWidths(
+      [
+        ['name', { field: 'name', grow: 1 }],
+        ['status', { field: 'status' }],
+      ],
+      new Map([
+        ['name', 120],
+        ['status', 80],
+      ]),
+      500
+    )
+
+    expect(widths.get('name')).toBe(420)
+    expect(widths.get('status')).toBe(80)
+  })
+
+  it('distributes extra width by grow ratio', () => {
+    const widths = computeAutoFillColumnWidths(
+      [
+        ['name', { field: 'name', grow: 1 }],
+        ['description', { field: 'description', grow: 3 }],
+        ['status', { field: 'status' }],
+      ],
+      new Map([
+        ['name', 120],
+        ['description', 180],
+        ['status', 100],
+      ]),
+      800
+    )
+
+    expect(widths.get('name')).toBe(220)
+    expect(widths.get('description')).toBe(480)
+    expect(widths.get('status')).toBe(100)
+  })
+
+  it('keeps base widths when grow columns exist but the viewport is narrower than the base total', () => {
+    const widths = computeAutoFillColumnWidths(
+      [
+        ['name', { field: 'name', grow: 1 }],
+        ['description', { field: 'description', grow: 3 }],
+        ['status', { field: 'status' }],
+      ],
+      new Map([
+        ['name', 120],
+        ['description', 180],
+        ['status', 100],
+      ]),
+      300
+    )
+
+    expect(widths.get('name')).toBe(120)
+    expect(widths.get('description')).toBe(180)
+    expect(widths.get('status')).toBe(100)
+  })
+
+  it('ignores invalid grow values', () => {
+    const widths = computeAutoFillColumnWidths(
+      [
+        ['name', { field: 'name', grow: 0 }],
+        ['description', { field: 'description', grow: Number.NaN }],
+        ['status', { field: 'status', grow: -1 }],
+        ['notes', { field: 'notes', grow: Number.POSITIVE_INFINITY }],
+      ],
+      new Map([
+        ['name', 100],
+        ['description', 100],
+        ['status', 100],
+        ['notes', 100],
+      ]),
+      800
+    )
+
+    expect(widths.get('name')).toBe(200)
+    expect(widths.get('description')).toBe(200)
+    expect(widths.get('status')).toBe(200)
+    expect(widths.get('notes')).toBe(200)
+  })
+
+  it('keeps invalid grow columns fixed when another column can grow', () => {
+    const widths = computeAutoFillColumnWidths(
+      [
+        ['name', { field: 'name', grow: 1 }],
+        ['description', { field: 'description', grow: Number.NaN }],
+        ['status', { field: 'status' }],
+      ],
+      new Map([
+        ['name', 100],
+        ['description', 100],
+        ['status', 100],
+      ]),
+      600
+    )
+
+    expect(widths.get('name')).toBe(400)
+    expect(widths.get('description')).toBe(100)
+    expect(widths.get('status')).toBe(100)
+  })
 })

--- a/packages/data-table/src/columns/tests/node/column-width-state.test.ts
+++ b/packages/data-table/src/columns/tests/node/column-width-state.test.ts
@@ -125,4 +125,178 @@ describe('column width state', () => {
       ])
     )
   })
+
+  it('distributes measured widths by grow ratio before resize', () => {
+    engine.pub(
+      columns$,
+      new Map([
+        ['name', { field: 'name', grow: 1 }],
+        ['description', { field: 'description', grow: 3 }],
+        ['updated', { field: 'updated' }],
+      ])
+    )
+    engine.pub(
+      measuredColumnWidths$,
+      new Map([
+        ['name', 120],
+        ['description', 180],
+        ['updated', 100],
+      ])
+    )
+    engine.pub(viewportWidth$, 800)
+
+    expect(engine.getValue(columnWidths$)).toStrictEqual(
+      new Map([
+        ['name', 220],
+        ['description', 480],
+        ['updated', 100],
+      ])
+    )
+  })
+
+  it('lets sticky columns participate in grow distribution', () => {
+    engine.pub(
+      columns$,
+      new Map([
+        ['name', { field: 'name', grow: 1, sticky: 'left' }],
+        ['description', { field: 'description', grow: 3 }],
+        ['updated', { field: 'updated' }],
+      ])
+    )
+    engine.pub(
+      measuredColumnWidths$,
+      new Map([
+        ['name', 120],
+        ['description', 180],
+        ['updated', 100],
+      ])
+    )
+    engine.pub(viewportWidth$, 800)
+
+    expect(engine.getValue(columnWidths$)).toStrictEqual(
+      new Map([
+        ['name', 220],
+        ['description', 480],
+        ['updated', 100],
+      ])
+    )
+  })
+
+  it('falls back to equal visible-column distribution when the only grow column is hidden', () => {
+    engine.pub(
+      columns$,
+      new Map([
+        ['name', { field: 'name', grow: 1, visible: false }],
+        ['status', { field: 'status' }],
+        ['updated', { field: 'updated' }],
+      ])
+    )
+    engine.pub(
+      measuredColumnWidths$,
+      new Map([
+        ['name', 100],
+        ['status', 100],
+        ['updated', 100],
+      ])
+    )
+    engine.pub(viewportWidth$, 600)
+
+    expect(engine.getValue(columnWidths$)).toStrictEqual(
+      new Map([
+        ['status', 300],
+        ['updated', 300],
+      ])
+    )
+  })
+
+  it('returns to grow-aware auto-fill behavior when the last override is cleared', () => {
+    engine.pub(
+      columns$,
+      new Map([
+        ['name', { field: 'name', grow: 1 }],
+        ['description', { field: 'description', grow: 3 }],
+        ['updated', { field: 'updated' }],
+      ])
+    )
+    engine.pub(
+      measuredColumnWidths$,
+      new Map([
+        ['name', 120],
+        ['description', 180],
+        ['updated', 100],
+      ])
+    )
+    engine.pub(viewportWidth$, 800)
+    engine.pub(columnWidthOverrides$, new Map([['name', 220]]))
+
+    engine.pub(clearColumnWidthOverride$, { key: 'name' })
+
+    expect(engine.getValue(columnWidthOverrides$)).toStrictEqual(new Map())
+    expect(engine.getValue(columnWidths$)).toStrictEqual(
+      new Map([
+        ['name', 220],
+        ['description', 480],
+        ['updated', 100],
+      ])
+    )
+  })
+
+  it('uses a resized grow column override as its rendered width and freezes siblings', () => {
+    engine.pub(
+      columns$,
+      new Map([
+        ['name', { field: 'name', grow: 1 }],
+        ['description', { field: 'description', grow: 3 }],
+        ['updated', { field: 'updated' }],
+      ])
+    )
+    engine.pub(
+      measuredColumnWidths$,
+      new Map([
+        ['name', 120],
+        ['description', 180],
+        ['updated', 100],
+      ])
+    )
+    engine.pub(viewportWidth$, 800)
+    engine.pub(columnWidthOverrides$, new Map([['name', 260]]))
+
+    expect(engine.getValue(columnWidths$)).toStrictEqual(
+      new Map([
+        ['name', 260],
+        ['description', 480],
+        ['updated', 100],
+      ])
+    )
+  })
+
+  it('keeps non-overridden grow columns frozen across viewport changes after a resize override exists', () => {
+    engine.pub(
+      columns$,
+      new Map([
+        ['name', { field: 'name', grow: 1 }],
+        ['description', { field: 'description', grow: 3 }],
+        ['updated', { field: 'updated' }],
+      ])
+    )
+    engine.pub(
+      measuredColumnWidths$,
+      new Map([
+        ['name', 120],
+        ['description', 180],
+        ['updated', 100],
+      ])
+    )
+    engine.pub(viewportWidth$, 800)
+    engine.pub(columnWidthOverrides$, new Map([['name', 260]]))
+    engine.pub(viewportWidth$, 1_000)
+
+    expect(engine.getValue(columnWidths$)).toStrictEqual(
+      new Map([
+        ['name', 260],
+        ['description', 480],
+        ['updated', 100],
+      ])
+    )
+  })
 })

--- a/packages/data-table/tsconfig.json
+++ b/packages/data-table/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/ui/data-table": ["../../apps/virtuoso.dev/registry/new-york/data-table/data-table"],
       "@/components/ui/data-table/column-reorder": ["../../apps/virtuoso.dev/registry/new-york/data-table/column-reorder/index.ts"],
       "@/components/ui/data-table/column-resize": ["../../apps/virtuoso.dev/registry/new-york/data-table/column-resize/index.ts"],
+      "@/components/ui/data-table/column-sort": ["../../apps/virtuoso.dev/registry/new-york/data-table/column-sort/index.ts"],
       "@/*": ["../../apps/virtuoso.dev/src/*"],
       "@virtuoso.dev/data-table": ["./src/index.ts"],
       "@virtuoso.dev/data-table/column-reorder": ["./src/features/column-reorder/index.ts"],

--- a/packages/data-table/vite.config.ts
+++ b/packages/data-table/vite.config.ts
@@ -28,6 +28,10 @@ export default inLadle
             replacement: resolve(import.meta.dirname, '../../apps/virtuoso.dev/registry/new-york/data-table/column-resize/index.ts'),
           },
           {
+            find: '@/components/ui/data-table/column-sort',
+            replacement: resolve(import.meta.dirname, '../../apps/virtuoso.dev/registry/new-york/data-table/column-sort/index.ts'),
+          },
+          {
             find: '@/components/ui/data-table',
             replacement: resolve(import.meta.dirname, '../../apps/virtuoso.dev/registry/new-york/data-table/data-table.tsx'),
           },

--- a/packages/virtuoso-skills/skills/data-table/SKILL.md
+++ b/packages/virtuoso-skills/skills/data-table/SKILL.md
@@ -168,20 +168,20 @@ Full guide: [migrating-from-table-virtuoso](references/9.guides/04.migrating-fro
 
 ## Troubleshooting
 
-| Symptom                                 | Fix                                                                                                 |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Blank table or header only              | Give the table a measurable height                                                                  |
+| Symptom                                 | Fix                                                                                                                                          |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Blank table or header only              | Give the table a measurable height                                                                                                           |
 | Table does not fill its panel           | Use the optional flex-height pattern: measured parent, `min-h-0` ancestors, `shrink-0` chrome, `DataTable` as `flex-1` with `height: '100%'` |
-| Shadcn component imports fail           | Run the registry install, or import headless from `@virtuoso.dev/data-table`                        |
-| Page and table both scroll              | Use only one scroll mode                                                                            |
-| Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through |
-| Rows remount / lose state after sorting | Add `computeRowKey`                                                                                 |
-| Body cells overlap columns              | Move width classes from `DataTableCell` to `DataTableColumnHeader`; use `DataTableColumn grow={...}` for extra width |
-| Action/display column has no header     | Add an explicit visible `DataTableColumnHeader` label, e.g. `Actions`; `field`/`id` is an identity, not a UI label |
-| Double outer border/frame               | Remove call-site `rounded-md border`; the shadcn wrapper already owns the default table frame                     |
-| Sticky/header colors don't match body   | Override the shadcn wrapper's `--data-table-*` variables on `DataTable` or in the copied wrapper defaults             |
-| Sticky columns clipped                  | Check parent `overflow` and header min-widths                                                       |
-| Empty cells flash on horizontal scroll  | Raise `columnOverscanCount`                                                                         |
+| Shadcn component imports fail           | Run the registry install, or import headless from `@virtuoso.dev/data-table`                                                                 |
+| Page and table both scroll              | Use only one scroll mode                                                                                                                     |
+| Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through                                          |
+| Rows remount / lose state after sorting | Add `computeRowKey`                                                                                                                          |
+| Body cells overlap columns              | Move width classes from `DataTableCell` to `DataTableColumnHeader`; use `DataTableColumn grow={...}` for extra width                         |
+| Action/display column has no header     | Add an explicit visible `DataTableColumnHeader` label, e.g. `Actions`; `field`/`id` is an identity, not a UI label                           |
+| Double outer border/frame               | Remove call-site `rounded-md border`; the shadcn wrapper already owns the default table frame                                                |
+| Sticky/header colors don't match body   | Override the shadcn wrapper's `--data-table-*` variables on `DataTable` or in the copied wrapper defaults                                    |
+| Sticky columns clipped                  | Check parent `overflow` and header min-widths                                                                                                |
+| Empty cells flash on horizontal scroll  | Raise `columnOverscanCount`                                                                                                                  |
 
 Before shipping a shadcn table, grep for width utilities on cells and move them to headers:
 

--- a/packages/virtuoso-skills/skills/data-table/SKILL.md
+++ b/packages/virtuoso-skills/skills/data-table/SKILL.md
@@ -52,6 +52,24 @@ export default function App() {
 
 Columns are JSX, not config objects. `field` is both the row-data lookup key and the column's public identifier (used by visibility, reordering, persistence). The table needs a real height, like every Virtuoso component.
 
+Treat `field` and `id` as stable column identities, not as user-facing labels. Add an explicit `DataTableColumnHeader` for every visible column. This is especially important for display-only columns such as `actions`: use a visible label like `Actions` unless the product intentionally wants an icon-only/headerless column, in which case use `sr-only` text for accessibility.
+
+When a table should fill the remaining height in a page, panel, or card, use a measured flex column instead of a fixed pixel height. Every flex ancestor between the measured container and the table needs `min-h-0`; non-table chrome should be `shrink-0`; the table should be the growing child with `style={{ height: '100%' }}`:
+
+```tsx
+<section className="flex h-full min-h-0 flex-col">
+  <PageHeader className="shrink-0" />
+  <div className="flex min-h-0 flex-1 flex-col gap-3">
+    <Toolbar className="shrink-0" />
+    <DataTable className="min-h-0 flex-1" model={model} style={{ height: '100%' }}>
+      {/* columns */}
+    </DataTable>
+  </div>
+</section>
+```
+
+This is optional. If the parent does not have a definite height, keep using a fixed height (`style={{ height: 360 }}`) or choose `useWindowScroll` / `customScrollParent` deliberately.
+
 Column widths are owned by the table through header measurements. Put base width classes such as `w-*`, `min-w-*`, and `basis-*` on `DataTableColumnHeader`, not on `DataTableCell`. Cells render inside tracks sized from header measurements; cell width utilities can force body content outside those tracks and make columns overlap at narrow widths. Use cell `className` for typography, alignment, padding, truncation, and color. For complex cell content, put `min-w-0` on an inner wrapper instead of widening the cell.
 
 When building a table, choose fixed vs growing columns from the data being displayed:
@@ -92,6 +110,8 @@ Example:
 Hold the model in `useState` with lazy init — `const [model] = useState(() => localModel({ data }))`. Do not use `useMemo`; React may discard memoized values, and the model instance must be retained. Module scope is fine for a static singleton table.
 
 Local filtering/sorting/grouping runs through a named-stage pipeline: declare `pipeline: ['filter', 'sort']` plus `actions`, then dispatch with `model.send({ action: 'filter', payload })`. See [local-data-model](references/2.data-model/01.local-data-model.md) and the [local-filter-sort-group example](references/8.examples/07.local-filter-sort-group.md).
+
+For remote sorting/filtering/search controls, keep the action payload in the model rather than mirroring it in React state. Seed defaults with `initialActions`, dispatch changes with `model.send()` or `dispatchModelAction$`, and read `modelActionState$` to paint active controls. This is especially important when `modelStatePersistenceAdapter()` restores saved action state.
 
 Provide `computeRowKey={({ data }) => data.id}` whenever rows can reorder (sort, filter, remote updates) — without it rows remount and lose local state.
 
@@ -151,11 +171,13 @@ Full guide: [migrating-from-table-virtuoso](references/9.guides/04.migrating-fro
 | Symptom                                 | Fix                                                                                                 |
 | --------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | Blank table or header only              | Give the table a measurable height                                                                  |
+| Table does not fill its panel           | Use the optional flex-height pattern: measured parent, `min-h-0` ancestors, `shrink-0` chrome, `DataTable` as `flex-1` with `height: '100%'` |
 | Shadcn component imports fail           | Run the registry install, or import headless from `@virtuoso.dev/data-table`                        |
 | Page and table both scroll              | Use only one scroll mode                                                                            |
 | Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through |
 | Rows remount / lose state after sorting | Add `computeRowKey`                                                                                 |
 | Body cells overlap columns              | Move width classes from `DataTableCell` to `DataTableColumnHeader`; use `DataTableColumn grow={...}` for extra width |
+| Action/display column has no header     | Add an explicit visible `DataTableColumnHeader` label, e.g. `Actions`; `field`/`id` is an identity, not a UI label |
 | Double outer border/frame               | Remove call-site `rounded-md border`; the shadcn wrapper already owns the default table frame                     |
 | Sticky/header colors don't match body   | Override the shadcn wrapper's `--data-table-*` variables on `DataTable` or in the copied wrapper defaults             |
 | Sticky columns clipped                  | Check parent `overflow` and header min-widths                                                       |

--- a/packages/virtuoso-skills/skills/data-table/SKILL.md
+++ b/packages/virtuoso-skills/skills/data-table/SKILL.md
@@ -40,7 +40,7 @@ const model = localModel({ data: products })
 
 export default function App() {
   return (
-    <DataTable className="rounded-xl" model={model} style={{ height: 360 }}>
+    <DataTable model={model} style={{ height: 360 }}>
       <DataTableColumn field="name">
         <DataTableColumnHeader>Product</DataTableColumnHeader>
         <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
@@ -126,6 +126,8 @@ For UI far from the table, pass `engineId="orders-table"` and use the same hooks
 ## Customization
 
 - Styling goes through `className` on the wrapper components and semantic data attributes — never use `data-testid` as a styling hook.
+- The shadcn wrapper already renders the app-level table frame (`rounded-md border`) on `DataTable`. Do not add `rounded-md border` at each table instance; use `className` only for intentional frame overrides such as `rounded-xl`, `border-0`, `border-2`, shadows, or table variable overrides.
+- The shadcn wrapper exposes table-level CSS variables (`--data-table-bg`, `--data-table-fg`, `--data-table-border`, `--data-table-muted`, `--data-table-muted-fg`, `--data-table-row-hover`, `--data-table-sticky-hover`) and uses them for sticky headers, sticky columns, rows, and loading surfaces. When adapting to a host design system, override those variables once on `DataTable` or in the copied wrapper defaults instead of styling sticky cells individually.
 - Replace internals via the `components` prop: `Row`, `StickyColumnContainer`, `LoadingPlaceholder`, `LoadingOverlay`, `LoadingFooter` (component overrides must forward refs). Top-level: `EmptyPlaceholder`, `ScrollElement`.
 - `context={{ ... }}` flows to `computeRowKey`, `EmptyPlaceholder`, loading slots, and component overrides — but not to cell/header renderers (use React context there). See [ambient-context](references/7.customization/05.ambient-context.md).
 - Scroll modes: default internal scroller, `useWindowScroll`, or `customScrollParent` — pick exactly one.
@@ -154,6 +156,8 @@ Full guide: [migrating-from-table-virtuoso](references/9.guides/04.migrating-fro
 | Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through |
 | Rows remount / lose state after sorting | Add `computeRowKey`                                                                                 |
 | Body cells overlap columns              | Move width classes from `DataTableCell` to `DataTableColumnHeader`; use `DataTableColumn grow={...}` for extra width |
+| Double outer border/frame               | Remove call-site `rounded-md border`; the shadcn wrapper already owns the default table frame                     |
+| Sticky/header colors don't match body   | Override the shadcn wrapper's `--data-table-*` variables on `DataTable` or in the copied wrapper defaults             |
 | Sticky columns clipped                  | Check parent `overflow` and header min-widths                                                       |
 | Empty cells flash on horizontal scroll  | Raise `columnOverscanCount`                                                                         |
 

--- a/packages/virtuoso-skills/skills/data-table/SKILL.md
+++ b/packages/virtuoso-skills/skills/data-table/SKILL.md
@@ -52,6 +52,35 @@ export default function App() {
 
 Columns are JSX, not config objects. `field` is both the row-data lookup key and the column's public identifier (used by visibility, reordering, persistence). The table needs a real height, like every Virtuoso component.
 
+Column widths are owned by the table through header measurements. Put base width classes such as `w-*`, `min-w-*`, and `basis-*` on `DataTableColumnHeader`, not on `DataTableCell`. Cells render inside tracks sized from header measurements; cell width utilities can force body content outside those tracks and make columns overlap at narrow widths. Use cell `className` for typography, alignment, padding, truncation, and color. For complex cell content, put `min-w-0` on an inner wrapper instead of widening the cell.
+
+When building a table, choose fixed vs growing columns from the data being displayed:
+
+- Keep compact columns fixed by omitting `grow`: ids, slugs, checkboxes, action menus, icon buttons, status labels, badges, versions, counts, dates, timestamps, and short enum or metadata columns.
+- Mark text-heavy columns as growing with `DataTableColumn grow={number}`: names, titles, descriptions, summaries, messages, notes, paths, and other content where extra horizontal space improves scanning or reduces truncation.
+- Use positive finite grow values. `grow={0}` is equivalent to omitting `grow`; prefer omission for fixed columns unless a generated config shape needs an explicit value.
+- Ground the choice in local understanding of the table. A `name` column often grows, but a short code-like name may be fixed; a `label` column is often fixed, but user-authored labels may grow.
+- Do not make every column grow. `grow` protects compact columns from absorbing leftover space while useful text columns take the room.
+
+Example:
+
+```tsx
+<DataTableColumn field="name" grow={1}>
+  <DataTableColumnHeader className="min-w-72">Name</DataTableColumnHeader>
+  <DataTableCell>{NameCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="description" grow={3}>
+  <DataTableColumnHeader className="min-w-80">Description</DataTableColumnHeader>
+  <DataTableCell>{DescriptionCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn id="actions">
+  <DataTableColumnHeader className="w-16 justify-center">Actions</DataTableColumnHeader>
+  <DataTableCell>{ActionsCell}</DataTableCell>
+</DataTableColumn>
+```
+
 ## Choosing a data model
 
 | Situation                                                       | Model                                                                                                 |
@@ -124,8 +153,15 @@ Full guide: [migrating-from-table-virtuoso](references/9.guides/04.migrating-fro
 | Page and table both scroll              | Use only one scroll mode                                                                            |
 | Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through |
 | Rows remount / lose state after sorting | Add `computeRowKey`                                                                                 |
-| Sticky columns clipped                  | Check parent `overflow` and column min-widths                                                       |
+| Body cells overlap columns              | Move width classes from `DataTableCell` to `DataTableColumnHeader`; use `DataTableColumn grow={...}` for extra width |
+| Sticky columns clipped                  | Check parent `overflow` and header min-widths                                                       |
 | Empty cells flash on horizontal scroll  | Raise `columnOverscanCount`                                                                         |
+
+Before shipping a shadcn table, grep for width utilities on cells and move them to headers:
+
+```bash
+rg 'DataTableCell.*className=.*(w-|min-w|max-w|basis-|grow|shrink|flex-(none|auto|initial|1|\[))'
+```
 
 For tests, wrap in `VirtuosoDataTableTestingContext.Provider value={{ itemHeight, viewportHeight }}` (JSDOM has no layout) and assert behavior, not exact DOM row counts — overscan renders extra rows. Use real-browser tests for sticky columns, resizing, and drag interactions. See [testing](references/9.guides/01.testing.md).
 
@@ -134,7 +170,7 @@ For tests, wrap in `VirtuosoDataTableTestingContext.Provider value={{ itemHeight
 - [references/README.md](references/README.md) — overview
 - `references/1.installation/` — [shadcn](references/1.installation/01.shadcn.md), [headless](references/1.installation/02.headless.md)
 - `references/2.data-model/` — [local](references/2.data-model/01.local-data-model.md), [remote](references/2.data-model/02.remote-data-model.md), [row-keys](references/2.data-model/03.row-keys.md)
-- `references/3.columns/` — [defining-columns](references/3.columns/01.defining-columns.md), [cell-and-header-renderers](references/3.columns/02.cell-and-header-renderers.md), [column-groups](references/3.columns/03.column-groups.md), [sticky-columns](references/3.columns/04.sticky-columns.md), [visibility](references/3.columns/05.column-visibility.md), [resizing](references/3.columns/06.column-resizing.md), [reordering](references/3.columns/07.column-reordering.md), [runtime-columns](references/3.columns/08.runtime-columns.md)
+- `references/3.columns/` — [defining-columns](references/3.columns/01.defining-columns.md), [cell-and-header-renderers](references/3.columns/02.cell-and-header-renderers.md), [column-groups](references/3.columns/03.column-groups.md), [sticky-columns](references/3.columns/04.sticky-columns.md), [visibility](references/3.columns/05.column-visibility.md), [resizing](references/3.columns/06.column-resizing.md), [reordering](references/3.columns/07.column-reordering.md), [runtime-columns](references/3.columns/08.runtime-columns.md), [column-layout](references/3.columns/09.column-layout.md)
 - Features: [grouped-rows](references/4.grouped-rows.md), [state-persistence](references/5.state-persistence.md), [controlling-the-table](references/6.controlling-the-table.md)
 - `references/7.customization/` — [styling](references/7.customization/01.styling.md), [replacing-internals](references/7.customization/02.replacing-internals.md), [empty-and-loading-states](references/7.customization/03.empty-and-loading-states.md), [scroll-containers](references/7.customization/04.scroll-containers.md), [ambient-context](references/7.customization/05.ambient-context.md), [header-slots](references/7.customization/06.header-slots.md), [shadcn-wrapper](references/7.customization/07.shadcn-wrapper.md)
 - `references/8.examples/` — worked examples from basic table to remote pagination, dashboards, and persistence

--- a/packages/virtuoso-skills/skills/data-table/references/2.data-model/02.remote-data-model.md
+++ b/packages/virtuoso-skills/skills/data-table/references/2.data-model/02.remote-data-model.md
@@ -168,6 +168,8 @@ model.send({ action: 'search', payload: 'desk' })
 
 Returning new params triggers a refresh. With `persistence: true`, the payload of each action — the search string, the selected category — is saved alongside the rest of the table's persisted state and replayed through the handler the next time the table loads, so users come back to the same filtered view. Pass `capture` and `restore` instead of `true` when you need a custom serialized shape.
 
+For stateful controls such as sort, filter, group, or search, prefer the model action state as the source of truth. Seed default active controls with `initialActions`, dispatch changes through `model.send()` or `dispatchModelAction$`, and read `modelActionState$` to paint active buttons. Do not mirror sort/filter payloads in React state just to keep controls highlighted; if a control must be controlled by React, explicitly restore that local state when using `modelStatePersistenceAdapter()`.
+
 For a complete column-header sort control that sends `{ field, direction }` to a remote model, see [Remote Column Sorting](/data-table/examples/remote-column-sorting/).
 
 ## Concurrency and cancellation

--- a/packages/virtuoso-skills/skills/data-table/references/3.columns/01.defining-columns.md
+++ b/packages/virtuoso-skills/skills/data-table/references/3.columns/01.defining-columns.md
@@ -14,7 +14,7 @@ sidebar:
 </DataTableColumn>
 ```
 
-For a row `{ name: 'Standing Desk' }`, the cell renderer receives `'Standing Desk'` as `cellValue`. Omitting `DataTableCell` falls back to the field value; omitting `DataTableColumnHeader` falls back to the field name.
+For a row `{ name: 'Standing Desk' }`, the cell renderer receives `'Standing Desk'` as `cellValue`. Omitting `DataTableCell` falls back to the field value; omitting `DataTableColumnHeader` on a field-backed column falls back to the field name. In app UIs, prefer explicit headers so you control capitalization, wording, and accessibility.
 
 Display-only columns do not need matching row fields. Give them an explicit `id` instead. The id becomes the stable column identity, and `cellValue` is `undefined` unless you provide an `accessor`.
 
@@ -24,6 +24,8 @@ Display-only columns do not need matching row fields. Give them an explicit `id`
   <DataTableCell>{({ row }) => <ActionsMenu row={row.data} />}</DataTableCell>
 </DataTableColumn>
 ```
+
+`id` is not a visible label. For action, selection, expansion, status-icon, and other display-only columns, always provide a `DataTableColumnHeader`. Use visible text such as `Actions` by default; use `sr-only` text only when the product intentionally wants a headerless icon column.
 
 Computed columns also use an explicit `id`, plus an `accessor` when you want the table to provide a derived `cellValue`.
 

--- a/packages/virtuoso-skills/skills/data-table/references/3.columns/02.cell-and-header-renderers.md
+++ b/packages/virtuoso-skills/skills/data-table/references/3.columns/02.cell-and-header-renderers.md
@@ -15,6 +15,15 @@ Both `DataTableCell` and `DataTableColumnHeader` accept a `className` prop along
 <DataTableCell className="text-right tabular-nums">{({ cellValue }) => currency.format(Number(cellValue))}</DataTableCell>
 ```
 
+Do not put column width utilities on `DataTableCell`. Classes like `w-*`, `min-w-*`, `max-w-*`, `basis-*`, `flex-*`, `grow`, and `shrink-*` do not control the column track from a body cell. Put base width classes on `DataTableColumnHeader`, and use `DataTableColumn grow={...}` when a column should absorb leftover horizontal space. A cell width can make the body content fight the measured grid track and overlap neighboring columns. For cell content that needs truncation or nested layout, keep the cell unconstrained and put `min-w-0` on an inner wrapper:
+
+```tsx
+<DataTableColumn field="name">
+  <DataTableColumnHeader className="min-w-64">Name</DataTableColumnHeader>
+  <DataTableCell className="font-medium">{({ row }) => <div className="min-w-0 truncate">{row.data.name}</div>}</DataTableCell>
+</DataTableColumn>
+```
+
 Each visible cell is its own element; the table also column- and row-virtualizes, so an extra wrapper inside the render function multiplies by every rendered cell on every scroll. Save nested elements for styling that's only part of the cell content — a status badge, an inline icon, a secondary line of metadata.
 
 The shadcn wrapper accepts plain text for static headers:

--- a/packages/virtuoso-skills/skills/data-table/references/3.columns/06.column-resizing.md
+++ b/packages/virtuoso-skills/skills/data-table/references/3.columns/06.column-resizing.md
@@ -69,25 +69,55 @@ Skip `HeaderEdge` for columns the user shouldn't be allowed to resize — a fixe
 
 ## Where column widths live
 
-The table owns every column's width through its header. It measures each `DataTableColumnHeader`, distributes any leftover viewport space across the visible columns, and uses the resulting size for every body cell in that column. The drag handle, the programmatic `resizeColumn$` call, and the persisted overrides all feed into that same pipeline as runtime overrides on top of the measured base.
+The table owns every column's width through its header. It measures each `DataTableColumnHeader`, distributes any leftover viewport space across the visible columns, and uses the resulting size for every body cell in that column. The drag handle, the programmatic `resizeColumn$` call, and the persisted overrides feed into that same pipeline as user-selected rendered widths. While a resize override is active, sibling columns keep their current rendered widths so dragging a boundary feels direct and can create horizontal overflow.
 
-To set a column's _default_ width, style the header. The header row is a flex container, so width and flex utilities on `DataTableColumnHeader` work the way they would on any flex child — `w-20`, `min-w-32`, `max-w-64`, `grow`, `shrink-0`, `basis-32`:
+To set a column's _base_ width, style the header with width or minimum-width classes. To decide which columns receive leftover horizontal space, use `DataTableColumn grow={number}`. Do not use Tailwind flex growth classes as the table sizing API:
 
 ```tsx
 <DataTableColumn field="id">
-  <DataTableColumnHeader className="w-20 grow-0">ID</DataTableColumnHeader>
+  <DataTableColumnHeader className="w-20">ID</DataTableColumnHeader>
   <DataTableCell>{({ cellValue }) => String(cellValue)}</DataTableCell>
 </DataTableColumn>
 
-<DataTableColumn field="name">
-  <DataTableColumnHeader className="min-w-48 grow">Product</DataTableColumnHeader>
+<DataTableColumn field="name" grow={1}>
+  <DataTableColumnHeader className="min-w-48">Product</DataTableColumnHeader>
   <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
 </DataTableColumn>
 ```
 
+For the full sizing model, including fixed metadata columns, text-heavy grow columns, horizontal overflow, and resize override behavior, see [Column Layout](/data-table/columns/column-layout/).
+
 :::caution[Don't put widths on the cell]
 Body cells render inside a grid track sized to the column's measured width — they're already constrained from the outside. Width CSS on `DataTableCell` (`w-*`, `min-w-*`, `max-w-*`, `flex-*`, `basis-*`) doesn't influence the column and can fight the grid into clipped or overflowing content. When a column needs to be wider, widen its header. Reserve cell CSS for things inside the track: padding, alignment, typography, truncation.
 :::
+
+This includes width pressure added for "realistic" content. If a prompt name, badge stack, action menu, or timestamp needs room, express that as a header width:
+
+```tsx
+<DataTableColumn field="updated_at">
+  <DataTableColumnHeader className="min-w-44">Updated</DataTableColumnHeader>
+  <DataTableCell className="font-medium">{UpdatedCell}</DataTableCell>
+</DataTableColumn>
+```
+
+Do not mirror that width on the body cell. For multi-line or nested content, place layout helpers inside the cell renderer:
+
+```tsx
+<DataTableCell>
+  {({ row }) => (
+    <div className="min-w-0">
+      <p className="truncate">{row.data.name}</p>
+      <p className="truncate text-muted-foreground">{row.data.slug}</p>
+    </div>
+  )}
+</DataTableCell>
+```
+
+As a final review step, search for width utilities on cell declarations:
+
+```bash
+rg 'DataTableCell.*className=.*(w-|min-w|max-w|basis-|grow|shrink|flex-(none|auto|initial|1|\[))'
+```
 
 ## Resizing without the drag handle
 
@@ -113,7 +143,7 @@ The payload's `key` is the column's internal identifier, not its `field`. The lo
 
 ## Persisting widths across reloads
 
-The handle records the user's _intent_ — "the user wants the name column 280px wide." Intent is what gets saved; the _realized_ width the column actually renders at depends on the table size and the other columns, and shifts as the layout shifts. Saving the realized number locks the user into the layout that happened to be on screen when they last touched the handle.
+The handle records the user's _intent_ — "the user wants the name column 280px wide." Intent is what gets saved. Automatic `grow` output is not persisted; clearing the override lets the column fall back to its measured base width and the current grow distribution.
 
 Mount `columnWidthPersistenceAdapter()` on `DataTableStatePersistence` to persist overrides. The adapter saves them keyed by `field`, so the saved entry survives reordering, partial column lists, and dynamically generated columns. [State Persistence](/data-table/state-persistence/) covers the full wiring, including the field-name contract that ties saved state to column declarations.
 

--- a/packages/virtuoso-skills/skills/data-table/references/3.columns/09.column-layout.md
+++ b/packages/virtuoso-skills/skills/data-table/references/3.columns/09.column-layout.md
@@ -1,0 +1,88 @@
+---
+title: Column Layout
+description: Set base column widths and choose which columns grow into extra horizontal space.
+sidebar:
+  label: Column Layout
+---
+
+Column width has two parts: the base width and the realized width.
+
+The base width comes from the column header. The table measures `DataTableColumnHeader`, then uses that measured width as the starting point for both the header and every body cell in that column.
+
+The realized width is the width the column gets after the table compares all base widths with the viewport. When the viewport is wider than the total base width, extra space is distributed by the table. When the viewport is narrower, columns keep their base widths and the table scrolls horizontally.
+
+## Set Base Widths On Headers
+
+Use header width classes for the minimum useful size of each column:
+
+```tsx
+<DataTableColumn field="name">
+  <DataTableColumnHeader className="min-w-72">Name</DataTableColumnHeader>
+  <DataTableCell>{NameCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="updated">
+  <DataTableColumnHeader className="w-44">Updated</DataTableColumnHeader>
+  <DataTableCell>{UpdatedCell}</DataTableCell>
+</DataTableColumn>
+```
+
+Do not mirror those widths on `DataTableCell`. Body cells render inside tracks sized by the table. Cell width utilities can fight those tracks and cause clipping or overlap.
+
+## Choose Which Columns Grow
+
+Use `DataTableColumn grow={number}` for columns that should absorb extra viewport width. The value is a ratio, not a CSS flex shorthand.
+Omitting `grow`, or passing `grow={0}`, keeps the column fixed when another visible column grows.
+
+```tsx
+<DataTableColumn field="name" grow={1}>
+  <DataTableColumnHeader className="min-w-72">Name</DataTableColumnHeader>
+  <DataTableCell>{NameCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="description" grow={3}>
+  <DataTableColumnHeader className="min-w-80">Description</DataTableColumnHeader>
+  <DataTableCell>{DescriptionCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="versions">
+  <DataTableColumnHeader className="w-40">Versions</DataTableColumnHeader>
+  <DataTableCell>{VersionBadgesCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="updated">
+  <DataTableColumnHeader className="w-44">Updated</DataTableColumnHeader>
+  <DataTableCell>{UpdatedCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn id="actions">
+  <DataTableColumnHeader className="w-16 justify-center">Actions</DataTableColumnHeader>
+  <DataTableCell>{ActionsCell}</DataTableCell>
+</DataTableColumn>
+```
+
+In this layout, `name` and `description` receive all extra width. `description` receives three times as much extra width as `name`. `versions`, `updated`, and `actions` keep their base widths.
+
+Choose grow columns from the local data and workflow. IDs, slugs, checkboxes, action menus, short labels, badges, version counts, timestamps, and compact metadata usually should not grow. Names, titles, descriptions, summaries, messages, notes, paths, and other text-heavy content usually benefit from extra room. The field name is only a clue: a short code-like `name` may be fixed, while a user-authored label column may deserve room.
+
+Do not make every column grow. The point of `grow` is to let useful text columns breathe while compact columns stay compact.
+
+## What Happens Without Grow
+
+Tables that do not set `grow` preserve the default auto-fill behavior: when the viewport is wider than the total base width, extra space is distributed evenly across visible columns. This keeps existing tables filling their container without changing every column declaration.
+
+Once any visible column has a positive finite `grow` value, only grow columns receive leftover width. Non-grow columns keep their base widths.
+
+## There Is No Shrink Prop
+
+`grow` only distributes extra space. It does not shrink columns below their base widths, and there is no `shrink` table API.
+
+When the viewport narrows, grow space disappears first. After the total base width no longer fits, the table keeps base widths and uses horizontal scrolling.
+
+## Resizing Grow Columns
+
+Column resizing sets the rendered width of that column. During and after a resize override, the table preserves the current rendered widths of the other columns instead of redistributing grow space on every pointer move. That keeps the resize handle under the pointer and lets wider columns push the table into horizontal overflow.
+
+Clear the resize override to return the column to its measured base width and the normal `grow` distribution.
+
+Persist resize overrides as user-selected widths, not as automatic grow output. The saved width is the user's explicit override; automatic grow space is recalculated only when no resize override is active for that layout.

--- a/packages/virtuoso-skills/skills/data-table/references/3.columns/index.md
+++ b/packages/virtuoso-skills/skills/data-table/references/3.columns/index.md
@@ -72,12 +72,15 @@ Omit the header to fall back to the field name; omit the cell to fall back to th
 
 `field` is both the cell lookup key (`row.data[field]`) and the column's persistent identity. Keep it stable across releases if you use any column features that save state — see [State Persistence](/data-table/state-persistence/#field-names-are-the-persistence-contract) for the rules around renaming.
 
+For layout, put base widths on `DataTableColumnHeader` and use `DataTableColumn grow={...}` only for columns that should absorb extra horizontal space. See [Column Layout](/data-table/columns/column-layout/) for the sizing model and guidance on choosing fixed vs growing columns from the data being displayed.
+
 ## Where to go next
 
 Declarative shape:
 
 - [Defining Columns](/data-table/columns/defining-columns/) — `field`, default rendering, declaration order, visibility, generated columns.
 - [Formatting Cells and Headers](/data-table/columns/cell-and-header-renderers/) — render params, extracted renderer functions, custom header content.
+- [Column Layout](/data-table/columns/column-layout/) — base widths, `grow` ratios, fixed metadata columns, and horizontal overflow.
 - [Column Groups](/data-table/columns/column-groups/) — wrap adjacent columns under a shared header.
 - [Sticky Columns](/data-table/columns/sticky-columns/) — pin a column to the left or right edge during horizontal scrolling.
 

--- a/packages/virtuoso-skills/skills/data-table/references/7.customization/01.styling.md
+++ b/packages/virtuoso-skills/skills/data-table/references/7.customization/01.styling.md
@@ -23,7 +23,7 @@ const model = localModel({ data: rows })
 
 export default function App() {
   return (
-    <DataTable className="rounded-xl border-2 border-slate-900/10 shadow-sm" model={model} style={{ height: 280 }}>
+    <DataTable model={model} style={{ height: 280 }}>
       <DataTableColumn field="name">
         <DataTableColumnHeader>Product</DataTableColumnHeader>
         <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
@@ -61,10 +61,22 @@ export default function App() {
 
 ## Wrapper-level styling
 
-`className` on `<DataTable>` reaches the outer frame around the scroll viewport. Use it for borders, rounded corners, shadow, and the table's overall background.
+`className` on `<DataTable>` reaches the outer frame around the scroll viewport. The shadcn wrapper already provides the default frame (`rounded-md border`) and table surface, so you do not need to repeat `rounded-md border` at each instance. Use wrapper classes for intentional frame overrides, shadows, and table-level CSS variable overrides.
 
 ```tsx
-<DataTable className="rounded-xl border bg-card shadow-sm" model={model}>
+<DataTable className="rounded-xl shadow-sm" model={model}>
+  {/* columns */}
+</DataTable>
+```
+
+To remove or strengthen the default frame, override it directly:
+
+```tsx
+<DataTable className="border-0" model={model}>
+  {/* columns */}
+</DataTable>
+
+<DataTable className="border-2" model={model}>
   {/* columns */}
 </DataTable>
 ```

--- a/packages/virtuoso-skills/skills/data-table/references/7.customization/04.scroll-containers.md
+++ b/packages/virtuoso-skills/skills/data-table/references/7.customization/04.scroll-containers.md
@@ -42,6 +42,40 @@ export default function App() {
 }
 ```
 
+## Fill available panel height
+
+For app pages where the table should consume the remaining space below fixed page chrome, keep the default internal table scroller and give the table a measured flex slot. This is usually better than guessing a pixel height.
+
+The important pieces are:
+
+- a parent with a real height, such as a route shell, panel, or card body
+- `min-h-0` on each flex ancestor between that measured parent and the table
+- `shrink-0` on controls above the table
+- `flex-1 min-h-0` on `DataTable`, plus `style={{ height: '100%' }}`
+
+```tsx
+export function OrdersPage() {
+  return (
+    <section className="flex h-full min-h-0 flex-col">
+      <PageHeader className="shrink-0" />
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3">
+        <Toolbar className="shrink-0" />
+
+        <DataTable className="min-h-0 flex-1" computeRowKey={({ data }) => data.id} model={model} style={{ height: '100%' }}>
+          <DataTableColumn field="name">
+            <DataTableColumnHeader>Order</DataTableColumnHeader>
+            <DataTableCell>{({ cellValue }) => String(cellValue)}</DataTableCell>
+          </DataTableColumn>
+        </DataTable>
+      </div>
+    </section>
+  )
+}
+```
+
+Use this pattern only when the parent is height-constrained. If the table lives in normal document flow, keep a fixed table height (`style={{ height: 360 }}`) or intentionally switch to `useWindowScroll` / `customScrollParent`.
+
 ## Window scrolling
 
 `useWindowScroll` makes the document viewport drive the table's scroll state:

--- a/packages/virtuoso-skills/skills/data-table/references/7.customization/07.shadcn-wrapper.md
+++ b/packages/virtuoso-skills/skills/data-table/references/7.customization/07.shadcn-wrapper.md
@@ -61,15 +61,15 @@ The default shadcn wrapper gives `DataTable` an app-level frame (`rounded-md bor
 
 The variables matter most for sticky headers and sticky columns: those pieces are separate overlay containers, so they need an opaque background, but that background should match the table body instead of being hardcoded independently.
 
-| Variable                     | Default                          | Used for                                           |
-| ---------------------------- | -------------------------------- | -------------------------------------------------- |
-| `--data-table-bg`            | `hsl(var(--background))`         | Table body, sticky header, sticky column wrappers  |
-| `--data-table-fg`            | `hsl(var(--foreground))`         | Default table/header/group-header text             |
-| `--data-table-border`        | `hsl(var(--border))`             | Row separators, header borders, loading containers |
-| `--data-table-muted`         | `hsl(var(--muted))`              | Group rows, skeleton rows, sticky hover blends     |
-| `--data-table-muted-fg`      | `hsl(var(--muted-foreground))`   | Loading and secondary wrapper text                 |
-| `--data-table-row-hover`     | `hsl(var(--muted) / 0.5)`        | Non-sticky row hover background                    |
-| `--data-table-sticky-hover`  | a mix of muted and table bg      | Sticky column hover background                     |
+| Variable                    | Default                        | Used for                                           |
+| --------------------------- | ------------------------------ | -------------------------------------------------- |
+| `--data-table-bg`           | `hsl(var(--background))`       | Table body, sticky header, sticky column wrappers  |
+| `--data-table-fg`           | `hsl(var(--foreground))`       | Default table/header/group-header text             |
+| `--data-table-border`       | `hsl(var(--border))`           | Row separators, header borders, loading containers |
+| `--data-table-muted`        | `hsl(var(--muted))`            | Group rows, skeleton rows, sticky hover blends     |
+| `--data-table-muted-fg`     | `hsl(var(--muted-foreground))` | Loading and secondary wrapper text                 |
+| `--data-table-row-hover`    | `hsl(var(--muted) / 0.5)`      | Non-sticky row hover background                    |
+| `--data-table-sticky-hover` | a mix of muted and table bg    | Sticky column hover background                     |
 
 If your app maps shadcn tokens to a different design system, override these variables once on the `DataTable` root or in the copied wrapper defaults. Do not style sticky cells individually just to fix a surface mismatch.
 

--- a/packages/virtuoso-skills/skills/data-table/references/7.customization/07.shadcn-wrapper.md
+++ b/packages/virtuoso-skills/skills/data-table/references/7.customization/07.shadcn-wrapper.md
@@ -23,7 +23,7 @@ const model = localModel({ data: rows })
 
 export default function App() {
   return (
-    <DataTable className="rounded-xl border-2 border-border/70 shadow-sm" model={model} style={{ height: 280 }}>
+    <DataTable model={model} style={{ height: 280 }}>
       <DataTableColumn field="product">
         <DataTableColumnHeader>Product</DataTableColumnHeader>
         <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
@@ -49,10 +49,42 @@ The wrapper covers _presentation_:
 
 - default row, header, sticky-column, empty, and loading components
 - Tailwind classes for cells, headers, and group headers
+- the default table frame (`rounded-md border`) and table surface variables
 - ergonomic names (`DataTable`, `DataTableColumn`, `DataTableColumnHeader`, `DataTableCell`)
 - re-exports of the headless hooks and helpers you'll use day-to-day
 
 Edit it like any other component in your app. Tailwind classes, default props, alternate variants, additional re-exports — all fair game. The wrapper file imports behavior from `@virtuoso.dev/data-table`, so your styling edits never fork table mechanics.
+
+## Table surface variables
+
+The default shadcn wrapper gives `DataTable` an app-level frame (`rounded-md border`) and defines a small set of CSS variables on the same root. The frame border uses `--data-table-border`; callers do not need to add `rounded-md border` at each table instance. Use `className` only for intentional overrides such as `rounded-xl`, `border-0`, `border-2`, `shadow-sm`, or table variable overrides.
+
+The variables matter most for sticky headers and sticky columns: those pieces are separate overlay containers, so they need an opaque background, but that background should match the table body instead of being hardcoded independently.
+
+| Variable                     | Default                          | Used for                                           |
+| ---------------------------- | -------------------------------- | -------------------------------------------------- |
+| `--data-table-bg`            | `hsl(var(--background))`         | Table body, sticky header, sticky column wrappers  |
+| `--data-table-fg`            | `hsl(var(--foreground))`         | Default table/header/group-header text             |
+| `--data-table-border`        | `hsl(var(--border))`             | Row separators, header borders, loading containers |
+| `--data-table-muted`         | `hsl(var(--muted))`              | Group rows, skeleton rows, sticky hover blends     |
+| `--data-table-muted-fg`      | `hsl(var(--muted-foreground))`   | Loading and secondary wrapper text                 |
+| `--data-table-row-hover`     | `hsl(var(--muted) / 0.5)`        | Non-sticky row hover background                    |
+| `--data-table-sticky-hover`  | a mix of muted and table bg      | Sticky column hover background                     |
+
+If your app maps shadcn tokens to a different design system, override these variables once on the `DataTable` root or in the copied wrapper defaults. Do not style sticky cells individually just to fix a surface mismatch.
+
+```tsx
+<DataTable
+  className="
+    [--data-table-bg:hsl(var(--surface-container-lowest))]
+    [--data-table-fg:hsl(var(--on-surface))]
+    [--data-table-border:hsl(var(--outline))]
+    [--data-table-muted:hsl(var(--surface-container-low))]
+    [--data-table-muted-fg:hsl(var(--on-surface-variant))]
+  "
+  model={model}
+/>
+```
 
 ## What the headless package owns
 
@@ -79,6 +111,7 @@ Each one is header-slot UI you can restyle. The streams they publish to live in 
 The wrapper is the right place to change:
 
 - default Tailwind classes on `DataTable`, `DataTableCell`, `DataTableColumnHeader`
+- the default table frame, radius, border, and surface variables
 - the default `Row`, `EmptyPlaceholder`, `LoadingPlaceholder` your team should see
 - ergonomic re-exports you add for your codebase
 

--- a/packages/virtuoso-skills/skills/data-table/references/8.examples/16.remote-column-sorting.md
+++ b/packages/virtuoso-skills/skills/data-table/references/8.examples/16.remote-column-sorting.md
@@ -5,7 +5,7 @@ sidebar:
   label: Remote Sorting
 ---
 
-Each sortable column header sends a `sort` action to the remote model. The action updates the request params, the model refetches from the first page, and the active header button reads the current sort from `modelActionState$`.
+Each sortable column header sends a `sort` action to the remote model. The action updates the request params, the model refetches from the first page, and the active header button reads the current sort from `modelActionState$`. Do not keep a second `sortBy` / `sortOrder` React state just to paint the header; seed the model with `initialActions` for a default sort and let `modelActionState$` be the source of truth.
 
 The shadcn `SortHeaderButton` defaults to a payload shaped as `{ field, direction }`, where `direction` cycles through `'asc'`, `'desc'`, and no sort.
 
@@ -15,6 +15,8 @@ The shadcn `SortHeaderButton` defaults to a payload shaped as `{ field, directio
 - `SortHeaderButton` — shadcn slot component for column-header sorting
 - `HeaderEnd` — places the sort button after the header label
 - `computeRowKey` — keeps row identity stable when sorting reorders rows
+- `initialActions` — seeds the active sort in model action state
+- `modelStatePersistenceAdapter()` — optionally persists the sort action payload across reloads
 
 ```tsx live wide file=App.tsx
 import { useState } from 'react'
@@ -22,22 +24,28 @@ import { useState } from 'react'
 import { DataTable, DataTableCell, DataTableColumn, DataTableColumnHeader, HeaderEnd } from '@/components/ui/data-table'
 import { SortHeaderButton } from '@/components/ui/data-table/column-sort'
 import { defaultOffsetViewportHandler, remoteModel } from '@virtuoso.dev/data-table'
+import { DataTableStatePersistence, modelStatePersistenceAdapter } from '@virtuoso.dev/data-table/state-persistence'
 
 import { fetchProducts, placeholder } from './api'
 
 import type { Product, Query } from './api'
+
+const defaultSort = { field: 'name', direction: 'asc' } satisfies NonNullable<Query['sort']>
+const persistenceAdapters = [modelStatePersistenceAdapter()]
 
 export default function App() {
   const [model] = useState(() =>
     remoteModel<Product, Query>({
       actions: {
         sort: {
+          persistence: true,
           strategy: 'supersede',
           handler: ({ params, payload }) => ({ ...params, sort: payload as Query['sort'] }),
         },
       },
       fetch: fetchProducts,
-      initialParams: {},
+      initialActions: [{ action: 'sort', payload: defaultSort }],
+      initialParams: { sort: defaultSort },
       onViewportChange: defaultOffsetViewportHandler,
       pageSize: 40,
       placeholder,
@@ -46,6 +54,8 @@ export default function App() {
 
   return (
     <DataTable className="rounded-xl" computeRowKey={({ data }) => data.id} model={model} style={{ height: 420 }}>
+      <DataTableStatePersistence adapters={persistenceAdapters} storageKey="remote-column-sorting-example" />
+
       <DataTableColumn field="name">
         <DataTableColumnHeader>
           <HeaderEnd component={SortHeaderButton} />

--- a/plugins/virtuoso-skills/skills/data-table/SKILL.md
+++ b/plugins/virtuoso-skills/skills/data-table/SKILL.md
@@ -168,20 +168,20 @@ Full guide: [migrating-from-table-virtuoso](references/9.guides/04.migrating-fro
 
 ## Troubleshooting
 
-| Symptom                                 | Fix                                                                                                 |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Blank table or header only              | Give the table a measurable height                                                                  |
+| Symptom                                 | Fix                                                                                                                                          |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Blank table or header only              | Give the table a measurable height                                                                                                           |
 | Table does not fill its panel           | Use the optional flex-height pattern: measured parent, `min-h-0` ancestors, `shrink-0` chrome, `DataTable` as `flex-1` with `height: '100%'` |
-| Shadcn component imports fail           | Run the registry install, or import headless from `@virtuoso.dev/data-table`                        |
-| Page and table both scroll              | Use only one scroll mode                                                                            |
-| Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through |
-| Rows remount / lose state after sorting | Add `computeRowKey`                                                                                 |
-| Body cells overlap columns              | Move width classes from `DataTableCell` to `DataTableColumnHeader`; use `DataTableColumn grow={...}` for extra width |
-| Action/display column has no header     | Add an explicit visible `DataTableColumnHeader` label, e.g. `Actions`; `field`/`id` is an identity, not a UI label |
-| Double outer border/frame               | Remove call-site `rounded-md border`; the shadcn wrapper already owns the default table frame                     |
-| Sticky/header colors don't match body   | Override the shadcn wrapper's `--data-table-*` variables on `DataTable` or in the copied wrapper defaults             |
-| Sticky columns clipped                  | Check parent `overflow` and header min-widths                                                       |
-| Empty cells flash on horizontal scroll  | Raise `columnOverscanCount`                                                                         |
+| Shadcn component imports fail           | Run the registry install, or import headless from `@virtuoso.dev/data-table`                                                                 |
+| Page and table both scroll              | Use only one scroll mode                                                                                                                     |
+| Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through                                          |
+| Rows remount / lose state after sorting | Add `computeRowKey`                                                                                                                          |
+| Body cells overlap columns              | Move width classes from `DataTableCell` to `DataTableColumnHeader`; use `DataTableColumn grow={...}` for extra width                         |
+| Action/display column has no header     | Add an explicit visible `DataTableColumnHeader` label, e.g. `Actions`; `field`/`id` is an identity, not a UI label                           |
+| Double outer border/frame               | Remove call-site `rounded-md border`; the shadcn wrapper already owns the default table frame                                                |
+| Sticky/header colors don't match body   | Override the shadcn wrapper's `--data-table-*` variables on `DataTable` or in the copied wrapper defaults                                    |
+| Sticky columns clipped                  | Check parent `overflow` and header min-widths                                                                                                |
+| Empty cells flash on horizontal scroll  | Raise `columnOverscanCount`                                                                                                                  |
 
 Before shipping a shadcn table, grep for width utilities on cells and move them to headers:
 

--- a/plugins/virtuoso-skills/skills/data-table/SKILL.md
+++ b/plugins/virtuoso-skills/skills/data-table/SKILL.md
@@ -52,6 +52,24 @@ export default function App() {
 
 Columns are JSX, not config objects. `field` is both the row-data lookup key and the column's public identifier (used by visibility, reordering, persistence). The table needs a real height, like every Virtuoso component.
 
+Treat `field` and `id` as stable column identities, not as user-facing labels. Add an explicit `DataTableColumnHeader` for every visible column. This is especially important for display-only columns such as `actions`: use a visible label like `Actions` unless the product intentionally wants an icon-only/headerless column, in which case use `sr-only` text for accessibility.
+
+When a table should fill the remaining height in a page, panel, or card, use a measured flex column instead of a fixed pixel height. Every flex ancestor between the measured container and the table needs `min-h-0`; non-table chrome should be `shrink-0`; the table should be the growing child with `style={{ height: '100%' }}`:
+
+```tsx
+<section className="flex h-full min-h-0 flex-col">
+  <PageHeader className="shrink-0" />
+  <div className="flex min-h-0 flex-1 flex-col gap-3">
+    <Toolbar className="shrink-0" />
+    <DataTable className="min-h-0 flex-1" model={model} style={{ height: '100%' }}>
+      {/* columns */}
+    </DataTable>
+  </div>
+</section>
+```
+
+This is optional. If the parent does not have a definite height, keep using a fixed height (`style={{ height: 360 }}`) or choose `useWindowScroll` / `customScrollParent` deliberately.
+
 Column widths are owned by the table through header measurements. Put base width classes such as `w-*`, `min-w-*`, and `basis-*` on `DataTableColumnHeader`, not on `DataTableCell`. Cells render inside tracks sized from header measurements; cell width utilities can force body content outside those tracks and make columns overlap at narrow widths. Use cell `className` for typography, alignment, padding, truncation, and color. For complex cell content, put `min-w-0` on an inner wrapper instead of widening the cell.
 
 When building a table, choose fixed vs growing columns from the data being displayed:
@@ -92,6 +110,8 @@ Example:
 Hold the model in `useState` with lazy init — `const [model] = useState(() => localModel({ data }))`. Do not use `useMemo`; React may discard memoized values, and the model instance must be retained. Module scope is fine for a static singleton table.
 
 Local filtering/sorting/grouping runs through a named-stage pipeline: declare `pipeline: ['filter', 'sort']` plus `actions`, then dispatch with `model.send({ action: 'filter', payload })`. See [local-data-model](references/2.data-model/01.local-data-model.md) and the [local-filter-sort-group example](references/8.examples/07.local-filter-sort-group.md).
+
+For remote sorting/filtering/search controls, keep the action payload in the model rather than mirroring it in React state. Seed defaults with `initialActions`, dispatch changes with `model.send()` or `dispatchModelAction$`, and read `modelActionState$` to paint active controls. This is especially important when `modelStatePersistenceAdapter()` restores saved action state.
 
 Provide `computeRowKey={({ data }) => data.id}` whenever rows can reorder (sort, filter, remote updates) — without it rows remount and lose local state.
 
@@ -151,11 +171,13 @@ Full guide: [migrating-from-table-virtuoso](references/9.guides/04.migrating-fro
 | Symptom                                 | Fix                                                                                                 |
 | --------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | Blank table or header only              | Give the table a measurable height                                                                  |
+| Table does not fill its panel           | Use the optional flex-height pattern: measured parent, `min-h-0` ancestors, `shrink-0` chrome, `DataTable` as `flex-1` with `height: '100%'` |
 | Shadcn component imports fail           | Run the registry install, or import headless from `@virtuoso.dev/data-table`                        |
 | Page and table both scroll              | Use only one scroll mode                                                                            |
 | Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through |
 | Rows remount / lose state after sorting | Add `computeRowKey`                                                                                 |
 | Body cells overlap columns              | Move width classes from `DataTableCell` to `DataTableColumnHeader`; use `DataTableColumn grow={...}` for extra width |
+| Action/display column has no header     | Add an explicit visible `DataTableColumnHeader` label, e.g. `Actions`; `field`/`id` is an identity, not a UI label |
 | Double outer border/frame               | Remove call-site `rounded-md border`; the shadcn wrapper already owns the default table frame                     |
 | Sticky/header colors don't match body   | Override the shadcn wrapper's `--data-table-*` variables on `DataTable` or in the copied wrapper defaults             |
 | Sticky columns clipped                  | Check parent `overflow` and header min-widths                                                       |

--- a/plugins/virtuoso-skills/skills/data-table/SKILL.md
+++ b/plugins/virtuoso-skills/skills/data-table/SKILL.md
@@ -40,7 +40,7 @@ const model = localModel({ data: products })
 
 export default function App() {
   return (
-    <DataTable className="rounded-xl" model={model} style={{ height: 360 }}>
+    <DataTable model={model} style={{ height: 360 }}>
       <DataTableColumn field="name">
         <DataTableColumnHeader>Product</DataTableColumnHeader>
         <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
@@ -126,6 +126,8 @@ For UI far from the table, pass `engineId="orders-table"` and use the same hooks
 ## Customization
 
 - Styling goes through `className` on the wrapper components and semantic data attributes — never use `data-testid` as a styling hook.
+- The shadcn wrapper already renders the app-level table frame (`rounded-md border`) on `DataTable`. Do not add `rounded-md border` at each table instance; use `className` only for intentional frame overrides such as `rounded-xl`, `border-0`, `border-2`, shadows, or table variable overrides.
+- The shadcn wrapper exposes table-level CSS variables (`--data-table-bg`, `--data-table-fg`, `--data-table-border`, `--data-table-muted`, `--data-table-muted-fg`, `--data-table-row-hover`, `--data-table-sticky-hover`) and uses them for sticky headers, sticky columns, rows, and loading surfaces. When adapting to a host design system, override those variables once on `DataTable` or in the copied wrapper defaults instead of styling sticky cells individually.
 - Replace internals via the `components` prop: `Row`, `StickyColumnContainer`, `LoadingPlaceholder`, `LoadingOverlay`, `LoadingFooter` (component overrides must forward refs). Top-level: `EmptyPlaceholder`, `ScrollElement`.
 - `context={{ ... }}` flows to `computeRowKey`, `EmptyPlaceholder`, loading slots, and component overrides — but not to cell/header renderers (use React context there). See [ambient-context](references/7.customization/05.ambient-context.md).
 - Scroll modes: default internal scroller, `useWindowScroll`, or `customScrollParent` — pick exactly one.
@@ -154,6 +156,8 @@ Full guide: [migrating-from-table-virtuoso](references/9.guides/04.migrating-fro
 | Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through |
 | Rows remount / lose state after sorting | Add `computeRowKey`                                                                                 |
 | Body cells overlap columns              | Move width classes from `DataTableCell` to `DataTableColumnHeader`; use `DataTableColumn grow={...}` for extra width |
+| Double outer border/frame               | Remove call-site `rounded-md border`; the shadcn wrapper already owns the default table frame                     |
+| Sticky/header colors don't match body   | Override the shadcn wrapper's `--data-table-*` variables on `DataTable` or in the copied wrapper defaults             |
 | Sticky columns clipped                  | Check parent `overflow` and header min-widths                                                       |
 | Empty cells flash on horizontal scroll  | Raise `columnOverscanCount`                                                                         |
 

--- a/plugins/virtuoso-skills/skills/data-table/SKILL.md
+++ b/plugins/virtuoso-skills/skills/data-table/SKILL.md
@@ -52,6 +52,35 @@ export default function App() {
 
 Columns are JSX, not config objects. `field` is both the row-data lookup key and the column's public identifier (used by visibility, reordering, persistence). The table needs a real height, like every Virtuoso component.
 
+Column widths are owned by the table through header measurements. Put base width classes such as `w-*`, `min-w-*`, and `basis-*` on `DataTableColumnHeader`, not on `DataTableCell`. Cells render inside tracks sized from header measurements; cell width utilities can force body content outside those tracks and make columns overlap at narrow widths. Use cell `className` for typography, alignment, padding, truncation, and color. For complex cell content, put `min-w-0` on an inner wrapper instead of widening the cell.
+
+When building a table, choose fixed vs growing columns from the data being displayed:
+
+- Keep compact columns fixed by omitting `grow`: ids, slugs, checkboxes, action menus, icon buttons, status labels, badges, versions, counts, dates, timestamps, and short enum or metadata columns.
+- Mark text-heavy columns as growing with `DataTableColumn grow={number}`: names, titles, descriptions, summaries, messages, notes, paths, and other content where extra horizontal space improves scanning or reduces truncation.
+- Use positive finite grow values. `grow={0}` is equivalent to omitting `grow`; prefer omission for fixed columns unless a generated config shape needs an explicit value.
+- Ground the choice in local understanding of the table. A `name` column often grows, but a short code-like name may be fixed; a `label` column is often fixed, but user-authored labels may grow.
+- Do not make every column grow. `grow` protects compact columns from absorbing leftover space while useful text columns take the room.
+
+Example:
+
+```tsx
+<DataTableColumn field="name" grow={1}>
+  <DataTableColumnHeader className="min-w-72">Name</DataTableColumnHeader>
+  <DataTableCell>{NameCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="description" grow={3}>
+  <DataTableColumnHeader className="min-w-80">Description</DataTableColumnHeader>
+  <DataTableCell>{DescriptionCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn id="actions">
+  <DataTableColumnHeader className="w-16 justify-center">Actions</DataTableColumnHeader>
+  <DataTableCell>{ActionsCell}</DataTableCell>
+</DataTableColumn>
+```
+
 ## Choosing a data model
 
 | Situation                                                       | Model                                                                                                 |
@@ -124,8 +153,15 @@ Full guide: [migrating-from-table-virtuoso](references/9.guides/04.migrating-fro
 | Page and table both scroll              | Use only one scroll mode                                                                            |
 | Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through |
 | Rows remount / lose state after sorting | Add `computeRowKey`                                                                                 |
-| Sticky columns clipped                  | Check parent `overflow` and column min-widths                                                       |
+| Body cells overlap columns              | Move width classes from `DataTableCell` to `DataTableColumnHeader`; use `DataTableColumn grow={...}` for extra width |
+| Sticky columns clipped                  | Check parent `overflow` and header min-widths                                                       |
 | Empty cells flash on horizontal scroll  | Raise `columnOverscanCount`                                                                         |
+
+Before shipping a shadcn table, grep for width utilities on cells and move them to headers:
+
+```bash
+rg 'DataTableCell.*className=.*(w-|min-w|max-w|basis-|grow|shrink|flex-(none|auto|initial|1|\[))'
+```
 
 For tests, wrap in `VirtuosoDataTableTestingContext.Provider value={{ itemHeight, viewportHeight }}` (JSDOM has no layout) and assert behavior, not exact DOM row counts — overscan renders extra rows. Use real-browser tests for sticky columns, resizing, and drag interactions. See [testing](references/9.guides/01.testing.md).
 
@@ -134,7 +170,7 @@ For tests, wrap in `VirtuosoDataTableTestingContext.Provider value={{ itemHeight
 - [references/README.md](references/README.md) — overview
 - `references/1.installation/` — [shadcn](references/1.installation/01.shadcn.md), [headless](references/1.installation/02.headless.md)
 - `references/2.data-model/` — [local](references/2.data-model/01.local-data-model.md), [remote](references/2.data-model/02.remote-data-model.md), [row-keys](references/2.data-model/03.row-keys.md)
-- `references/3.columns/` — [defining-columns](references/3.columns/01.defining-columns.md), [cell-and-header-renderers](references/3.columns/02.cell-and-header-renderers.md), [column-groups](references/3.columns/03.column-groups.md), [sticky-columns](references/3.columns/04.sticky-columns.md), [visibility](references/3.columns/05.column-visibility.md), [resizing](references/3.columns/06.column-resizing.md), [reordering](references/3.columns/07.column-reordering.md), [runtime-columns](references/3.columns/08.runtime-columns.md)
+- `references/3.columns/` — [defining-columns](references/3.columns/01.defining-columns.md), [cell-and-header-renderers](references/3.columns/02.cell-and-header-renderers.md), [column-groups](references/3.columns/03.column-groups.md), [sticky-columns](references/3.columns/04.sticky-columns.md), [visibility](references/3.columns/05.column-visibility.md), [resizing](references/3.columns/06.column-resizing.md), [reordering](references/3.columns/07.column-reordering.md), [runtime-columns](references/3.columns/08.runtime-columns.md), [column-layout](references/3.columns/09.column-layout.md)
 - Features: [grouped-rows](references/4.grouped-rows.md), [state-persistence](references/5.state-persistence.md), [controlling-the-table](references/6.controlling-the-table.md)
 - `references/7.customization/` — [styling](references/7.customization/01.styling.md), [replacing-internals](references/7.customization/02.replacing-internals.md), [empty-and-loading-states](references/7.customization/03.empty-and-loading-states.md), [scroll-containers](references/7.customization/04.scroll-containers.md), [ambient-context](references/7.customization/05.ambient-context.md), [header-slots](references/7.customization/06.header-slots.md), [shadcn-wrapper](references/7.customization/07.shadcn-wrapper.md)
 - `references/8.examples/` — worked examples from basic table to remote pagination, dashboards, and persistence

--- a/plugins/virtuoso-skills/skills/data-table/references/2.data-model/02.remote-data-model.md
+++ b/plugins/virtuoso-skills/skills/data-table/references/2.data-model/02.remote-data-model.md
@@ -168,6 +168,8 @@ model.send({ action: 'search', payload: 'desk' })
 
 Returning new params triggers a refresh. With `persistence: true`, the payload of each action — the search string, the selected category — is saved alongside the rest of the table's persisted state and replayed through the handler the next time the table loads, so users come back to the same filtered view. Pass `capture` and `restore` instead of `true` when you need a custom serialized shape.
 
+For stateful controls such as sort, filter, group, or search, prefer the model action state as the source of truth. Seed default active controls with `initialActions`, dispatch changes through `model.send()` or `dispatchModelAction$`, and read `modelActionState$` to paint active buttons. Do not mirror sort/filter payloads in React state just to keep controls highlighted; if a control must be controlled by React, explicitly restore that local state when using `modelStatePersistenceAdapter()`.
+
 For a complete column-header sort control that sends `{ field, direction }` to a remote model, see [Remote Column Sorting](/data-table/examples/remote-column-sorting/).
 
 ## Concurrency and cancellation

--- a/plugins/virtuoso-skills/skills/data-table/references/3.columns/01.defining-columns.md
+++ b/plugins/virtuoso-skills/skills/data-table/references/3.columns/01.defining-columns.md
@@ -14,7 +14,7 @@ sidebar:
 </DataTableColumn>
 ```
 
-For a row `{ name: 'Standing Desk' }`, the cell renderer receives `'Standing Desk'` as `cellValue`. Omitting `DataTableCell` falls back to the field value; omitting `DataTableColumnHeader` falls back to the field name.
+For a row `{ name: 'Standing Desk' }`, the cell renderer receives `'Standing Desk'` as `cellValue`. Omitting `DataTableCell` falls back to the field value; omitting `DataTableColumnHeader` on a field-backed column falls back to the field name. In app UIs, prefer explicit headers so you control capitalization, wording, and accessibility.
 
 Display-only columns do not need matching row fields. Give them an explicit `id` instead. The id becomes the stable column identity, and `cellValue` is `undefined` unless you provide an `accessor`.
 
@@ -24,6 +24,8 @@ Display-only columns do not need matching row fields. Give them an explicit `id`
   <DataTableCell>{({ row }) => <ActionsMenu row={row.data} />}</DataTableCell>
 </DataTableColumn>
 ```
+
+`id` is not a visible label. For action, selection, expansion, status-icon, and other display-only columns, always provide a `DataTableColumnHeader`. Use visible text such as `Actions` by default; use `sr-only` text only when the product intentionally wants a headerless icon column.
 
 Computed columns also use an explicit `id`, plus an `accessor` when you want the table to provide a derived `cellValue`.
 

--- a/plugins/virtuoso-skills/skills/data-table/references/3.columns/02.cell-and-header-renderers.md
+++ b/plugins/virtuoso-skills/skills/data-table/references/3.columns/02.cell-and-header-renderers.md
@@ -15,6 +15,15 @@ Both `DataTableCell` and `DataTableColumnHeader` accept a `className` prop along
 <DataTableCell className="text-right tabular-nums">{({ cellValue }) => currency.format(Number(cellValue))}</DataTableCell>
 ```
 
+Do not put column width utilities on `DataTableCell`. Classes like `w-*`, `min-w-*`, `max-w-*`, `basis-*`, `flex-*`, `grow`, and `shrink-*` do not control the column track from a body cell. Put base width classes on `DataTableColumnHeader`, and use `DataTableColumn grow={...}` when a column should absorb leftover horizontal space. A cell width can make the body content fight the measured grid track and overlap neighboring columns. For cell content that needs truncation or nested layout, keep the cell unconstrained and put `min-w-0` on an inner wrapper:
+
+```tsx
+<DataTableColumn field="name">
+  <DataTableColumnHeader className="min-w-64">Name</DataTableColumnHeader>
+  <DataTableCell className="font-medium">{({ row }) => <div className="min-w-0 truncate">{row.data.name}</div>}</DataTableCell>
+</DataTableColumn>
+```
+
 Each visible cell is its own element; the table also column- and row-virtualizes, so an extra wrapper inside the render function multiplies by every rendered cell on every scroll. Save nested elements for styling that's only part of the cell content — a status badge, an inline icon, a secondary line of metadata.
 
 The shadcn wrapper accepts plain text for static headers:

--- a/plugins/virtuoso-skills/skills/data-table/references/3.columns/06.column-resizing.md
+++ b/plugins/virtuoso-skills/skills/data-table/references/3.columns/06.column-resizing.md
@@ -69,25 +69,55 @@ Skip `HeaderEdge` for columns the user shouldn't be allowed to resize — a fixe
 
 ## Where column widths live
 
-The table owns every column's width through its header. It measures each `DataTableColumnHeader`, distributes any leftover viewport space across the visible columns, and uses the resulting size for every body cell in that column. The drag handle, the programmatic `resizeColumn$` call, and the persisted overrides all feed into that same pipeline as runtime overrides on top of the measured base.
+The table owns every column's width through its header. It measures each `DataTableColumnHeader`, distributes any leftover viewport space across the visible columns, and uses the resulting size for every body cell in that column. The drag handle, the programmatic `resizeColumn$` call, and the persisted overrides feed into that same pipeline as user-selected rendered widths. While a resize override is active, sibling columns keep their current rendered widths so dragging a boundary feels direct and can create horizontal overflow.
 
-To set a column's _default_ width, style the header. The header row is a flex container, so width and flex utilities on `DataTableColumnHeader` work the way they would on any flex child — `w-20`, `min-w-32`, `max-w-64`, `grow`, `shrink-0`, `basis-32`:
+To set a column's _base_ width, style the header with width or minimum-width classes. To decide which columns receive leftover horizontal space, use `DataTableColumn grow={number}`. Do not use Tailwind flex growth classes as the table sizing API:
 
 ```tsx
 <DataTableColumn field="id">
-  <DataTableColumnHeader className="w-20 grow-0">ID</DataTableColumnHeader>
+  <DataTableColumnHeader className="w-20">ID</DataTableColumnHeader>
   <DataTableCell>{({ cellValue }) => String(cellValue)}</DataTableCell>
 </DataTableColumn>
 
-<DataTableColumn field="name">
-  <DataTableColumnHeader className="min-w-48 grow">Product</DataTableColumnHeader>
+<DataTableColumn field="name" grow={1}>
+  <DataTableColumnHeader className="min-w-48">Product</DataTableColumnHeader>
   <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
 </DataTableColumn>
 ```
 
+For the full sizing model, including fixed metadata columns, text-heavy grow columns, horizontal overflow, and resize override behavior, see [Column Layout](/data-table/columns/column-layout/).
+
 :::caution[Don't put widths on the cell]
 Body cells render inside a grid track sized to the column's measured width — they're already constrained from the outside. Width CSS on `DataTableCell` (`w-*`, `min-w-*`, `max-w-*`, `flex-*`, `basis-*`) doesn't influence the column and can fight the grid into clipped or overflowing content. When a column needs to be wider, widen its header. Reserve cell CSS for things inside the track: padding, alignment, typography, truncation.
 :::
+
+This includes width pressure added for "realistic" content. If a prompt name, badge stack, action menu, or timestamp needs room, express that as a header width:
+
+```tsx
+<DataTableColumn field="updated_at">
+  <DataTableColumnHeader className="min-w-44">Updated</DataTableColumnHeader>
+  <DataTableCell className="font-medium">{UpdatedCell}</DataTableCell>
+</DataTableColumn>
+```
+
+Do not mirror that width on the body cell. For multi-line or nested content, place layout helpers inside the cell renderer:
+
+```tsx
+<DataTableCell>
+  {({ row }) => (
+    <div className="min-w-0">
+      <p className="truncate">{row.data.name}</p>
+      <p className="truncate text-muted-foreground">{row.data.slug}</p>
+    </div>
+  )}
+</DataTableCell>
+```
+
+As a final review step, search for width utilities on cell declarations:
+
+```bash
+rg 'DataTableCell.*className=.*(w-|min-w|max-w|basis-|grow|shrink|flex-(none|auto|initial|1|\[))'
+```
 
 ## Resizing without the drag handle
 
@@ -113,7 +143,7 @@ The payload's `key` is the column's internal identifier, not its `field`. The lo
 
 ## Persisting widths across reloads
 
-The handle records the user's _intent_ — "the user wants the name column 280px wide." Intent is what gets saved; the _realized_ width the column actually renders at depends on the table size and the other columns, and shifts as the layout shifts. Saving the realized number locks the user into the layout that happened to be on screen when they last touched the handle.
+The handle records the user's _intent_ — "the user wants the name column 280px wide." Intent is what gets saved. Automatic `grow` output is not persisted; clearing the override lets the column fall back to its measured base width and the current grow distribution.
 
 Mount `columnWidthPersistenceAdapter()` on `DataTableStatePersistence` to persist overrides. The adapter saves them keyed by `field`, so the saved entry survives reordering, partial column lists, and dynamically generated columns. [State Persistence](/data-table/state-persistence/) covers the full wiring, including the field-name contract that ties saved state to column declarations.
 

--- a/plugins/virtuoso-skills/skills/data-table/references/3.columns/09.column-layout.md
+++ b/plugins/virtuoso-skills/skills/data-table/references/3.columns/09.column-layout.md
@@ -1,0 +1,88 @@
+---
+title: Column Layout
+description: Set base column widths and choose which columns grow into extra horizontal space.
+sidebar:
+  label: Column Layout
+---
+
+Column width has two parts: the base width and the realized width.
+
+The base width comes from the column header. The table measures `DataTableColumnHeader`, then uses that measured width as the starting point for both the header and every body cell in that column.
+
+The realized width is the width the column gets after the table compares all base widths with the viewport. When the viewport is wider than the total base width, extra space is distributed by the table. When the viewport is narrower, columns keep their base widths and the table scrolls horizontally.
+
+## Set Base Widths On Headers
+
+Use header width classes for the minimum useful size of each column:
+
+```tsx
+<DataTableColumn field="name">
+  <DataTableColumnHeader className="min-w-72">Name</DataTableColumnHeader>
+  <DataTableCell>{NameCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="updated">
+  <DataTableColumnHeader className="w-44">Updated</DataTableColumnHeader>
+  <DataTableCell>{UpdatedCell}</DataTableCell>
+</DataTableColumn>
+```
+
+Do not mirror those widths on `DataTableCell`. Body cells render inside tracks sized by the table. Cell width utilities can fight those tracks and cause clipping or overlap.
+
+## Choose Which Columns Grow
+
+Use `DataTableColumn grow={number}` for columns that should absorb extra viewport width. The value is a ratio, not a CSS flex shorthand.
+Omitting `grow`, or passing `grow={0}`, keeps the column fixed when another visible column grows.
+
+```tsx
+<DataTableColumn field="name" grow={1}>
+  <DataTableColumnHeader className="min-w-72">Name</DataTableColumnHeader>
+  <DataTableCell>{NameCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="description" grow={3}>
+  <DataTableColumnHeader className="min-w-80">Description</DataTableColumnHeader>
+  <DataTableCell>{DescriptionCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="versions">
+  <DataTableColumnHeader className="w-40">Versions</DataTableColumnHeader>
+  <DataTableCell>{VersionBadgesCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="updated">
+  <DataTableColumnHeader className="w-44">Updated</DataTableColumnHeader>
+  <DataTableCell>{UpdatedCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn id="actions">
+  <DataTableColumnHeader className="w-16 justify-center">Actions</DataTableColumnHeader>
+  <DataTableCell>{ActionsCell}</DataTableCell>
+</DataTableColumn>
+```
+
+In this layout, `name` and `description` receive all extra width. `description` receives three times as much extra width as `name`. `versions`, `updated`, and `actions` keep their base widths.
+
+Choose grow columns from the local data and workflow. IDs, slugs, checkboxes, action menus, short labels, badges, version counts, timestamps, and compact metadata usually should not grow. Names, titles, descriptions, summaries, messages, notes, paths, and other text-heavy content usually benefit from extra room. The field name is only a clue: a short code-like `name` may be fixed, while a user-authored label column may deserve room.
+
+Do not make every column grow. The point of `grow` is to let useful text columns breathe while compact columns stay compact.
+
+## What Happens Without Grow
+
+Tables that do not set `grow` preserve the default auto-fill behavior: when the viewport is wider than the total base width, extra space is distributed evenly across visible columns. This keeps existing tables filling their container without changing every column declaration.
+
+Once any visible column has a positive finite `grow` value, only grow columns receive leftover width. Non-grow columns keep their base widths.
+
+## There Is No Shrink Prop
+
+`grow` only distributes extra space. It does not shrink columns below their base widths, and there is no `shrink` table API.
+
+When the viewport narrows, grow space disappears first. After the total base width no longer fits, the table keeps base widths and uses horizontal scrolling.
+
+## Resizing Grow Columns
+
+Column resizing sets the rendered width of that column. During and after a resize override, the table preserves the current rendered widths of the other columns instead of redistributing grow space on every pointer move. That keeps the resize handle under the pointer and lets wider columns push the table into horizontal overflow.
+
+Clear the resize override to return the column to its measured base width and the normal `grow` distribution.
+
+Persist resize overrides as user-selected widths, not as automatic grow output. The saved width is the user's explicit override; automatic grow space is recalculated only when no resize override is active for that layout.

--- a/plugins/virtuoso-skills/skills/data-table/references/3.columns/index.md
+++ b/plugins/virtuoso-skills/skills/data-table/references/3.columns/index.md
@@ -72,12 +72,15 @@ Omit the header to fall back to the field name; omit the cell to fall back to th
 
 `field` is both the cell lookup key (`row.data[field]`) and the column's persistent identity. Keep it stable across releases if you use any column features that save state — see [State Persistence](/data-table/state-persistence/#field-names-are-the-persistence-contract) for the rules around renaming.
 
+For layout, put base widths on `DataTableColumnHeader` and use `DataTableColumn grow={...}` only for columns that should absorb extra horizontal space. See [Column Layout](/data-table/columns/column-layout/) for the sizing model and guidance on choosing fixed vs growing columns from the data being displayed.
+
 ## Where to go next
 
 Declarative shape:
 
 - [Defining Columns](/data-table/columns/defining-columns/) — `field`, default rendering, declaration order, visibility, generated columns.
 - [Formatting Cells and Headers](/data-table/columns/cell-and-header-renderers/) — render params, extracted renderer functions, custom header content.
+- [Column Layout](/data-table/columns/column-layout/) — base widths, `grow` ratios, fixed metadata columns, and horizontal overflow.
 - [Column Groups](/data-table/columns/column-groups/) — wrap adjacent columns under a shared header.
 - [Sticky Columns](/data-table/columns/sticky-columns/) — pin a column to the left or right edge during horizontal scrolling.
 

--- a/plugins/virtuoso-skills/skills/data-table/references/7.customization/01.styling.md
+++ b/plugins/virtuoso-skills/skills/data-table/references/7.customization/01.styling.md
@@ -23,7 +23,7 @@ const model = localModel({ data: rows })
 
 export default function App() {
   return (
-    <DataTable className="rounded-xl border-2 border-slate-900/10 shadow-sm" model={model} style={{ height: 280 }}>
+    <DataTable model={model} style={{ height: 280 }}>
       <DataTableColumn field="name">
         <DataTableColumnHeader>Product</DataTableColumnHeader>
         <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
@@ -61,10 +61,22 @@ export default function App() {
 
 ## Wrapper-level styling
 
-`className` on `<DataTable>` reaches the outer frame around the scroll viewport. Use it for borders, rounded corners, shadow, and the table's overall background.
+`className` on `<DataTable>` reaches the outer frame around the scroll viewport. The shadcn wrapper already provides the default frame (`rounded-md border`) and table surface, so you do not need to repeat `rounded-md border` at each instance. Use wrapper classes for intentional frame overrides, shadows, and table-level CSS variable overrides.
 
 ```tsx
-<DataTable className="rounded-xl border bg-card shadow-sm" model={model}>
+<DataTable className="rounded-xl shadow-sm" model={model}>
+  {/* columns */}
+</DataTable>
+```
+
+To remove or strengthen the default frame, override it directly:
+
+```tsx
+<DataTable className="border-0" model={model}>
+  {/* columns */}
+</DataTable>
+
+<DataTable className="border-2" model={model}>
   {/* columns */}
 </DataTable>
 ```

--- a/plugins/virtuoso-skills/skills/data-table/references/7.customization/04.scroll-containers.md
+++ b/plugins/virtuoso-skills/skills/data-table/references/7.customization/04.scroll-containers.md
@@ -42,6 +42,40 @@ export default function App() {
 }
 ```
 
+## Fill available panel height
+
+For app pages where the table should consume the remaining space below fixed page chrome, keep the default internal table scroller and give the table a measured flex slot. This is usually better than guessing a pixel height.
+
+The important pieces are:
+
+- a parent with a real height, such as a route shell, panel, or card body
+- `min-h-0` on each flex ancestor between that measured parent and the table
+- `shrink-0` on controls above the table
+- `flex-1 min-h-0` on `DataTable`, plus `style={{ height: '100%' }}`
+
+```tsx
+export function OrdersPage() {
+  return (
+    <section className="flex h-full min-h-0 flex-col">
+      <PageHeader className="shrink-0" />
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3">
+        <Toolbar className="shrink-0" />
+
+        <DataTable className="min-h-0 flex-1" computeRowKey={({ data }) => data.id} model={model} style={{ height: '100%' }}>
+          <DataTableColumn field="name">
+            <DataTableColumnHeader>Order</DataTableColumnHeader>
+            <DataTableCell>{({ cellValue }) => String(cellValue)}</DataTableCell>
+          </DataTableColumn>
+        </DataTable>
+      </div>
+    </section>
+  )
+}
+```
+
+Use this pattern only when the parent is height-constrained. If the table lives in normal document flow, keep a fixed table height (`style={{ height: 360 }}`) or intentionally switch to `useWindowScroll` / `customScrollParent`.
+
 ## Window scrolling
 
 `useWindowScroll` makes the document viewport drive the table's scroll state:

--- a/plugins/virtuoso-skills/skills/data-table/references/7.customization/07.shadcn-wrapper.md
+++ b/plugins/virtuoso-skills/skills/data-table/references/7.customization/07.shadcn-wrapper.md
@@ -61,15 +61,15 @@ The default shadcn wrapper gives `DataTable` an app-level frame (`rounded-md bor
 
 The variables matter most for sticky headers and sticky columns: those pieces are separate overlay containers, so they need an opaque background, but that background should match the table body instead of being hardcoded independently.
 
-| Variable                     | Default                          | Used for                                           |
-| ---------------------------- | -------------------------------- | -------------------------------------------------- |
-| `--data-table-bg`            | `hsl(var(--background))`         | Table body, sticky header, sticky column wrappers  |
-| `--data-table-fg`            | `hsl(var(--foreground))`         | Default table/header/group-header text             |
-| `--data-table-border`        | `hsl(var(--border))`             | Row separators, header borders, loading containers |
-| `--data-table-muted`         | `hsl(var(--muted))`              | Group rows, skeleton rows, sticky hover blends     |
-| `--data-table-muted-fg`      | `hsl(var(--muted-foreground))`   | Loading and secondary wrapper text                 |
-| `--data-table-row-hover`     | `hsl(var(--muted) / 0.5)`        | Non-sticky row hover background                    |
-| `--data-table-sticky-hover`  | a mix of muted and table bg      | Sticky column hover background                     |
+| Variable                    | Default                        | Used for                                           |
+| --------------------------- | ------------------------------ | -------------------------------------------------- |
+| `--data-table-bg`           | `hsl(var(--background))`       | Table body, sticky header, sticky column wrappers  |
+| `--data-table-fg`           | `hsl(var(--foreground))`       | Default table/header/group-header text             |
+| `--data-table-border`       | `hsl(var(--border))`           | Row separators, header borders, loading containers |
+| `--data-table-muted`        | `hsl(var(--muted))`            | Group rows, skeleton rows, sticky hover blends     |
+| `--data-table-muted-fg`     | `hsl(var(--muted-foreground))` | Loading and secondary wrapper text                 |
+| `--data-table-row-hover`    | `hsl(var(--muted) / 0.5)`      | Non-sticky row hover background                    |
+| `--data-table-sticky-hover` | a mix of muted and table bg    | Sticky column hover background                     |
 
 If your app maps shadcn tokens to a different design system, override these variables once on the `DataTable` root or in the copied wrapper defaults. Do not style sticky cells individually just to fix a surface mismatch.
 

--- a/plugins/virtuoso-skills/skills/data-table/references/7.customization/07.shadcn-wrapper.md
+++ b/plugins/virtuoso-skills/skills/data-table/references/7.customization/07.shadcn-wrapper.md
@@ -23,7 +23,7 @@ const model = localModel({ data: rows })
 
 export default function App() {
   return (
-    <DataTable className="rounded-xl border-2 border-border/70 shadow-sm" model={model} style={{ height: 280 }}>
+    <DataTable model={model} style={{ height: 280 }}>
       <DataTableColumn field="product">
         <DataTableColumnHeader>Product</DataTableColumnHeader>
         <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
@@ -49,10 +49,42 @@ The wrapper covers _presentation_:
 
 - default row, header, sticky-column, empty, and loading components
 - Tailwind classes for cells, headers, and group headers
+- the default table frame (`rounded-md border`) and table surface variables
 - ergonomic names (`DataTable`, `DataTableColumn`, `DataTableColumnHeader`, `DataTableCell`)
 - re-exports of the headless hooks and helpers you'll use day-to-day
 
 Edit it like any other component in your app. Tailwind classes, default props, alternate variants, additional re-exports — all fair game. The wrapper file imports behavior from `@virtuoso.dev/data-table`, so your styling edits never fork table mechanics.
+
+## Table surface variables
+
+The default shadcn wrapper gives `DataTable` an app-level frame (`rounded-md border`) and defines a small set of CSS variables on the same root. The frame border uses `--data-table-border`; callers do not need to add `rounded-md border` at each table instance. Use `className` only for intentional overrides such as `rounded-xl`, `border-0`, `border-2`, `shadow-sm`, or table variable overrides.
+
+The variables matter most for sticky headers and sticky columns: those pieces are separate overlay containers, so they need an opaque background, but that background should match the table body instead of being hardcoded independently.
+
+| Variable                     | Default                          | Used for                                           |
+| ---------------------------- | -------------------------------- | -------------------------------------------------- |
+| `--data-table-bg`            | `hsl(var(--background))`         | Table body, sticky header, sticky column wrappers  |
+| `--data-table-fg`            | `hsl(var(--foreground))`         | Default table/header/group-header text             |
+| `--data-table-border`        | `hsl(var(--border))`             | Row separators, header borders, loading containers |
+| `--data-table-muted`         | `hsl(var(--muted))`              | Group rows, skeleton rows, sticky hover blends     |
+| `--data-table-muted-fg`      | `hsl(var(--muted-foreground))`   | Loading and secondary wrapper text                 |
+| `--data-table-row-hover`     | `hsl(var(--muted) / 0.5)`        | Non-sticky row hover background                    |
+| `--data-table-sticky-hover`  | a mix of muted and table bg      | Sticky column hover background                     |
+
+If your app maps shadcn tokens to a different design system, override these variables once on the `DataTable` root or in the copied wrapper defaults. Do not style sticky cells individually just to fix a surface mismatch.
+
+```tsx
+<DataTable
+  className="
+    [--data-table-bg:hsl(var(--surface-container-lowest))]
+    [--data-table-fg:hsl(var(--on-surface))]
+    [--data-table-border:hsl(var(--outline))]
+    [--data-table-muted:hsl(var(--surface-container-low))]
+    [--data-table-muted-fg:hsl(var(--on-surface-variant))]
+  "
+  model={model}
+/>
+```
 
 ## What the headless package owns
 
@@ -79,6 +111,7 @@ Each one is header-slot UI you can restyle. The streams they publish to live in 
 The wrapper is the right place to change:
 
 - default Tailwind classes on `DataTable`, `DataTableCell`, `DataTableColumnHeader`
+- the default table frame, radius, border, and surface variables
 - the default `Row`, `EmptyPlaceholder`, `LoadingPlaceholder` your team should see
 - ergonomic re-exports you add for your codebase
 

--- a/plugins/virtuoso-skills/skills/data-table/references/8.examples/16.remote-column-sorting.md
+++ b/plugins/virtuoso-skills/skills/data-table/references/8.examples/16.remote-column-sorting.md
@@ -5,7 +5,7 @@ sidebar:
   label: Remote Sorting
 ---
 
-Each sortable column header sends a `sort` action to the remote model. The action updates the request params, the model refetches from the first page, and the active header button reads the current sort from `modelActionState$`.
+Each sortable column header sends a `sort` action to the remote model. The action updates the request params, the model refetches from the first page, and the active header button reads the current sort from `modelActionState$`. Do not keep a second `sortBy` / `sortOrder` React state just to paint the header; seed the model with `initialActions` for a default sort and let `modelActionState$` be the source of truth.
 
 The shadcn `SortHeaderButton` defaults to a payload shaped as `{ field, direction }`, where `direction` cycles through `'asc'`, `'desc'`, and no sort.
 
@@ -15,6 +15,8 @@ The shadcn `SortHeaderButton` defaults to a payload shaped as `{ field, directio
 - `SortHeaderButton` — shadcn slot component for column-header sorting
 - `HeaderEnd` — places the sort button after the header label
 - `computeRowKey` — keeps row identity stable when sorting reorders rows
+- `initialActions` — seeds the active sort in model action state
+- `modelStatePersistenceAdapter()` — optionally persists the sort action payload across reloads
 
 ```tsx live wide file=App.tsx
 import { useState } from 'react'
@@ -22,22 +24,28 @@ import { useState } from 'react'
 import { DataTable, DataTableCell, DataTableColumn, DataTableColumnHeader, HeaderEnd } from '@/components/ui/data-table'
 import { SortHeaderButton } from '@/components/ui/data-table/column-sort'
 import { defaultOffsetViewportHandler, remoteModel } from '@virtuoso.dev/data-table'
+import { DataTableStatePersistence, modelStatePersistenceAdapter } from '@virtuoso.dev/data-table/state-persistence'
 
 import { fetchProducts, placeholder } from './api'
 
 import type { Product, Query } from './api'
+
+const defaultSort = { field: 'name', direction: 'asc' } satisfies NonNullable<Query['sort']>
+const persistenceAdapters = [modelStatePersistenceAdapter()]
 
 export default function App() {
   const [model] = useState(() =>
     remoteModel<Product, Query>({
       actions: {
         sort: {
+          persistence: true,
           strategy: 'supersede',
           handler: ({ params, payload }) => ({ ...params, sort: payload as Query['sort'] }),
         },
       },
       fetch: fetchProducts,
-      initialParams: {},
+      initialActions: [{ action: 'sort', payload: defaultSort }],
+      initialParams: { sort: defaultSort },
       onViewportChange: defaultOffsetViewportHandler,
       pageSize: 40,
       placeholder,
@@ -46,6 +54,8 @@ export default function App() {
 
   return (
     <DataTable className="rounded-xl" computeRowKey={({ data }) => data.id} model={model} style={{ height: 420 }}>
+      <DataTableStatePersistence adapters={persistenceAdapters} storageKey="remote-column-sorting-example" />
+
       <DataTableColumn field="name">
         <DataTableColumnHeader>
           <HeaderEnd component={SortHeaderButton} />

--- a/skills/data-table/SKILL.md
+++ b/skills/data-table/SKILL.md
@@ -168,20 +168,20 @@ Full guide: [migrating-from-table-virtuoso](references/9.guides/04.migrating-fro
 
 ## Troubleshooting
 
-| Symptom                                 | Fix                                                                                                 |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Blank table or header only              | Give the table a measurable height                                                                  |
+| Symptom                                 | Fix                                                                                                                                          |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Blank table or header only              | Give the table a measurable height                                                                                                           |
 | Table does not fill its panel           | Use the optional flex-height pattern: measured parent, `min-h-0` ancestors, `shrink-0` chrome, `DataTable` as `flex-1` with `height: '100%'` |
-| Shadcn component imports fail           | Run the registry install, or import headless from `@virtuoso.dev/data-table`                        |
-| Page and table both scroll              | Use only one scroll mode                                                                            |
-| Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through |
-| Rows remount / lose state after sorting | Add `computeRowKey`                                                                                 |
-| Body cells overlap columns              | Move width classes from `DataTableCell` to `DataTableColumnHeader`; use `DataTableColumn grow={...}` for extra width |
-| Action/display column has no header     | Add an explicit visible `DataTableColumnHeader` label, e.g. `Actions`; `field`/`id` is an identity, not a UI label |
-| Double outer border/frame               | Remove call-site `rounded-md border`; the shadcn wrapper already owns the default table frame                     |
-| Sticky/header colors don't match body   | Override the shadcn wrapper's `--data-table-*` variables on `DataTable` or in the copied wrapper defaults             |
-| Sticky columns clipped                  | Check parent `overflow` and header min-widths                                                       |
-| Empty cells flash on horizontal scroll  | Raise `columnOverscanCount`                                                                         |
+| Shadcn component imports fail           | Run the registry install, or import headless from `@virtuoso.dev/data-table`                                                                 |
+| Page and table both scroll              | Use only one scroll mode                                                                                                                     |
+| Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through                                          |
+| Rows remount / lose state after sorting | Add `computeRowKey`                                                                                                                          |
+| Body cells overlap columns              | Move width classes from `DataTableCell` to `DataTableColumnHeader`; use `DataTableColumn grow={...}` for extra width                         |
+| Action/display column has no header     | Add an explicit visible `DataTableColumnHeader` label, e.g. `Actions`; `field`/`id` is an identity, not a UI label                           |
+| Double outer border/frame               | Remove call-site `rounded-md border`; the shadcn wrapper already owns the default table frame                                                |
+| Sticky/header colors don't match body   | Override the shadcn wrapper's `--data-table-*` variables on `DataTable` or in the copied wrapper defaults                                    |
+| Sticky columns clipped                  | Check parent `overflow` and header min-widths                                                                                                |
+| Empty cells flash on horizontal scroll  | Raise `columnOverscanCount`                                                                                                                  |
 
 Before shipping a shadcn table, grep for width utilities on cells and move them to headers:
 

--- a/skills/data-table/SKILL.md
+++ b/skills/data-table/SKILL.md
@@ -52,6 +52,24 @@ export default function App() {
 
 Columns are JSX, not config objects. `field` is both the row-data lookup key and the column's public identifier (used by visibility, reordering, persistence). The table needs a real height, like every Virtuoso component.
 
+Treat `field` and `id` as stable column identities, not as user-facing labels. Add an explicit `DataTableColumnHeader` for every visible column. This is especially important for display-only columns such as `actions`: use a visible label like `Actions` unless the product intentionally wants an icon-only/headerless column, in which case use `sr-only` text for accessibility.
+
+When a table should fill the remaining height in a page, panel, or card, use a measured flex column instead of a fixed pixel height. Every flex ancestor between the measured container and the table needs `min-h-0`; non-table chrome should be `shrink-0`; the table should be the growing child with `style={{ height: '100%' }}`:
+
+```tsx
+<section className="flex h-full min-h-0 flex-col">
+  <PageHeader className="shrink-0" />
+  <div className="flex min-h-0 flex-1 flex-col gap-3">
+    <Toolbar className="shrink-0" />
+    <DataTable className="min-h-0 flex-1" model={model} style={{ height: '100%' }}>
+      {/* columns */}
+    </DataTable>
+  </div>
+</section>
+```
+
+This is optional. If the parent does not have a definite height, keep using a fixed height (`style={{ height: 360 }}`) or choose `useWindowScroll` / `customScrollParent` deliberately.
+
 Column widths are owned by the table through header measurements. Put base width classes such as `w-*`, `min-w-*`, and `basis-*` on `DataTableColumnHeader`, not on `DataTableCell`. Cells render inside tracks sized from header measurements; cell width utilities can force body content outside those tracks and make columns overlap at narrow widths. Use cell `className` for typography, alignment, padding, truncation, and color. For complex cell content, put `min-w-0` on an inner wrapper instead of widening the cell.
 
 When building a table, choose fixed vs growing columns from the data being displayed:
@@ -92,6 +110,8 @@ Example:
 Hold the model in `useState` with lazy init — `const [model] = useState(() => localModel({ data }))`. Do not use `useMemo`; React may discard memoized values, and the model instance must be retained. Module scope is fine for a static singleton table.
 
 Local filtering/sorting/grouping runs through a named-stage pipeline: declare `pipeline: ['filter', 'sort']` plus `actions`, then dispatch with `model.send({ action: 'filter', payload })`. See [local-data-model](references/2.data-model/01.local-data-model.md) and the [local-filter-sort-group example](references/8.examples/07.local-filter-sort-group.md).
+
+For remote sorting/filtering/search controls, keep the action payload in the model rather than mirroring it in React state. Seed defaults with `initialActions`, dispatch changes with `model.send()` or `dispatchModelAction$`, and read `modelActionState$` to paint active controls. This is especially important when `modelStatePersistenceAdapter()` restores saved action state.
 
 Provide `computeRowKey={({ data }) => data.id}` whenever rows can reorder (sort, filter, remote updates) — without it rows remount and lose local state.
 
@@ -151,11 +171,13 @@ Full guide: [migrating-from-table-virtuoso](references/9.guides/04.migrating-fro
 | Symptom                                 | Fix                                                                                                 |
 | --------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | Blank table or header only              | Give the table a measurable height                                                                  |
+| Table does not fill its panel           | Use the optional flex-height pattern: measured parent, `min-h-0` ancestors, `shrink-0` chrome, `DataTable` as `flex-1` with `height: '100%'` |
 | Shadcn component imports fail           | Run the registry install, or import headless from `@virtuoso.dev/data-table`                        |
 | Page and table both scroll              | Use only one scroll mode                                                                            |
 | Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through |
 | Rows remount / lose state after sorting | Add `computeRowKey`                                                                                 |
 | Body cells overlap columns              | Move width classes from `DataTableCell` to `DataTableColumnHeader`; use `DataTableColumn grow={...}` for extra width |
+| Action/display column has no header     | Add an explicit visible `DataTableColumnHeader` label, e.g. `Actions`; `field`/`id` is an identity, not a UI label |
 | Double outer border/frame               | Remove call-site `rounded-md border`; the shadcn wrapper already owns the default table frame                     |
 | Sticky/header colors don't match body   | Override the shadcn wrapper's `--data-table-*` variables on `DataTable` or in the copied wrapper defaults             |
 | Sticky columns clipped                  | Check parent `overflow` and header min-widths                                                       |

--- a/skills/data-table/SKILL.md
+++ b/skills/data-table/SKILL.md
@@ -40,7 +40,7 @@ const model = localModel({ data: products })
 
 export default function App() {
   return (
-    <DataTable className="rounded-xl" model={model} style={{ height: 360 }}>
+    <DataTable model={model} style={{ height: 360 }}>
       <DataTableColumn field="name">
         <DataTableColumnHeader>Product</DataTableColumnHeader>
         <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
@@ -126,6 +126,8 @@ For UI far from the table, pass `engineId="orders-table"` and use the same hooks
 ## Customization
 
 - Styling goes through `className` on the wrapper components and semantic data attributes — never use `data-testid` as a styling hook.
+- The shadcn wrapper already renders the app-level table frame (`rounded-md border`) on `DataTable`. Do not add `rounded-md border` at each table instance; use `className` only for intentional frame overrides such as `rounded-xl`, `border-0`, `border-2`, shadows, or table variable overrides.
+- The shadcn wrapper exposes table-level CSS variables (`--data-table-bg`, `--data-table-fg`, `--data-table-border`, `--data-table-muted`, `--data-table-muted-fg`, `--data-table-row-hover`, `--data-table-sticky-hover`) and uses them for sticky headers, sticky columns, rows, and loading surfaces. When adapting to a host design system, override those variables once on `DataTable` or in the copied wrapper defaults instead of styling sticky cells individually.
 - Replace internals via the `components` prop: `Row`, `StickyColumnContainer`, `LoadingPlaceholder`, `LoadingOverlay`, `LoadingFooter` (component overrides must forward refs). Top-level: `EmptyPlaceholder`, `ScrollElement`.
 - `context={{ ... }}` flows to `computeRowKey`, `EmptyPlaceholder`, loading slots, and component overrides — but not to cell/header renderers (use React context there). See [ambient-context](references/7.customization/05.ambient-context.md).
 - Scroll modes: default internal scroller, `useWindowScroll`, or `customScrollParent` — pick exactly one.
@@ -154,6 +156,8 @@ Full guide: [migrating-from-table-virtuoso](references/9.guides/04.migrating-fro
 | Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through |
 | Rows remount / lose state after sorting | Add `computeRowKey`                                                                                 |
 | Body cells overlap columns              | Move width classes from `DataTableCell` to `DataTableColumnHeader`; use `DataTableColumn grow={...}` for extra width |
+| Double outer border/frame               | Remove call-site `rounded-md border`; the shadcn wrapper already owns the default table frame                     |
+| Sticky/header colors don't match body   | Override the shadcn wrapper's `--data-table-*` variables on `DataTable` or in the copied wrapper defaults             |
 | Sticky columns clipped                  | Check parent `overflow` and header min-widths                                                       |
 | Empty cells flash on horizontal scroll  | Raise `columnOverscanCount`                                                                         |
 

--- a/skills/data-table/SKILL.md
+++ b/skills/data-table/SKILL.md
@@ -52,6 +52,35 @@ export default function App() {
 
 Columns are JSX, not config objects. `field` is both the row-data lookup key and the column's public identifier (used by visibility, reordering, persistence). The table needs a real height, like every Virtuoso component.
 
+Column widths are owned by the table through header measurements. Put base width classes such as `w-*`, `min-w-*`, and `basis-*` on `DataTableColumnHeader`, not on `DataTableCell`. Cells render inside tracks sized from header measurements; cell width utilities can force body content outside those tracks and make columns overlap at narrow widths. Use cell `className` for typography, alignment, padding, truncation, and color. For complex cell content, put `min-w-0` on an inner wrapper instead of widening the cell.
+
+When building a table, choose fixed vs growing columns from the data being displayed:
+
+- Keep compact columns fixed by omitting `grow`: ids, slugs, checkboxes, action menus, icon buttons, status labels, badges, versions, counts, dates, timestamps, and short enum or metadata columns.
+- Mark text-heavy columns as growing with `DataTableColumn grow={number}`: names, titles, descriptions, summaries, messages, notes, paths, and other content where extra horizontal space improves scanning or reduces truncation.
+- Use positive finite grow values. `grow={0}` is equivalent to omitting `grow`; prefer omission for fixed columns unless a generated config shape needs an explicit value.
+- Ground the choice in local understanding of the table. A `name` column often grows, but a short code-like name may be fixed; a `label` column is often fixed, but user-authored labels may grow.
+- Do not make every column grow. `grow` protects compact columns from absorbing leftover space while useful text columns take the room.
+
+Example:
+
+```tsx
+<DataTableColumn field="name" grow={1}>
+  <DataTableColumnHeader className="min-w-72">Name</DataTableColumnHeader>
+  <DataTableCell>{NameCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="description" grow={3}>
+  <DataTableColumnHeader className="min-w-80">Description</DataTableColumnHeader>
+  <DataTableCell>{DescriptionCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn id="actions">
+  <DataTableColumnHeader className="w-16 justify-center">Actions</DataTableColumnHeader>
+  <DataTableCell>{ActionsCell}</DataTableCell>
+</DataTableColumn>
+```
+
 ## Choosing a data model
 
 | Situation                                                       | Model                                                                                                 |
@@ -124,8 +153,15 @@ Full guide: [migrating-from-table-virtuoso](references/9.guides/04.migrating-fro
 | Page and table both scroll              | Use only one scroll mode                                                                            |
 | Remote rows never appear                | Return the right fetch shape (`{ rows, totalCount }` for offset mode) and pass the `signal` through |
 | Rows remount / lose state after sorting | Add `computeRowKey`                                                                                 |
-| Sticky columns clipped                  | Check parent `overflow` and column min-widths                                                       |
+| Body cells overlap columns              | Move width classes from `DataTableCell` to `DataTableColumnHeader`; use `DataTableColumn grow={...}` for extra width |
+| Sticky columns clipped                  | Check parent `overflow` and header min-widths                                                       |
 | Empty cells flash on horizontal scroll  | Raise `columnOverscanCount`                                                                         |
+
+Before shipping a shadcn table, grep for width utilities on cells and move them to headers:
+
+```bash
+rg 'DataTableCell.*className=.*(w-|min-w|max-w|basis-|grow|shrink|flex-(none|auto|initial|1|\[))'
+```
 
 For tests, wrap in `VirtuosoDataTableTestingContext.Provider value={{ itemHeight, viewportHeight }}` (JSDOM has no layout) and assert behavior, not exact DOM row counts — overscan renders extra rows. Use real-browser tests for sticky columns, resizing, and drag interactions. See [testing](references/9.guides/01.testing.md).
 
@@ -134,7 +170,7 @@ For tests, wrap in `VirtuosoDataTableTestingContext.Provider value={{ itemHeight
 - [references/README.md](references/README.md) — overview
 - `references/1.installation/` — [shadcn](references/1.installation/01.shadcn.md), [headless](references/1.installation/02.headless.md)
 - `references/2.data-model/` — [local](references/2.data-model/01.local-data-model.md), [remote](references/2.data-model/02.remote-data-model.md), [row-keys](references/2.data-model/03.row-keys.md)
-- `references/3.columns/` — [defining-columns](references/3.columns/01.defining-columns.md), [cell-and-header-renderers](references/3.columns/02.cell-and-header-renderers.md), [column-groups](references/3.columns/03.column-groups.md), [sticky-columns](references/3.columns/04.sticky-columns.md), [visibility](references/3.columns/05.column-visibility.md), [resizing](references/3.columns/06.column-resizing.md), [reordering](references/3.columns/07.column-reordering.md), [runtime-columns](references/3.columns/08.runtime-columns.md)
+- `references/3.columns/` — [defining-columns](references/3.columns/01.defining-columns.md), [cell-and-header-renderers](references/3.columns/02.cell-and-header-renderers.md), [column-groups](references/3.columns/03.column-groups.md), [sticky-columns](references/3.columns/04.sticky-columns.md), [visibility](references/3.columns/05.column-visibility.md), [resizing](references/3.columns/06.column-resizing.md), [reordering](references/3.columns/07.column-reordering.md), [runtime-columns](references/3.columns/08.runtime-columns.md), [column-layout](references/3.columns/09.column-layout.md)
 - Features: [grouped-rows](references/4.grouped-rows.md), [state-persistence](references/5.state-persistence.md), [controlling-the-table](references/6.controlling-the-table.md)
 - `references/7.customization/` — [styling](references/7.customization/01.styling.md), [replacing-internals](references/7.customization/02.replacing-internals.md), [empty-and-loading-states](references/7.customization/03.empty-and-loading-states.md), [scroll-containers](references/7.customization/04.scroll-containers.md), [ambient-context](references/7.customization/05.ambient-context.md), [header-slots](references/7.customization/06.header-slots.md), [shadcn-wrapper](references/7.customization/07.shadcn-wrapper.md)
 - `references/8.examples/` — worked examples from basic table to remote pagination, dashboards, and persistence

--- a/skills/data-table/references/2.data-model/02.remote-data-model.md
+++ b/skills/data-table/references/2.data-model/02.remote-data-model.md
@@ -168,6 +168,8 @@ model.send({ action: 'search', payload: 'desk' })
 
 Returning new params triggers a refresh. With `persistence: true`, the payload of each action — the search string, the selected category — is saved alongside the rest of the table's persisted state and replayed through the handler the next time the table loads, so users come back to the same filtered view. Pass `capture` and `restore` instead of `true` when you need a custom serialized shape.
 
+For stateful controls such as sort, filter, group, or search, prefer the model action state as the source of truth. Seed default active controls with `initialActions`, dispatch changes through `model.send()` or `dispatchModelAction$`, and read `modelActionState$` to paint active buttons. Do not mirror sort/filter payloads in React state just to keep controls highlighted; if a control must be controlled by React, explicitly restore that local state when using `modelStatePersistenceAdapter()`.
+
 For a complete column-header sort control that sends `{ field, direction }` to a remote model, see [Remote Column Sorting](/data-table/examples/remote-column-sorting/).
 
 ## Concurrency and cancellation

--- a/skills/data-table/references/3.columns/01.defining-columns.md
+++ b/skills/data-table/references/3.columns/01.defining-columns.md
@@ -14,7 +14,7 @@ sidebar:
 </DataTableColumn>
 ```
 
-For a row `{ name: 'Standing Desk' }`, the cell renderer receives `'Standing Desk'` as `cellValue`. Omitting `DataTableCell` falls back to the field value; omitting `DataTableColumnHeader` falls back to the field name.
+For a row `{ name: 'Standing Desk' }`, the cell renderer receives `'Standing Desk'` as `cellValue`. Omitting `DataTableCell` falls back to the field value; omitting `DataTableColumnHeader` on a field-backed column falls back to the field name. In app UIs, prefer explicit headers so you control capitalization, wording, and accessibility.
 
 Display-only columns do not need matching row fields. Give them an explicit `id` instead. The id becomes the stable column identity, and `cellValue` is `undefined` unless you provide an `accessor`.
 
@@ -24,6 +24,8 @@ Display-only columns do not need matching row fields. Give them an explicit `id`
   <DataTableCell>{({ row }) => <ActionsMenu row={row.data} />}</DataTableCell>
 </DataTableColumn>
 ```
+
+`id` is not a visible label. For action, selection, expansion, status-icon, and other display-only columns, always provide a `DataTableColumnHeader`. Use visible text such as `Actions` by default; use `sr-only` text only when the product intentionally wants a headerless icon column.
 
 Computed columns also use an explicit `id`, plus an `accessor` when you want the table to provide a derived `cellValue`.
 

--- a/skills/data-table/references/3.columns/02.cell-and-header-renderers.md
+++ b/skills/data-table/references/3.columns/02.cell-and-header-renderers.md
@@ -15,6 +15,15 @@ Both `DataTableCell` and `DataTableColumnHeader` accept a `className` prop along
 <DataTableCell className="text-right tabular-nums">{({ cellValue }) => currency.format(Number(cellValue))}</DataTableCell>
 ```
 
+Do not put column width utilities on `DataTableCell`. Classes like `w-*`, `min-w-*`, `max-w-*`, `basis-*`, `flex-*`, `grow`, and `shrink-*` do not control the column track from a body cell. Put base width classes on `DataTableColumnHeader`, and use `DataTableColumn grow={...}` when a column should absorb leftover horizontal space. A cell width can make the body content fight the measured grid track and overlap neighboring columns. For cell content that needs truncation or nested layout, keep the cell unconstrained and put `min-w-0` on an inner wrapper:
+
+```tsx
+<DataTableColumn field="name">
+  <DataTableColumnHeader className="min-w-64">Name</DataTableColumnHeader>
+  <DataTableCell className="font-medium">{({ row }) => <div className="min-w-0 truncate">{row.data.name}</div>}</DataTableCell>
+</DataTableColumn>
+```
+
 Each visible cell is its own element; the table also column- and row-virtualizes, so an extra wrapper inside the render function multiplies by every rendered cell on every scroll. Save nested elements for styling that's only part of the cell content — a status badge, an inline icon, a secondary line of metadata.
 
 The shadcn wrapper accepts plain text for static headers:

--- a/skills/data-table/references/3.columns/06.column-resizing.md
+++ b/skills/data-table/references/3.columns/06.column-resizing.md
@@ -69,25 +69,55 @@ Skip `HeaderEdge` for columns the user shouldn't be allowed to resize — a fixe
 
 ## Where column widths live
 
-The table owns every column's width through its header. It measures each `DataTableColumnHeader`, distributes any leftover viewport space across the visible columns, and uses the resulting size for every body cell in that column. The drag handle, the programmatic `resizeColumn$` call, and the persisted overrides all feed into that same pipeline as runtime overrides on top of the measured base.
+The table owns every column's width through its header. It measures each `DataTableColumnHeader`, distributes any leftover viewport space across the visible columns, and uses the resulting size for every body cell in that column. The drag handle, the programmatic `resizeColumn$` call, and the persisted overrides feed into that same pipeline as user-selected rendered widths. While a resize override is active, sibling columns keep their current rendered widths so dragging a boundary feels direct and can create horizontal overflow.
 
-To set a column's _default_ width, style the header. The header row is a flex container, so width and flex utilities on `DataTableColumnHeader` work the way they would on any flex child — `w-20`, `min-w-32`, `max-w-64`, `grow`, `shrink-0`, `basis-32`:
+To set a column's _base_ width, style the header with width or minimum-width classes. To decide which columns receive leftover horizontal space, use `DataTableColumn grow={number}`. Do not use Tailwind flex growth classes as the table sizing API:
 
 ```tsx
 <DataTableColumn field="id">
-  <DataTableColumnHeader className="w-20 grow-0">ID</DataTableColumnHeader>
+  <DataTableColumnHeader className="w-20">ID</DataTableColumnHeader>
   <DataTableCell>{({ cellValue }) => String(cellValue)}</DataTableCell>
 </DataTableColumn>
 
-<DataTableColumn field="name">
-  <DataTableColumnHeader className="min-w-48 grow">Product</DataTableColumnHeader>
+<DataTableColumn field="name" grow={1}>
+  <DataTableColumnHeader className="min-w-48">Product</DataTableColumnHeader>
   <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
 </DataTableColumn>
 ```
 
+For the full sizing model, including fixed metadata columns, text-heavy grow columns, horizontal overflow, and resize override behavior, see [Column Layout](/data-table/columns/column-layout/).
+
 :::caution[Don't put widths on the cell]
 Body cells render inside a grid track sized to the column's measured width — they're already constrained from the outside. Width CSS on `DataTableCell` (`w-*`, `min-w-*`, `max-w-*`, `flex-*`, `basis-*`) doesn't influence the column and can fight the grid into clipped or overflowing content. When a column needs to be wider, widen its header. Reserve cell CSS for things inside the track: padding, alignment, typography, truncation.
 :::
+
+This includes width pressure added for "realistic" content. If a prompt name, badge stack, action menu, or timestamp needs room, express that as a header width:
+
+```tsx
+<DataTableColumn field="updated_at">
+  <DataTableColumnHeader className="min-w-44">Updated</DataTableColumnHeader>
+  <DataTableCell className="font-medium">{UpdatedCell}</DataTableCell>
+</DataTableColumn>
+```
+
+Do not mirror that width on the body cell. For multi-line or nested content, place layout helpers inside the cell renderer:
+
+```tsx
+<DataTableCell>
+  {({ row }) => (
+    <div className="min-w-0">
+      <p className="truncate">{row.data.name}</p>
+      <p className="truncate text-muted-foreground">{row.data.slug}</p>
+    </div>
+  )}
+</DataTableCell>
+```
+
+As a final review step, search for width utilities on cell declarations:
+
+```bash
+rg 'DataTableCell.*className=.*(w-|min-w|max-w|basis-|grow|shrink|flex-(none|auto|initial|1|\[))'
+```
 
 ## Resizing without the drag handle
 
@@ -113,7 +143,7 @@ The payload's `key` is the column's internal identifier, not its `field`. The lo
 
 ## Persisting widths across reloads
 
-The handle records the user's _intent_ — "the user wants the name column 280px wide." Intent is what gets saved; the _realized_ width the column actually renders at depends on the table size and the other columns, and shifts as the layout shifts. Saving the realized number locks the user into the layout that happened to be on screen when they last touched the handle.
+The handle records the user's _intent_ — "the user wants the name column 280px wide." Intent is what gets saved. Automatic `grow` output is not persisted; clearing the override lets the column fall back to its measured base width and the current grow distribution.
 
 Mount `columnWidthPersistenceAdapter()` on `DataTableStatePersistence` to persist overrides. The adapter saves them keyed by `field`, so the saved entry survives reordering, partial column lists, and dynamically generated columns. [State Persistence](/data-table/state-persistence/) covers the full wiring, including the field-name contract that ties saved state to column declarations.
 

--- a/skills/data-table/references/3.columns/09.column-layout.md
+++ b/skills/data-table/references/3.columns/09.column-layout.md
@@ -1,0 +1,88 @@
+---
+title: Column Layout
+description: Set base column widths and choose which columns grow into extra horizontal space.
+sidebar:
+  label: Column Layout
+---
+
+Column width has two parts: the base width and the realized width.
+
+The base width comes from the column header. The table measures `DataTableColumnHeader`, then uses that measured width as the starting point for both the header and every body cell in that column.
+
+The realized width is the width the column gets after the table compares all base widths with the viewport. When the viewport is wider than the total base width, extra space is distributed by the table. When the viewport is narrower, columns keep their base widths and the table scrolls horizontally.
+
+## Set Base Widths On Headers
+
+Use header width classes for the minimum useful size of each column:
+
+```tsx
+<DataTableColumn field="name">
+  <DataTableColumnHeader className="min-w-72">Name</DataTableColumnHeader>
+  <DataTableCell>{NameCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="updated">
+  <DataTableColumnHeader className="w-44">Updated</DataTableColumnHeader>
+  <DataTableCell>{UpdatedCell}</DataTableCell>
+</DataTableColumn>
+```
+
+Do not mirror those widths on `DataTableCell`. Body cells render inside tracks sized by the table. Cell width utilities can fight those tracks and cause clipping or overlap.
+
+## Choose Which Columns Grow
+
+Use `DataTableColumn grow={number}` for columns that should absorb extra viewport width. The value is a ratio, not a CSS flex shorthand.
+Omitting `grow`, or passing `grow={0}`, keeps the column fixed when another visible column grows.
+
+```tsx
+<DataTableColumn field="name" grow={1}>
+  <DataTableColumnHeader className="min-w-72">Name</DataTableColumnHeader>
+  <DataTableCell>{NameCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="description" grow={3}>
+  <DataTableColumnHeader className="min-w-80">Description</DataTableColumnHeader>
+  <DataTableCell>{DescriptionCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="versions">
+  <DataTableColumnHeader className="w-40">Versions</DataTableColumnHeader>
+  <DataTableCell>{VersionBadgesCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn field="updated">
+  <DataTableColumnHeader className="w-44">Updated</DataTableColumnHeader>
+  <DataTableCell>{UpdatedCell}</DataTableCell>
+</DataTableColumn>
+
+<DataTableColumn id="actions">
+  <DataTableColumnHeader className="w-16 justify-center">Actions</DataTableColumnHeader>
+  <DataTableCell>{ActionsCell}</DataTableCell>
+</DataTableColumn>
+```
+
+In this layout, `name` and `description` receive all extra width. `description` receives three times as much extra width as `name`. `versions`, `updated`, and `actions` keep their base widths.
+
+Choose grow columns from the local data and workflow. IDs, slugs, checkboxes, action menus, short labels, badges, version counts, timestamps, and compact metadata usually should not grow. Names, titles, descriptions, summaries, messages, notes, paths, and other text-heavy content usually benefit from extra room. The field name is only a clue: a short code-like `name` may be fixed, while a user-authored label column may deserve room.
+
+Do not make every column grow. The point of `grow` is to let useful text columns breathe while compact columns stay compact.
+
+## What Happens Without Grow
+
+Tables that do not set `grow` preserve the default auto-fill behavior: when the viewport is wider than the total base width, extra space is distributed evenly across visible columns. This keeps existing tables filling their container without changing every column declaration.
+
+Once any visible column has a positive finite `grow` value, only grow columns receive leftover width. Non-grow columns keep their base widths.
+
+## There Is No Shrink Prop
+
+`grow` only distributes extra space. It does not shrink columns below their base widths, and there is no `shrink` table API.
+
+When the viewport narrows, grow space disappears first. After the total base width no longer fits, the table keeps base widths and uses horizontal scrolling.
+
+## Resizing Grow Columns
+
+Column resizing sets the rendered width of that column. During and after a resize override, the table preserves the current rendered widths of the other columns instead of redistributing grow space on every pointer move. That keeps the resize handle under the pointer and lets wider columns push the table into horizontal overflow.
+
+Clear the resize override to return the column to its measured base width and the normal `grow` distribution.
+
+Persist resize overrides as user-selected widths, not as automatic grow output. The saved width is the user's explicit override; automatic grow space is recalculated only when no resize override is active for that layout.

--- a/skills/data-table/references/3.columns/index.md
+++ b/skills/data-table/references/3.columns/index.md
@@ -72,12 +72,15 @@ Omit the header to fall back to the field name; omit the cell to fall back to th
 
 `field` is both the cell lookup key (`row.data[field]`) and the column's persistent identity. Keep it stable across releases if you use any column features that save state — see [State Persistence](/data-table/state-persistence/#field-names-are-the-persistence-contract) for the rules around renaming.
 
+For layout, put base widths on `DataTableColumnHeader` and use `DataTableColumn grow={...}` only for columns that should absorb extra horizontal space. See [Column Layout](/data-table/columns/column-layout/) for the sizing model and guidance on choosing fixed vs growing columns from the data being displayed.
+
 ## Where to go next
 
 Declarative shape:
 
 - [Defining Columns](/data-table/columns/defining-columns/) — `field`, default rendering, declaration order, visibility, generated columns.
 - [Formatting Cells and Headers](/data-table/columns/cell-and-header-renderers/) — render params, extracted renderer functions, custom header content.
+- [Column Layout](/data-table/columns/column-layout/) — base widths, `grow` ratios, fixed metadata columns, and horizontal overflow.
 - [Column Groups](/data-table/columns/column-groups/) — wrap adjacent columns under a shared header.
 - [Sticky Columns](/data-table/columns/sticky-columns/) — pin a column to the left or right edge during horizontal scrolling.
 

--- a/skills/data-table/references/7.customization/01.styling.md
+++ b/skills/data-table/references/7.customization/01.styling.md
@@ -23,7 +23,7 @@ const model = localModel({ data: rows })
 
 export default function App() {
   return (
-    <DataTable className="rounded-xl border-2 border-slate-900/10 shadow-sm" model={model} style={{ height: 280 }}>
+    <DataTable model={model} style={{ height: 280 }}>
       <DataTableColumn field="name">
         <DataTableColumnHeader>Product</DataTableColumnHeader>
         <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
@@ -61,10 +61,22 @@ export default function App() {
 
 ## Wrapper-level styling
 
-`className` on `<DataTable>` reaches the outer frame around the scroll viewport. Use it for borders, rounded corners, shadow, and the table's overall background.
+`className` on `<DataTable>` reaches the outer frame around the scroll viewport. The shadcn wrapper already provides the default frame (`rounded-md border`) and table surface, so you do not need to repeat `rounded-md border` at each instance. Use wrapper classes for intentional frame overrides, shadows, and table-level CSS variable overrides.
 
 ```tsx
-<DataTable className="rounded-xl border bg-card shadow-sm" model={model}>
+<DataTable className="rounded-xl shadow-sm" model={model}>
+  {/* columns */}
+</DataTable>
+```
+
+To remove or strengthen the default frame, override it directly:
+
+```tsx
+<DataTable className="border-0" model={model}>
+  {/* columns */}
+</DataTable>
+
+<DataTable className="border-2" model={model}>
   {/* columns */}
 </DataTable>
 ```

--- a/skills/data-table/references/7.customization/04.scroll-containers.md
+++ b/skills/data-table/references/7.customization/04.scroll-containers.md
@@ -42,6 +42,40 @@ export default function App() {
 }
 ```
 
+## Fill available panel height
+
+For app pages where the table should consume the remaining space below fixed page chrome, keep the default internal table scroller and give the table a measured flex slot. This is usually better than guessing a pixel height.
+
+The important pieces are:
+
+- a parent with a real height, such as a route shell, panel, or card body
+- `min-h-0` on each flex ancestor between that measured parent and the table
+- `shrink-0` on controls above the table
+- `flex-1 min-h-0` on `DataTable`, plus `style={{ height: '100%' }}`
+
+```tsx
+export function OrdersPage() {
+  return (
+    <section className="flex h-full min-h-0 flex-col">
+      <PageHeader className="shrink-0" />
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3">
+        <Toolbar className="shrink-0" />
+
+        <DataTable className="min-h-0 flex-1" computeRowKey={({ data }) => data.id} model={model} style={{ height: '100%' }}>
+          <DataTableColumn field="name">
+            <DataTableColumnHeader>Order</DataTableColumnHeader>
+            <DataTableCell>{({ cellValue }) => String(cellValue)}</DataTableCell>
+          </DataTableColumn>
+        </DataTable>
+      </div>
+    </section>
+  )
+}
+```
+
+Use this pattern only when the parent is height-constrained. If the table lives in normal document flow, keep a fixed table height (`style={{ height: 360 }}`) or intentionally switch to `useWindowScroll` / `customScrollParent`.
+
 ## Window scrolling
 
 `useWindowScroll` makes the document viewport drive the table's scroll state:

--- a/skills/data-table/references/7.customization/07.shadcn-wrapper.md
+++ b/skills/data-table/references/7.customization/07.shadcn-wrapper.md
@@ -61,15 +61,15 @@ The default shadcn wrapper gives `DataTable` an app-level frame (`rounded-md bor
 
 The variables matter most for sticky headers and sticky columns: those pieces are separate overlay containers, so they need an opaque background, but that background should match the table body instead of being hardcoded independently.
 
-| Variable                     | Default                          | Used for                                           |
-| ---------------------------- | -------------------------------- | -------------------------------------------------- |
-| `--data-table-bg`            | `hsl(var(--background))`         | Table body, sticky header, sticky column wrappers  |
-| `--data-table-fg`            | `hsl(var(--foreground))`         | Default table/header/group-header text             |
-| `--data-table-border`        | `hsl(var(--border))`             | Row separators, header borders, loading containers |
-| `--data-table-muted`         | `hsl(var(--muted))`              | Group rows, skeleton rows, sticky hover blends     |
-| `--data-table-muted-fg`      | `hsl(var(--muted-foreground))`   | Loading and secondary wrapper text                 |
-| `--data-table-row-hover`     | `hsl(var(--muted) / 0.5)`        | Non-sticky row hover background                    |
-| `--data-table-sticky-hover`  | a mix of muted and table bg      | Sticky column hover background                     |
+| Variable                    | Default                        | Used for                                           |
+| --------------------------- | ------------------------------ | -------------------------------------------------- |
+| `--data-table-bg`           | `hsl(var(--background))`       | Table body, sticky header, sticky column wrappers  |
+| `--data-table-fg`           | `hsl(var(--foreground))`       | Default table/header/group-header text             |
+| `--data-table-border`       | `hsl(var(--border))`           | Row separators, header borders, loading containers |
+| `--data-table-muted`        | `hsl(var(--muted))`            | Group rows, skeleton rows, sticky hover blends     |
+| `--data-table-muted-fg`     | `hsl(var(--muted-foreground))` | Loading and secondary wrapper text                 |
+| `--data-table-row-hover`    | `hsl(var(--muted) / 0.5)`      | Non-sticky row hover background                    |
+| `--data-table-sticky-hover` | a mix of muted and table bg    | Sticky column hover background                     |
 
 If your app maps shadcn tokens to a different design system, override these variables once on the `DataTable` root or in the copied wrapper defaults. Do not style sticky cells individually just to fix a surface mismatch.
 

--- a/skills/data-table/references/7.customization/07.shadcn-wrapper.md
+++ b/skills/data-table/references/7.customization/07.shadcn-wrapper.md
@@ -23,7 +23,7 @@ const model = localModel({ data: rows })
 
 export default function App() {
   return (
-    <DataTable className="rounded-xl border-2 border-border/70 shadow-sm" model={model} style={{ height: 280 }}>
+    <DataTable model={model} style={{ height: 280 }}>
       <DataTableColumn field="product">
         <DataTableColumnHeader>Product</DataTableColumnHeader>
         <DataTableCell className="font-medium">{({ cellValue }) => String(cellValue)}</DataTableCell>
@@ -49,10 +49,42 @@ The wrapper covers _presentation_:
 
 - default row, header, sticky-column, empty, and loading components
 - Tailwind classes for cells, headers, and group headers
+- the default table frame (`rounded-md border`) and table surface variables
 - ergonomic names (`DataTable`, `DataTableColumn`, `DataTableColumnHeader`, `DataTableCell`)
 - re-exports of the headless hooks and helpers you'll use day-to-day
 
 Edit it like any other component in your app. Tailwind classes, default props, alternate variants, additional re-exports — all fair game. The wrapper file imports behavior from `@virtuoso.dev/data-table`, so your styling edits never fork table mechanics.
+
+## Table surface variables
+
+The default shadcn wrapper gives `DataTable` an app-level frame (`rounded-md border`) and defines a small set of CSS variables on the same root. The frame border uses `--data-table-border`; callers do not need to add `rounded-md border` at each table instance. Use `className` only for intentional overrides such as `rounded-xl`, `border-0`, `border-2`, `shadow-sm`, or table variable overrides.
+
+The variables matter most for sticky headers and sticky columns: those pieces are separate overlay containers, so they need an opaque background, but that background should match the table body instead of being hardcoded independently.
+
+| Variable                     | Default                          | Used for                                           |
+| ---------------------------- | -------------------------------- | -------------------------------------------------- |
+| `--data-table-bg`            | `hsl(var(--background))`         | Table body, sticky header, sticky column wrappers  |
+| `--data-table-fg`            | `hsl(var(--foreground))`         | Default table/header/group-header text             |
+| `--data-table-border`        | `hsl(var(--border))`             | Row separators, header borders, loading containers |
+| `--data-table-muted`         | `hsl(var(--muted))`              | Group rows, skeleton rows, sticky hover blends     |
+| `--data-table-muted-fg`      | `hsl(var(--muted-foreground))`   | Loading and secondary wrapper text                 |
+| `--data-table-row-hover`     | `hsl(var(--muted) / 0.5)`        | Non-sticky row hover background                    |
+| `--data-table-sticky-hover`  | a mix of muted and table bg      | Sticky column hover background                     |
+
+If your app maps shadcn tokens to a different design system, override these variables once on the `DataTable` root or in the copied wrapper defaults. Do not style sticky cells individually just to fix a surface mismatch.
+
+```tsx
+<DataTable
+  className="
+    [--data-table-bg:hsl(var(--surface-container-lowest))]
+    [--data-table-fg:hsl(var(--on-surface))]
+    [--data-table-border:hsl(var(--outline))]
+    [--data-table-muted:hsl(var(--surface-container-low))]
+    [--data-table-muted-fg:hsl(var(--on-surface-variant))]
+  "
+  model={model}
+/>
+```
 
 ## What the headless package owns
 
@@ -79,6 +111,7 @@ Each one is header-slot UI you can restyle. The streams they publish to live in 
 The wrapper is the right place to change:
 
 - default Tailwind classes on `DataTable`, `DataTableCell`, `DataTableColumnHeader`
+- the default table frame, radius, border, and surface variables
 - the default `Row`, `EmptyPlaceholder`, `LoadingPlaceholder` your team should see
 - ergonomic re-exports you add for your codebase
 

--- a/skills/data-table/references/8.examples/16.remote-column-sorting.md
+++ b/skills/data-table/references/8.examples/16.remote-column-sorting.md
@@ -5,7 +5,7 @@ sidebar:
   label: Remote Sorting
 ---
 
-Each sortable column header sends a `sort` action to the remote model. The action updates the request params, the model refetches from the first page, and the active header button reads the current sort from `modelActionState$`.
+Each sortable column header sends a `sort` action to the remote model. The action updates the request params, the model refetches from the first page, and the active header button reads the current sort from `modelActionState$`. Do not keep a second `sortBy` / `sortOrder` React state just to paint the header; seed the model with `initialActions` for a default sort and let `modelActionState$` be the source of truth.
 
 The shadcn `SortHeaderButton` defaults to a payload shaped as `{ field, direction }`, where `direction` cycles through `'asc'`, `'desc'`, and no sort.
 
@@ -15,6 +15,8 @@ The shadcn `SortHeaderButton` defaults to a payload shaped as `{ field, directio
 - `SortHeaderButton` — shadcn slot component for column-header sorting
 - `HeaderEnd` — places the sort button after the header label
 - `computeRowKey` — keeps row identity stable when sorting reorders rows
+- `initialActions` — seeds the active sort in model action state
+- `modelStatePersistenceAdapter()` — optionally persists the sort action payload across reloads
 
 ```tsx live wide file=App.tsx
 import { useState } from 'react'
@@ -22,22 +24,28 @@ import { useState } from 'react'
 import { DataTable, DataTableCell, DataTableColumn, DataTableColumnHeader, HeaderEnd } from '@/components/ui/data-table'
 import { SortHeaderButton } from '@/components/ui/data-table/column-sort'
 import { defaultOffsetViewportHandler, remoteModel } from '@virtuoso.dev/data-table'
+import { DataTableStatePersistence, modelStatePersistenceAdapter } from '@virtuoso.dev/data-table/state-persistence'
 
 import { fetchProducts, placeholder } from './api'
 
 import type { Product, Query } from './api'
+
+const defaultSort = { field: 'name', direction: 'asc' } satisfies NonNullable<Query['sort']>
+const persistenceAdapters = [modelStatePersistenceAdapter()]
 
 export default function App() {
   const [model] = useState(() =>
     remoteModel<Product, Query>({
       actions: {
         sort: {
+          persistence: true,
           strategy: 'supersede',
           handler: ({ params, payload }) => ({ ...params, sort: payload as Query['sort'] }),
         },
       },
       fetch: fetchProducts,
-      initialParams: {},
+      initialActions: [{ action: 'sort', payload: defaultSort }],
+      initialParams: { sort: defaultSort },
       onViewportChange: defaultOffsetViewportHandler,
       pageSize: 40,
       placeholder,
@@ -46,6 +54,8 @@ export default function App() {
 
   return (
     <DataTable className="rounded-xl" computeRowKey={({ data }) => data.id} model={model} style={{ height: 420 }}>
+      <DataTableStatePersistence adapters={persistenceAdapters} storageKey="remote-column-sorting-example" />
+
       <DataTableColumn field="name">
         <DataTableColumnHeader>
           <HeaderEnd component={SortHeaderButton} />


### PR DESCRIPTION
## What changed

- Added column-level grow sizing so selected data-table columns can absorb spare viewport width by ratio while compact columns keep their measured base widths.
- Fixed header end-slot positioning so sortable header buttons stay aligned to the rendered edge of grown columns.
- Added Ladle/browser coverage for grow-column layouts, including a shadcn sortable table story for inspecting sort icon placement.
- Updated the shadcn registry wrapper and docs/skill guidance around wrapper-owned styling surfaces, flex-height layouts, explicit display-column headers, and model-owned sort/filter/search state.
- Updated the changeset for the data-table minor release.

## Why

Wide table viewports exposed a mismatch between measured header width and rendered grown-column width. Header controls such as sorting appeared at the measured-content boundary instead of the actual column boundary. The branch teaches the table about explicit grow ratios and adjusts header end slots to account for the realized column width.

## Validation

- pnpm --filter @virtuoso.dev/data-table typecheck
- pnpm --filter @virtuoso.dev/data-table lint
- pnpm --filter @virtuoso.dev/data-table exec vitest run --browser.headless src/columns/tests/browser/column-grow-layout.test.tsx
- pnpm dev:build from packages/data-table
- pnpm lint:md
- pnpm validate:skills
- pnpm --filter @virtuoso.dev/virtuoso.dev lint
- pnpm changeset status --since 0af9e75b334fdd5076bbd2f0cc7a7c99eba95c63