### PR TITLE
fix: clamp initialItemCount to data length when data prop is used

### DIFF
--- a/.changeset/clamp-initial-item-count.md
+++ b/.changeset/clamp-initial-item-count.md
@@ -1,0 +1,5 @@
+---
+'react-virtuoso': patch
+---
+
+Fixed "Zero-sized element, this should not happen" error when `initialItemCount` exceeds `data.length`. The initial list state builder now clamps the item count to the data array length when the `data` prop is used, preventing phantom items with `undefined` data from being rendered.

--- a/packages/react-virtuoso/src/listStateSystem.ts
+++ b/packages/react-virtuoso/src/listStateSystem.ts
@@ -109,7 +109,7 @@ export function buildListStateFromItemCount(
     }
   }
 
-  const adjustedCount = itemCount + includedGroupsCount
+  const adjustedCount = data.length > 0 ? Math.min(itemCount + includedGroupsCount, data.length) : itemCount + includedGroupsCount
   const initialTopMostItemIndexNumber = getInitialTopMostItemIndexNumber(initialTopMostItemIndex, adjustedCount)
 
   const items = Array.from({ length: adjustedCount }).map((_, index) => ({

--- a/packages/react-virtuoso/test/listSystem.test.ts
+++ b/packages/react-virtuoso/test/listSystem.test.ts
@@ -45,6 +45,18 @@ describe('list engine', () => {
       expect(getValue(listState).items).toHaveLength(10)
     })
 
+    it('clamps initialItemCount to data length when data has fewer items', () => {
+      const { data, initialItemCount, listState, propsReady } = init(listSystem)
+
+      publish(data, ['a', 'b', 'c'])
+      publish(initialItemCount, 10)
+      publish(propsReady, true)
+
+      const items = getValue(listState).items
+      expect(items).toHaveLength(3)
+      expect(items.every((item) => item.data !== undefined)).toBe(true)
+    })
+
     it('returns the full set if a fixed item height is set', () => {
       const { fixedItemHeight, listState, propsReady, scrollTop, totalCount, viewportHeight } = init(listSystem)
 


### PR DESCRIPTION
## Bug

When `initialItemCount` exceeds `data.length`, `buildListStateFromItemCount` creates phantom items with `data: undefined`. These phantom items produce zero-height DOM elements, triggering the "Zero-sized element, this should not happen" console error for each one.

### Reproduction

```tsx
<Virtuoso
  data={["A", "B", "C"]}       // 3 items
  initialItemCount={10}          // greater than data.length
  itemContent={(index, item) => <div>{item ?? "undefined!"}</div>}
  style={{ height: 400 }}
/>
```

Console shows `Zero-sized element, this should not happen {child: div}` repeated 7 times (10 - 3 = 7 phantom items).

### Root cause

In `buildListStateFromItemCount` (`listStateSystem.ts`), the item count is not clamped to the data array length:

```typescript
const adjustedCount = itemCount + includedGroupsCount
// adjustedCount can exceed data.length ^^^
const items = Array.from({ length: adjustedCount }).map((_, index) => ({
    data: data[index + initialTopMostItemIndexNumber],
    // ^^^ accesses indices beyond data.length → undefined
    ...
}))
```

### Fix

Clamp `adjustedCount` to `data.length` when the `data` prop is provided (non-empty array):

```typescript
const adjustedCount = data.length > 0
  ? Math.min(itemCount + includedGroupsCount, data.length)
  : itemCount + includedGroupsCount
```

When `data` is not used (`totalCount`-only mode, where `data` defaults to `[]`), the existing behavior is preserved.

### Relation to #1060

This is a **separate code path** from the issue fixed in #1061. That PR addressed a `ResizeObserver` timing issue in `useSize`. This fix addresses `buildListStateFromItemCount` never clamping to `data.length` — a bug that was present before and after #1061. The continued reports on #1060 (e.g., [this comment](https://github.com/petyosi/react-virtuoso/issues/1060#issuecomment-2380658329) on v4.8.0+) suggest this code path was the remaining unfixed cause.

### Test added

Added a test in `listSystem.test.ts` verifying that `initialItemCount` is clamped to `data.length` and no items have `undefined` data.