### PR TITLE
Measure window-scrolling lists before they enter view

### DIFF
--- a/.changeset/calm-lists-measure.md
+++ b/.changeset/calm-lists-measure.md
@@ -1,0 +1,5 @@
+---
+'react-virtuoso': patch
+---
+
+Measure window-scrolling lists before they enter the viewport so their estimated height is included in the document layout.

--- a/packages/react-virtuoso/e2e/window-offscreen-bootstrap.test.ts
+++ b/packages/react-virtuoso/e2e/window-offscreen-bootstrap.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test'
+
+test('estimates its height before entering the window viewport', async ({ baseURL, page }) => {
+  await page.goto(`${baseURL}/?story=window-offscreen-bootstrap--example&mode=preview`)
+  await page.waitForSelector('[data-storyloaded]')
+
+  const scroller = page.locator('[data-virtuoso-scroller]')
+  await expect.poll(() => scroller.evaluate((element) => element.getBoundingClientRect().height)).toBeGreaterThan(3000)
+
+  const initialLayout = await scroller.evaluate((element) => ({
+    documentHeight: document.documentElement.scrollHeight,
+    listHeight: element.getBoundingClientRect().height,
+    listTop: element.getBoundingClientRect().top,
+    scrollY: window.scrollY,
+    viewportHeight: window.innerHeight,
+  }))
+
+  expect(initialLayout.scrollY).toBe(0)
+  expect(initialLayout.listTop).toBeGreaterThan(initialLayout.viewportHeight)
+  expect(initialLayout.listHeight).toBeGreaterThan(3000)
+  expect(initialLayout.documentHeight).toBeGreaterThan(initialLayout.listTop + 3000)
+  await expect(page.locator('[data-item-index="0"]')).toBeAttached()
+})

--- a/packages/react-virtuoso/examples/window-offscreen-bootstrap.tsx
+++ b/packages/react-virtuoso/examples/window-offscreen-bootstrap.tsx
@@ -1,0 +1,47 @@
+import { Virtuoso } from '../src'
+
+const ITEM_COUNT = 100
+
+export function Example() {
+  return (
+    <main style={{ margin: '0 auto', maxWidth: 720, padding: '0 24px 48px' }}>
+      <section
+        data-testid="content-above-list"
+        style={{
+          alignItems: 'center',
+          background: '#e2e8f0',
+          boxSizing: 'border-box',
+          display: 'flex',
+          flexDirection: 'column',
+          height: 'calc(100vh + 320px)',
+          justifyContent: 'flex-start',
+          padding: '32px 24px',
+        }}
+      >
+        <h1 style={{ margin: 0 }}>Content above an off-screen window-scrolling list</h1>
+        <p style={{ lineHeight: 1.5, maxWidth: 560 }}>
+          On initial render, the list starts below the viewport. Its estimated height should already be included in the document scrollbar.
+        </p>
+      </section>
+
+      <Virtuoso
+        itemContent={(index) => (
+          <div
+            style={{
+              background: index % 2 === 0 ? '#ffffff' : '#f8fafc',
+              borderBottom: '1px solid #cbd5e1',
+              boxSizing: 'border-box',
+              height: 40 + (index % 3) * 20,
+              padding: '10px 16px',
+            }}
+          >
+            Row {index + 1}
+          </div>
+        )}
+        style={{ border: '1px solid #94a3b8' }}
+        totalCount={ITEM_COUNT}
+        useWindowScroll
+      />
+    </main>
+  )
+}

--- a/packages/react-virtuoso/src/listSystem.ts
+++ b/packages/react-virtuoso/src/listSystem.ts
@@ -97,8 +97,10 @@ export const listSystem = u.system(
     u.connect(rangeChanged, featureGroup1.scrollSeekRangeChanged)
     u.connect(
       u.pipe(
-        featureGroup1.windowViewportRect,
-        u.map((value) => value.visibleHeight)
+        u.combineLatest(featureGroup1.windowViewportRect, domIO.headerHeight, domIO.fixedHeaderHeight),
+        // Keep a measurement range active when a window-scrolling list starts below the viewport.
+        // One content pixel beyond the headers is enough to render the probe item and estimate the full list height.
+        u.map(([viewport, headerHeight, fixedHeaderHeight]) => Math.max(headerHeight + fixedHeaderHeight + 1, viewport.visibleHeight))
       ),
       domIO.viewportHeight
     )

--- a/packages/react-virtuoso/test/windowScrollerSystem.test.ts
+++ b/packages/react-virtuoso/test/windowScrollerSystem.test.ts
@@ -4,6 +4,36 @@ import { listSystem } from '../src/listSystem'
 import * as u from '../src/urx'
 
 describe('window scroller system', () => {
+  it('measures the list before it enters the window viewport', () => {
+    const {
+      fixedHeaderHeight,
+      headerHeight,
+      listState,
+      propsReady,
+      sizeRanges,
+      totalCount,
+      totalListHeight,
+      windowScrollContainerState,
+      windowViewportRect,
+    } = u.init(listSystem)
+
+    u.publish(totalCount, 100)
+    u.publish(propsReady, true)
+    u.publish(headerHeight, 60)
+    u.publish(fixedHeaderHeight, 20)
+    u.publish(windowViewportRect, { listHeight: 0, offsetTop: 1200, visibleHeight: -400 })
+    u.publish(windowScrollContainerState, { scrollHeight: 1200, scrollTop: 0, viewportHeight: 800 })
+
+    expect(u.getValue(listState)).toMatchObject({
+      items: [{ index: 0, offset: 0, size: 0 }],
+    })
+
+    u.publish(sizeRanges, [{ endIndex: 0, size: 40, startIndex: 0 }])
+
+    expect(u.getValue(totalListHeight)).toBe(4080)
+    expect(u.getValue(listState).items).toHaveLength(1)
+  })
+
   it('offsets the window scroll top with the element offset top', () => {
     const { scrollTop, windowScrollContainerState, windowViewportRect } = u.init(listSystem)
     const sub = vi.fn()


### PR DESCRIPTION
## Why

A `useWindowScroll` list that starts below the browser viewport receives a non-positive visible height. It therefore renders no probe item and contributes no estimated list height to the document until the user scrolls near it. This makes the document scrollbar change abruptly.

Fixes #1486.

## What changes

Window-scrolling lists now keep a minimal measurement range active beyond regular and fixed headers. This renders one probe item while the list is off-screen, allowing Virtuoso to estimate the complete list height without rendering an off-screen batch.

The change includes a standalone Ladle reproduction that runs in preview mode, a browser regression test that confirms the list height is present before scrolling, and focused engine coverage for header-aware measurement.

## Verification

The React Virtuoso unit suite passes with 197 tests and 4 skipped. Formatting, lint, type checking, markdown lint, and diff checks pass. The targeted Ladle browser test passed using the full-screen `mode=preview` route.