### PR TITLE
fix: handle dynamic horizontal direction changes

### DIFF
--- a/.changeset/tidy-tools-smile.md
+++ b/.changeset/tidy-tools-smile.md
@@ -1,0 +1,5 @@
+---
+'react-virtuoso': patch
+---
+
+Handle horizontal list direction changes between LTR and RTL without remounting the list.

--- a/packages/react-virtuoso/e2e/horizontal-rtl.test.ts
+++ b/packages/react-virtuoso/e2e/horizontal-rtl.test.ts
@@ -56,17 +56,22 @@ test.describe('horizontal list with a dynamic direction', () => {
     await navigateToExample(page, baseURL, 'horizontal-dynamic-direction')
   })
 
-  test('updates logical offsets after switching from ltr to rtl', async ({ page }) => {
+  test('updates logical and physical offsets when the direction changes', async ({ page }) => {
     const scroller = page.locator('[data-testid=virtuoso-scroller]')
 
     await expect(page.locator('[data-testid=direction]')).toHaveText('ltr')
     await page.click('#toggle-direction')
     await expect(page.locator('[data-testid=direction]')).toHaveText('rtl')
 
-    await scroller.evaluate((element) => {
-      element.scrollLeft = -1000
-    })
+    await page.click('#start-20')
+    await expect(page.locator('[data-testid=range]')).toHaveText('20-25')
+    expect(await scroller.evaluate((element) => element.scrollLeft)).toBeLessThan(0)
 
+    await page.click('#toggle-direction')
+    await expect(page.locator('[data-testid=direction]')).toHaveText('ltr')
+
+    await page.click('#start-10')
     await expect(page.locator('[data-testid=range]')).toHaveText('10-15')
+    expect(await scroller.evaluate((element) => element.scrollLeft)).toBeGreaterThan(0)
   })
 })

--- a/packages/react-virtuoso/e2e/horizontal-rtl.test.ts
+++ b/packages/react-virtuoso/e2e/horizontal-rtl.test.ts
@@ -50,3 +50,23 @@ test.describe('horizontal list in rtl', () => {
     expectClosePosition(position.itemLeft, position.scrollerLeft)
   })
 })
+
+test.describe('horizontal list with a dynamic direction', () => {
+  test.beforeEach(async ({ baseURL, page }) => {
+    await navigateToExample(page, baseURL, 'horizontal-dynamic-direction')
+  })
+
+  test('updates logical offsets after switching from ltr to rtl', async ({ page }) => {
+    const scroller = page.locator('[data-testid=virtuoso-scroller]')
+
+    await expect(page.locator('[data-testid=direction]')).toHaveText('ltr')
+    await page.click('#toggle-direction')
+    await expect(page.locator('[data-testid=direction]')).toHaveText('rtl')
+
+    await scroller.evaluate((element) => {
+      element.scrollLeft = -1000
+    })
+
+    await expect(page.locator('[data-testid=range]')).toHaveText('10-15')
+  })
+})

--- a/packages/react-virtuoso/examples/horizontal-dynamic-direction.tsx
+++ b/packages/react-virtuoso/examples/horizontal-dynamic-direction.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+
+import { Virtuoso } from '../src'
+
+import type { ListRange } from '../src'
+
+const itemStyle: React.CSSProperties = {
+  alignItems: 'center',
+  background: '#e8edf5',
+  border: '1px solid #aeb7c6',
+  boxSizing: 'border-box',
+  display: 'flex',
+  height: '100%',
+  justifyContent: 'center',
+  width: 100,
+}
+
+export function Example() {
+  const [direction, setDirection] = React.useState<'ltr' | 'rtl'>('ltr')
+  const [range, setRange] = React.useState<ListRange>({ endIndex: 0, startIndex: 0 })
+
+  return (
+    <div style={{ height: 160, width: 520 }}>
+      <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+        <button id="toggle-direction" onClick={() => setDirection((current) => (current === 'ltr' ? 'rtl' : 'ltr'))}>
+          Toggle direction
+        </button>
+        <span data-testid="direction">{direction}</span>
+        <span data-testid="range">
+          {range.startIndex}-{range.endIndex}
+        </span>
+      </div>
+      <Virtuoso
+        computeItemKey={(key: number) => `item-${key.toString()}`}
+        horizontalDirection
+        itemContent={(index) => <div style={itemStyle}>Item {index}</div>}
+        rangeChanged={setRange}
+        style={{ direction, height: 100, width: '100%' }}
+        totalCount={100}
+      />
+    </div>
+  )
+}

