### PR TITLE
Fix invalid React Virtuoso skill examples

### DIFF
--- a/.changeset/quiet-virtuosos-scroll.md
+++ b/.changeset/quiet-virtuosos-scroll.md
@@ -1,0 +1,5 @@
+---
+'@virtuoso.dev/virtuoso-skills': patch
+---
+
+Correct invalid prepend and grouped-list examples in the React Virtuoso agent skill.

--- a/packages/react-virtuoso/docs/2.grouped-virtuoso/grouped-with-load-on-demand.md
+++ b/packages/react-virtuoso/docs/2.grouped-virtuoso/grouped-with-load-on-demand.md
@@ -45,12 +45,12 @@ export default function App() {
   const calculateGroupsSoFar = useCallback((totalGroups, count) => {
     const groups = []
     let i = 0
-    do {
+    while (count > 0 && i < totalGroups.length) {
       const group = totalGroups[i]
       groups.push(Math.min(group, count))
       count -= group
       i++
-    } while (count > 0 && i <= totalGroups.length)
+    }
     return groups
   }, [])
 

--- a/packages/react-virtuoso/docs/2.grouped-virtuoso/scroll-to-group.md
+++ b/packages/react-virtuoso/docs/2.grouped-virtuoso/scroll-to-group.md
@@ -23,10 +23,10 @@ export default function App() {
       }))
     })
 
-    const groups = letters.slice(0, 15)
+    const groups = letters
 
-    const groupCounts = letters.map((letter, index) => {
-      return users.filter((user, userIndex) => user.name.startsWith(letter)).length
+    const groupCounts = groups.map((letter) => {
+      return users.filter((user) => user.name.startsWith(letter)).length
     })
     return { users, groups, groupCounts }
   }, [])

--- a/packages/virtuoso-skills/skills/react-virtuoso/SKILL.md
+++ b/packages/virtuoso-skills/skills/react-virtuoso/SKILL.md
@@ -66,12 +66,20 @@ Prepending naively makes the list jump. Instead, keep a `firstItemIndex` that yo
 ```tsx
 const [firstItemIndex, setFirstItemIndex] = useState(START)
 
-const prepend = (older: Item[]) => {
+const prepend = async () => {
+  const older = await fetchOlderItems()
   setFirstItemIndex((i) => i - older.length)
   setItems((current) => [...older, ...current])
 }
 
-<Virtuoso firstItemIndex={firstItemIndex} initialTopMostItemIndex={START} data={items} startReached={prepend} ... />
+<Virtuoso
+  computeItemKey={(_, item) => item.id}
+  data={items}
+  firstItemIndex={firstItemIndex}
+  initialTopMostItemIndex={{ index: 'LAST' }}
+  startReached={() => void prepend()}
+  ...
+/>
 ```
 
 `firstItemIndex` must stay a positive number, so start it large (e.g. `100000`). For `GroupedVirtuoso`, decrease it by the number of new items only, excluding the group headers. See [endless-scrolling](references/1.virtuoso/endless-scrolling.md).

--- a/packages/virtuoso-skills/skills/react-virtuoso/references/2.grouped-virtuoso/grouped-with-load-on-demand.md
+++ b/packages/virtuoso-skills/skills/react-virtuoso/references/2.grouped-virtuoso/grouped-with-load-on-demand.md
@@ -45,12 +45,12 @@ export default function App() {
   const calculateGroupsSoFar = useCallback((totalGroups, count) => {
     const groups = []
     let i = 0
-    do {
+    while (count > 0 && i < totalGroups.length) {
       const group = totalGroups[i]
       groups.push(Math.min(group, count))
       count -= group
       i++
-    } while (count > 0 && i <= totalGroups.length)
+    }
     return groups
   }, [])
 

--- a/packages/virtuoso-skills/skills/react-virtuoso/references/2.grouped-virtuoso/scroll-to-group.md
+++ b/packages/virtuoso-skills/skills/react-virtuoso/references/2.grouped-virtuoso/scroll-to-group.md
@@ -23,10 +23,10 @@ export default function App() {
       }))
     })
 
-    const groups = letters.slice(0, 15)
+    const groups = letters
 
-    const groupCounts = letters.map((letter, index) => {
-      return users.filter((user, userIndex) => user.name.startsWith(letter)).length
+    const groupCounts = groups.map((letter) => {
+      return users.filter((user) => user.name.startsWith(letter)).length
     })
     return { users, groups, groupCounts }
   }, [])

--- a/plugins/virtuoso-skills/skills/react-virtuoso/SKILL.md
+++ b/plugins/virtuoso-skills/skills/react-virtuoso/SKILL.md
@@ -66,12 +66,20 @@ Prepending naively makes the list jump. Instead, keep a `firstItemIndex` that yo
 ```tsx
 const [firstItemIndex, setFirstItemIndex] = useState(START)
 
-const prepend = (older: Item[]) => {
+const prepend = async () => {
+  const older = await fetchOlderItems()
   setFirstItemIndex((i) => i - older.length)
   setItems((current) => [...older, ...current])
 }
 
-<Virtuoso firstItemIndex={firstItemIndex} initialTopMostItemIndex={START} data={items} startReached={prepend} ... />
+<Virtuoso
+  computeItemKey={(_, item) => item.id}
+  data={items}
+  firstItemIndex={firstItemIndex}
+  initialTopMostItemIndex={{ index: 'LAST' }}
+  startReached={() => void prepend()}
+  ...
+/>
 ```
 
 `firstItemIndex` must stay a positive number, so start it large (e.g. `100000`). For `GroupedVirtuoso`, decrease it by the number of new items only, excluding the group headers. See [endless-scrolling](references/1.virtuoso/endless-scrolling.md).

