### PR TITLE
Fix stale group row sizes after data updates

### DIFF
--- a/.changeset/steady-group-row-sizes.md
+++ b/.changeset/steady-group-row-sizes.md
@@ -1,0 +1,5 @@
+---
+'@virtuoso.dev/data-table': patch
+---
+
+Keep grouped row measurements accurate after local model data updates.

--- a/packages/data-table/src/resize/accumulate-size-range.ts
+++ b/packages/data-table/src/resize/accumulate-size-range.ts
@@ -7,8 +7,9 @@ export function accumulateSizeRange(results: SizeRange[], element: HTMLElement, 
 
   const index = Number.parseInt(element.dataset.index, 10)
   const knownSize = Number.parseFloat(element.dataset.knownSize ?? '')
+  const isGroupRow = element.dataset.groupRow !== undefined
 
-  if (size === knownSize) {
+  if (size === knownSize && !isGroupRow) {
     return
   }
 

--- a/packages/data-table/src/resize/tests/node/accumulate-size-range.test.ts
+++ b/packages/data-table/src/resize/tests/node/accumulate-size-range.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { findMaxKeyValue } from '../../../sizing/AATree'
+import { EMPTY_SIZE_STATE, updateSizeState } from '../../../sizing/SizeState'
+import { accumulateSizeRange } from '../../accumulate-size-range'
+
+import type { SizeRange } from '../../../interfaces'
+
+function rowElement(index: number, knownSize: number, group: boolean): HTMLElement {
+  const dataset = { index: String(index), knownSize: String(knownSize) }
+  if (group) {
+    Object.assign(dataset, { groupRow: '' })
+  }
+  return { dataset } as unknown as HTMLElement
+}
+
+describe(accumulateSizeRange, () => {
+  it('skips unchanged ordinary rows', () => {
+    const ranges: SizeRange[] = []
+
+    accumulateSizeRange(ranges, rowElement(2, 44, false), 44)
+
+    expect(ranges).toStrictEqual([])
+  })
+
+  it('retains authoritative group sizes after grouped data changes', () => {
+    const actualSizes = [36, 36, 44, 36, 36, 44]
+    const groupIndices = new Set([0, 1, 3, 4])
+    const ranges: SizeRange[] = []
+
+    for (const [index, size] of actualSizes.entries()) {
+      accumulateSizeRange(ranges, rowElement(index, 36, groupIndices.has(index)), size)
+    }
+
+    expect(ranges).toStrictEqual([
+      { startIndex: 0, endIndex: 1, size: 36 },
+      { startIndex: 2, endIndex: 2, size: 44 },
+      { startIndex: 3, endIndex: 4, size: 36 },
+      { startIndex: 5, endIndex: 5, size: 44 },
+    ])
+
+    const state = updateSizeState({ ...EMPTY_SIZE_STATE, lastSize: 44 }, ranges, groupIndices)
+    expect(actualSizes.map((_, index) => findMaxKeyValue(state.sizeTree, index)[1])).toStrictEqual(actualSizes)
+  })
+})

--- a/packages/data-table/src/rows/tests/browser/data-change-sizing.test.tsx
+++ b/packages/data-table/src/rows/tests/browser/data-change-sizing.test.tsx
@@ -267,7 +267,7 @@ describe('data change sizing', () => {
     await expect
       .poll(() => {
         const rows = [...screen.container.querySelectorAll(rowSelector)] as HTMLElement[]
-        const tableBody = screen.container.querySelector(tableBodySelector) as HTMLElement | null
+        const tableBody = screen.container.querySelector<HTMLElement>(tableBodySelector)
 
         return {
           actualSizes: rows.map((row) => Math.round(row.getBoundingClientRect().height)),

--- a/packages/data-table/src/rows/tests/browser/data-change-sizing.test.tsx
+++ b/packages/data-table/src/rows/tests/browser/data-change-sizing.test.tsx
@@ -208,4 +208,84 @@ describe('data change sizing', () => {
       expect(positions[i]).toBe(expectedTop)
     }
   })
+
+  test('group row sizes remain accurate after collapsing and expanding grouped data', async () => {
+    const expandedData: (DataItem | GroupItem)[] = [
+      { groupName: 'Group A' },
+      { groupName: 'Team A' },
+      { id: 1, name: 'Task A', category: 'A' },
+      { groupName: 'Group B' },
+      { groupName: 'Team B' },
+      { id: 2, name: 'Task B', category: 'B' },
+    ]
+    const expandedGroups = [
+      { index: 0, level: 0 },
+      { index: 1, level: 1 },
+      { index: 3, level: 0 },
+      { index: 4, level: 1 },
+    ]
+    const collapsedData = [expandedData[0]!, expandedData[3]!, expandedData[4]!, expandedData[5]!]
+    const collapsedGroups = [
+      { index: 0, level: 0 },
+      { index: 1, level: 0 },
+      { index: 2, level: 1 },
+    ]
+
+    function TestComponent() {
+      const model = useMemo(() => localModel<DataItem, GroupItem>({ data: expandedData as DataItem[], groups: expandedGroups }), [])
+
+      return (
+        <>
+          <button data-testid="collapse" onClick={() => model.setData?.(collapsedData, collapsedGroups)}>
+            Collapse
+          </button>
+          <button data-testid="expand" onClick={() => model.setData?.(expandedData, expandedGroups)}>
+            Expand
+          </button>
+          <VirtuosoDataTable style={{ height: CONTAINER_HEIGHT, width: CONTAINER_WIDTH }} model={model}>
+            <GroupHeaderCell>{({ row }) => <div style={{ height: 36 }}>{(row.data as GroupItem).groupName}</div>}</GroupHeaderCell>
+            <Column field="name">
+              <ColumnHeader>{() => <div style={{ width: COLUMN_WIDTH, height: HEADER_HEIGHT }}>Name</div>}</ColumnHeader>
+              <Cell>{({ cellValue }) => <div style={{ height: 44 }}>{String(cellValue ?? '')}</div>}</Cell>
+            </Column>
+          </VirtuosoDataTable>
+        </>
+      )
+    }
+
+    const screen = await render(<TestComponent />)
+    await waitForReady(screen)
+
+    const collapseButton = screen.container.querySelector('[data-testid="collapse"]') as HTMLButtonElement
+    const expandButton = screen.container.querySelector('[data-testid="expand"]') as HTMLButtonElement
+
+    collapseButton.click()
+    await expect.poll(() => screen.container.querySelectorAll(rowSelector).length).toBe(collapsedData.length)
+
+    expandButton.click()
+
+    await expect
+      .poll(() => {
+        const rows = [...screen.container.querySelectorAll(rowSelector)] as HTMLElement[]
+        const tableBody = screen.container.querySelector(tableBodySelector) as HTMLElement | null
+
+        return {
+          actualSizes: rows.map((row) => Math.round(row.getBoundingClientRect().height)),
+          bodyHeight: tableBody?.style.height,
+          knownSizes: rows.map((row) => Number.parseFloat(row.dataset.knownSize ?? '0')),
+        }
+      })
+      .toStrictEqual({
+        actualSizes: [36, 36, 44, 36, 36, 44],
+        bodyHeight: '232px',
+        knownSizes: [36, 36, 44, 36, 36, 44],
+      })
+
+    const rows = [...screen.container.querySelectorAll(rowSelector)] as HTMLElement[]
+    for (let index = 1; index < rows.length; index++) {
+      const previousRect = rows[index - 1]!.getBoundingClientRect()
+      const currentRect = rows[index]!.getBoundingClientRect()
+      expect(Math.round(currentRect.top - previousRect.bottom)).toBe(0)
+    }
+  })
 })


### PR DESCRIPTION
Fixes #1483

Group rows now report their measured height even when it matches the current known size. This keeps later group heights from being replaced by a task-row measurement after grouped data changes.

The regression covers two group levels with mixed 36px and 44px rows and verifies the final size tree.

Tests:
- 374 node tests
- `tsgo -b --noEmit`
- oxfmt and oxlint on the changed files