--- a/packages/react-virtuoso/examples/horizontal-dynamic-direction.tsx
+++ b/packages/react-virtuoso/examples/horizontal-dynamic-direction.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { Virtuoso } from '../src'
 
-import type { ListRange } from '../src'
+import type { ListRange, VirtuosoHandle } from '../src'
 
 const itemStyle: React.CSSProperties = {
   alignItems: 'center',
@@ -16,6 +16,7 @@ const itemStyle: React.CSSProperties = {
 }
 
 export function Example() {
+  const virtuosoRef = React.useRef<VirtuosoHandle>(null)
   const [direction, setDirection] = React.useState<'ltr' | 'rtl'>('ltr')
   const [range, setRange] = React.useState<ListRange>({ endIndex: 0, startIndex: 0 })
 
@@ -24,6 +25,12 @@ export function Example() {
       <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
         <button id="toggle-direction" onClick={() => setDirection((current) => (current === 'ltr' ? 'rtl' : 'ltr'))}>
           Toggle direction
+        </button>
+        <button id="start-10" onClick={() => virtuosoRef.current!.scrollToIndex({ align: 'start', index: 10 })}>
+          Start at 10
+        </button>
+        <button id="start-20" onClick={() => virtuosoRef.current!.scrollToIndex({ align: 'start', index: 20 })}>
+          Start at 20
         </button>
         <span data-testid="direction">{direction}</span>
         <span data-testid="range">
@@ -35,6 +42,7 @@ export function Example() {
         horizontalDirection
         itemContent={(index) => <div style={itemStyle}>Item {index}</div>}
         rangeChanged={setRange}
+        ref={virtuosoRef}
         style={{ direction, height: 100, width: '100%' }}
         totalCount={100}
       />

--- a/packages/react-virtuoso/src/hooks/useScrollTop.ts
+++ b/packages/react-virtuoso/src/hooks/useScrollTop.ts
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom'
 import * as u from '../urx'
 import { approximatelyEqual } from '../utils/approximatelyEqual'
 import { correctItemSize } from '../utils/correctItemSize'
-import { clearHorizontalScrollDirectionCache, getLogicalScrollLeft, getPhysicalScrollLeft } from '../utils/horizontalScroll'
+import { getLogicalScrollLeft, getPhysicalScrollLeft } from '../utils/horizontalScroll'
 
 import type { ScrollContainerState } from '../interfaces'
 
@@ -84,13 +84,11 @@ export default function useScrollTop(
   React.useEffect(() => {
     const localRef = customScrollParent ?? scrollerRef.current!
 
-    clearHorizontalScrollDirectionCache(localRef)
     scrollerRefCallback(customScrollParent ?? scrollerRef.current)
     handler({ suppressFlushSync: true, target: localRef } as unknown as Event)
     localRef.addEventListener('scroll', handler, { passive: true })
 
     return () => {
-      clearHorizontalScrollDirectionCache(localRef)
       scrollerRefCallback(null)
       localRef.removeEventListener('scroll', handler)
     }

--- a/packages/react-virtuoso/src/utils/horizontalScroll.ts
+++ b/packages/react-virtuoso/src/utils/horizontalScroll.ts
@@ -1,33 +1,18 @@
-const cachedRtlElements = new WeakMap<HTMLElement, boolean>()
-
 function scrollerElement(scroller: HTMLElement | Window) {
   return 'self' in scroller ? scroller.document.documentElement : scroller
 }
 
 function isRtl(scroller: HTMLElement | Window) {
   const element = scrollerElement(scroller)
-  const cached = cachedRtlElements.get(element)
-
-  if (cached !== undefined) {
-    return cached
-  }
-
-  const value = element.ownerDocument.defaultView!.getComputedStyle(element).direction === 'rtl'
-  cachedRtlElements.set(element, value)
-  return value
+  return element.ownerDocument.defaultView!.getComputedStyle(element).direction === 'rtl'
 }
 
-export function clearHorizontalScrollDirectionCache(scroller: HTMLElement | Window) {
-  cachedRtlElements.delete(scrollerElement(scroller))
-}
-
-function convertHorizontalScrollLeft(scroller: HTMLElement | Window, scrollLeft: number) {
+export function getLogicalScrollLeft(_scroller: HTMLElement | Window, scrollLeft: number) {
   // Supported browsers expose RTL horizontal scrolling as 0 at the right edge
-  // and negative values while scrolling left, making the conversion symmetric.
-  return isRtl(scroller) ? -scrollLeft : scrollLeft
+  // and negative values while scrolling left.
+  return Math.abs(scrollLeft)
 }
 
-export const getLogicalScrollLeft = convertHorizontalScrollLeft
 export function getPhysicalScrollLeft(scroller: HTMLElement | Window, scrollLeft: number) {
-  return convertHorizontalScrollLeft(scroller, scrollLeft)
+  return isRtl(scroller) ? -scrollLeft : scrollLeft
 }

--- a/packages/react-virtuoso/src/utils/horizontalScroll.ts
+++ b/packages/react-virtuoso/src/utils/horizontalScroll.ts
@@ -7,10 +7,12 @@ function isRtl(scroller: HTMLElement | Window) {
   return element.ownerDocument.defaultView!.getComputedStyle(element).direction === 'rtl'
 }
 
-export function getLogicalScrollLeft(_scroller: HTMLElement | Window, scrollLeft: number) {
+export function getLogicalScrollLeft(scroller: HTMLElement | Window, scrollLeft: number) {
   // Supported browsers expose RTL horizontal scrolling as 0 at the right edge
-  // and negative values while scrolling left.
-  return Math.abs(scrollLeft)
+  // and negative values while scrolling left. Safari can expose values beyond
+  // the normal range during elastic overscroll, so the direction is required
+  // to distinguish those values from regular RTL offsets.
+  return isRtl(scroller) ? -scrollLeft : scrollLeft
 }
 
 export function getPhysicalScrollLeft(scroller: HTMLElement | Window, scrollLeft: number) {

--- a/packages/react-virtuoso/test/horizontalScroll.test.ts
+++ b/packages/react-virtuoso/test/horizontalScroll.test.ts
@@ -3,10 +3,20 @@ import { describe, expect, it } from 'vitest'
 import { getLogicalScrollLeft, getPhysicalScrollLeft } from '../src/utils/horizontalScroll'
 
 describe('horizontal scroll direction', () => {
-  it('normalizes negative rtl offsets', () => {
+  it('uses the current computed direction for logical offsets', () => {
     const scroller = document.createElement('div')
+    scroller.style.direction = 'ltr'
+    document.body.append(scroller)
+
+    expect(getLogicalScrollLeft(scroller, 10)).toBe(10)
+    expect(getLogicalScrollLeft(scroller, -10)).toBe(-10)
+
+    scroller.style.direction = 'rtl'
 
     expect(getLogicalScrollLeft(scroller, -10)).toBe(10)
+    expect(getLogicalScrollLeft(scroller, 10)).toBe(-10)
+
+    scroller.remove()
   })
 
   it('uses the current computed direction for physical offsets', () => {

--- a/packages/react-virtuoso/test/horizontalScroll.test.ts
+++ b/packages/react-virtuoso/test/horizontalScroll.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { getLogicalScrollLeft, getPhysicalScrollLeft } from '../src/utils/horizontalScroll'
+
+describe('horizontal scroll direction', () => {
+  it('normalizes negative rtl offsets', () => {
+    const scroller = document.createElement('div')
+
+    expect(getLogicalScrollLeft(scroller, -10)).toBe(10)
+  })
+
+  it('uses the current computed direction for physical offsets', () => {
+    const scroller = document.createElement('div')
+    scroller.style.direction = 'ltr'
+    document.body.append(scroller)
+
+    expect(getPhysicalScrollLeft(scroller, 10)).toBe(10)
+
+    scroller.style.direction = 'rtl'
+
+    expect(getPhysicalScrollLeft(scroller, 10)).toBe(-10)
+    scroller.remove()
+  })
+})


### PR DESCRIPTION
## Summary

- normalize browser-native negative RTL offsets without relying on a cached direction
- read the current computed direction when translating logical offsets for imperative scrolling
- add unit and browser regression coverage for changing a horizontal list from LTR to RTL
- include a patch changeset for react-virtuoso

Fixes #1407

## Testing

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (196 passed, 4 skipped)
- `pnpm build`
- `pnpm e2e` (42 passed, 1 skipped)
