### PR TITLE
fix: clamp out-of-range VirtuosoGrid scrollToIndex to the last item

### DIFF
--- a/.changeset/clamp-grid-scroll-to-index.md
+++ b/.changeset/clamp-grid-scroll-to-index.md
@@ -1,0 +1,5 @@
+---
+"react-virtuoso": patch
+---
+
+Clamp out-of-range `VirtuosoGrid` `scrollToIndex` targets to the last available item.

--- a/packages/react-virtuoso/src/gridSystem.ts
+++ b/packages/react-virtuoso/src/gridSystem.ts
@@ -379,7 +379,7 @@ export const gridSystem = /*#__PURE__*/ u.system(
             index = totalCount - 1
           }
 
-          index = max(0, index, min(totalCount - 1, index))
+          index = max(0, min(totalCount - 1, index))
 
           let top = itemTop(viewportDimensions, gap, itemDimensions, index)
 

--- a/packages/react-virtuoso/test/gridSystem.test.ts
+++ b/packages/react-virtuoso/test/gridSystem.test.ts
@@ -185,6 +185,34 @@ describe('grid system', () => {
     expect(items[items.length - 1]!.index).toBe(11)
   })
 
+  it('clamps an out-of-range scrollToIndex to the last item', () => {
+    const { itemDimensions, scrollTo, scrollToIndex, totalCount, viewportDimensions } = init(gridSystem)
+
+    publish(totalCount, 10)
+    publish(viewportDimensions, {
+      height: 100,
+      width: 300,
+    })
+    publish(itemDimensions, {
+      height: 100,
+      width: 100,
+    })
+
+    const sub = vi.fn()
+    subscribe(scrollTo, sub)
+
+    const lastScrollTop = () => sub.mock.calls[sub.mock.calls.length - 1]![0].top
+
+    // three items per row, so the last item (index 9) sits on row 3 → top 300
+    publish(scrollToIndex, 9)
+    const lastItemTop = lastScrollTop()
+    expect(lastItemTop).toBe(300)
+
+    // an index past the end must scroll to the last item, not into empty space
+    publish(scrollToIndex, 500)
+    expect(lastScrollTop()).toBe(lastItemTop)
+  })
+
   it('correctly calculates items per row', () => {
     const { gap, gridState, itemDimensions, scrollTop, totalCount, viewportDimensions } = init(gridSystem)
 


### PR DESCRIPTION
## Problem

`VirtuosoGrid`'s imperative `scrollToIndex` does not clamp an index that is past the end of the list. Calling `gridRef.current.scrollToIndex(500)` on a 10-item grid scrolls into empty space far below the last item instead of landing on it.

The clamp in `gridSystem.ts` is:

```ts
index = max(0, index, min(totalCount - 1, index))
```

Passing the raw `index` as a third argument to `max` defeats the upper bound. For `index = 500`, `totalCount = 10`:

- `min(totalCount - 1, index)` → `min(9, 500)` → `9`
- `max(0, 500, 9)` → `500`  ← unclamped

`itemTop` then computes a row far past the end (`floor(500 / perRow)`), so the grid scrolls into blank space.

## Fix

Drop the stray middle argument so the upper bound holds:

```ts
index = max(0, min(totalCount - 1, index))
```

This mirrors the clamp already used for the flat list path (`originalIndexFromLocation` in `sizeSystem.ts`: `Math.max(0, Math.min(lastIndex, result))`), and the sibling fix that landed for out-of-range scroll targets in #1442 — the grid path was left with the broken clamp. In-range and negative indexes are unchanged.

## Test

Added a `gridSystem` test: with `totalCount = 10` and three items per row, `scrollToIndex(500)` now emits the same scroll target as the last valid item (`index = 9`) instead of a top far past the end. The test fails against the previous code (`expected 16600 to be 300`) and passes with the fix.