--- a/plugins/virtuoso-skills/skills/react-virtuoso/references/2.grouped-virtuoso/grouped-with-load-on-demand.md
+++ b/plugins/virtuoso-skills/skills/react-virtuoso/references/2.grouped-virtuoso/grouped-with-load-on-demand.md
@@ -45,12 +45,12 @@ export default function App() {
   const calculateGroupsSoFar = useCallback((totalGroups, count) => {
     const groups = []
     let i = 0
-    do {
+    while (count > 0 && i < totalGroups.length) {
       const group = totalGroups[i]
       groups.push(Math.min(group, count))
       count -= group
       i++
-    } while (count > 0 && i <= totalGroups.length)
+    }
     return groups
   }, [])
 

--- a/plugins/virtuoso-skills/skills/react-virtuoso/references/2.grouped-virtuoso/scroll-to-group.md
+++ b/plugins/virtuoso-skills/skills/react-virtuoso/references/2.grouped-virtuoso/scroll-to-group.md
@@ -23,10 +23,10 @@ export default function App() {
       }))
     })
 
-    const groups = letters.slice(0, 15)
+    const groups = letters
 
-    const groupCounts = letters.map((letter, index) => {
-      return users.filter((user, userIndex) => user.name.startsWith(letter)).length
+    const groupCounts = groups.map((letter) => {
+      return users.filter((user) => user.name.startsWith(letter)).length
     })
     return { users, groups, groupCounts }
   }, [])

--- a/skills/react-virtuoso/SKILL.md
+++ b/skills/react-virtuoso/SKILL.md
@@ -66,12 +66,20 @@ Prepending naively makes the list jump. Instead, keep a `firstItemIndex` that yo
 ```tsx
 const [firstItemIndex, setFirstItemIndex] = useState(START)
 
-const prepend = (older: Item[]) => {
+const prepend = async () => {
+  const older = await fetchOlderItems()
   setFirstItemIndex((i) => i - older.length)
   setItems((current) => [...older, ...current])
 }
 
-<Virtuoso firstItemIndex={firstItemIndex} initialTopMostItemIndex={START} data={items} startReached={prepend} ... />
+<Virtuoso
+  computeItemKey={(_, item) => item.id}
+  data={items}
+  firstItemIndex={firstItemIndex}
+  initialTopMostItemIndex={{ index: 'LAST' }}
+  startReached={() => void prepend()}
+  ...
+/>
 ```
 
 `firstItemIndex` must stay a positive number, so start it large (e.g. `100000`). For `GroupedVirtuoso`, decrease it by the number of new items only, excluding the group headers. See [endless-scrolling](references/1.virtuoso/endless-scrolling.md).

--- a/skills/react-virtuoso/references/2.grouped-virtuoso/grouped-with-load-on-demand.md
+++ b/skills/react-virtuoso/references/2.grouped-virtuoso/grouped-with-load-on-demand.md
@@ -45,12 +45,12 @@ export default function App() {
   const calculateGroupsSoFar = useCallback((totalGroups, count) => {
     const groups = []
     let i = 0
-    do {
+    while (count > 0 && i < totalGroups.length) {
       const group = totalGroups[i]
       groups.push(Math.min(group, count))
       count -= group
       i++
-    } while (count > 0 && i <= totalGroups.length)
+    }
     return groups
   }, [])
 

--- a/skills/react-virtuoso/references/2.grouped-virtuoso/scroll-to-group.md
+++ b/skills/react-virtuoso/references/2.grouped-virtuoso/scroll-to-group.md
@@ -23,10 +23,10 @@ export default function App() {
       }))
     })
 
-    const groups = letters.slice(0, 15)
+    const groups = letters
 
-    const groupCounts = letters.map((letter, index) => {
-      return users.filter((user, userIndex) => user.name.startsWith(letter)).length
+    const groupCounts = groups.map((letter) => {
+      return users.filter((user) => user.name.startsWith(letter)).length
     })
     return { users, groups, groupCounts }
   }, [])


### PR DESCRIPTION
## Summary

- fetch older items inside the `startReached` handler instead of treating its numeric index argument as item data
- use a stable item key and an explicit last-item initial position for prepend examples
- keep grouped-list labels and `groupCounts` aligned
- bound grouped load slicing to the available counts
- regenerate the packaged, root, and Codex skill mirrors
- add a patch changeset for `@virtuoso.dev/virtuoso-skills`

## Why

The distributed React Virtuoso skill contained examples that could throw at runtime, render undefined group labels, or produce `NaN` group counts. The prepend example also mixed the logical `firstItemIndex` offset with the relative initial item position and omitted the stable key required when items move.

## Impact

Readers and coding agents now get safe, internally consistent examples for reverse infinite scrolling and grouped lists.

## Validation

- `pnpm build:skills`
- `pnpm lint:md`
- `pnpm validate:skills`
- `pnpm format:check`
- focused grouped-count invariant checks for zero, partial, exact-limit, and over-limit loads
