### PR TITLE
fix: wrap ResizeObserver measurement dispatch in flushSync (one-frame flicker on upward scroll)

### DIFF
--- a/.changeset/tame-donuts-flush.md
+++ b/.changeset/tame-donuts-flush.md
@@ -1,0 +1,5 @@
+---
+'react-virtuoso': patch
+---
+
+Fix one-frame flicker on upward scroll: wrap the `skipAnimationFrameInResizeObserver` measurement dispatch in `ReactDOM.flushSync`, matching the treatment already given to native scroll events in `useScrollTop.ts`.

--- a/packages/react-virtuoso/src/hooks/useSize.ts
+++ b/packages/react-virtuoso/src/hooks/useSize.ts
@@ -1,4 +1,5 @@
 import React from 'react'
+import ReactDOM from 'react-dom'
 
 export type CallbackRefParam = HTMLElement | null
 
@@ -23,7 +24,9 @@ export function useSizeWithElRef(callback: (e: HTMLElement) => void, enabled: bo
           }
         }
         if (skipAnimationFrame) {
-          code()
+          // A ResizeObserver callback isn't a React-managed event, so an unwrapped setState
+          // here would paint one frame late. Match useScrollTop.ts's treatment of scroll events.
+          ReactDOM.flushSync(code)
         } else {
           requestAnimationFrame(code)
         }


### PR DESCRIPTION
\`useSize\`'s \`ResizeObserver\` callback drives item-height measurement, which feeds the upward-scroll \`deviation\` (\`marginTop\`) compensation via a plain \`setState\`. Since a \`ResizeObserver\` callback isn't a React-managed event, React defers the resulting re-render to a later task. When a row mounts with a real height different from its size-tree estimate during upward scrolling, the browser paints the displaced layout first and the compensation lands one frame later — a visible down-then-up flicker on every mis-estimated row.

\`useScrollTop.ts\` already gives native \`scroll\` events this exact treatment (\`ReactDOM.flushSync(call)\`); this PR gives the \`ResizeObserver\` measurement dispatch the same treatment.

**Repro:** side-by-side pristine-vs-patched demo (React 19, isolated iframes, paint-truth jump detector validated against CDP screencast pixels). Unpatched pane accumulates ~5 visible jumps/sec (max single jump 264px) during upward auto-scroll; patched pane stays at 0.

- Live: https://adcds.github.io/react-virtuoso-deviation-flicker/
- Source + full write-up: https://github.com/ADCDS/react-virtuoso-deviation-flicker

Verified against this repo directly before opening: \`pnpm --filter react-virtuoso typecheck\`, \`lint\`, \`build\`, and \`test\` (196 passed) all clean on this branch.