### PR TITLE
Add updateData for same-shape data snapshots

### DIFF
--- a/.changeset/gentle-rows-stay-mounted.md
+++ b/.changeset/gentle-rows-stay-mounted.md
@@ -1,0 +1,5 @@
+---
+'@virtuoso.dev/data-table': minor
+---
+
+Add `model.updateData(data)` for applying a same-shape data snapshot (same length, same rows at the same indices) without resetting the known row-size tree, so mounted cells keep their DOM nodes and local state (focused inputs, popovers, etc.) across the update. `setData()` is unchanged and still resets the size tree.

--- a/.changeset/gentle-rows-stay-mounted.md
+++ b/.changeset/gentle-rows-stay-mounted.md
@@ -2,4 +2,4 @@
 '@virtuoso.dev/data-table': minor
 ---
 
-Add `model.updateData(data)` for applying a same-shape data snapshot (same length, same rows at the same indices) without resetting the known row-size tree, so mounted cells keep their DOM nodes and local state (focused inputs, popovers, etc.) across the update. `setData()` is unchanged and still resets the size tree.
+Add `model.updateData(data)` for applying a same-shape data snapshot (same length, same rows and stable row keys at the same indices) without resetting the known row-size tree, so mounted cells keep their DOM nodes and local state (focused inputs, popovers, etc.) across the update. `setData()` is unchanged and still resets the size tree.

--- a/packages/data-table/docs/2.data-model/01.local-data-model.md
+++ b/packages/data-table/docs/2.data-model/01.local-data-model.md
@@ -128,8 +128,9 @@ React.useEffect(() => {
 
 - the row count is unchanged
 - each index still holds the same logical row — no insertions, deletions, or reorders
+- `computeRowKey` returns the same key for each row before and after the update
 - group markers are unaffected — `updateData` never takes a `groups` argument, since group placement is index/level metadata a value-only update can't legitimately change
-- row values may change freely
+- row values that do not determine the row key may change freely
 
 Cached sizes are retained as estimates for the new values and corrected by `ResizeObserver` for any row that's actually mounted. If the row count doesn't match, the table falls back to a full reset and logs a dev warning.
 

--- a/packages/data-table/docs/2.data-model/01.local-data-model.md
+++ b/packages/data-table/docs/2.data-model/01.local-data-model.md
@@ -114,6 +114,29 @@ For grouped rows, `model.setData(nextRows, nextGroups)` updates rows and markers
 
 If the row schema changes intentionally, remount the table with a new `key` so runtime columns can discover the new first result. See [Runtime Columns](/data-table/columns/runtime-columns/#rediscovering-columns).
 
+### Updating rows in place
+
+`setData` resets the table's size tracking along with the rows — every row is measured again, which briefly unmounts and remounts visible cells. When a refresh only changes row values — a live price tick, a status flip — and the row set is otherwise identical, `model.updateData(nextRows)` skips that reset:
+
+```tsx
+React.useEffect(() => {
+  model.updateData?.(products)
+}, [model, products])
+```
+
+`updateData` requires the caller to guarantee a strict contract between `nextRows` and the current rows:
+
+- the row count is unchanged
+- each index still holds the same logical row — no insertions, deletions, or reorders
+- group markers are unaffected — `updateData` never takes a `groups` argument, since group placement is index/level metadata a value-only update can't legitimately change
+- row values may change freely
+
+Cached sizes are retained as estimates for the new values and corrected by `ResizeObserver` for any row that's actually mounted. If the row count doesn't match, the table falls back to a full reset and logs a dev warning.
+
+A pipeline stage that sorts or filters on a field the update just changed can reorder rows at the same indices, which breaks the "same logical row per index" contract and misattributes cached heights to the wrong row. `updateData` on a model with a `pipeline` logs a dev warning for this reason — use `setData` there instead.
+
+A custom model (built directly on the model protocol rather than `localModel`) opts into the same behavior by returning `operation: 'update'` on the `DataResult` it emits.
+
 ## Grouping
 
 When rows naturally cluster — sales by region, products by category, employees by department — group headers belong between the rows they introduce. The library keeps those headers inside the same flat `data` array rather than nesting rows under each header, so the pipeline, sizing, and virtualization treat them as ordinary rows. A separate `groups` array tells the table which entries are headers and how deeply they nest.

--- a/packages/data-table/src/core/VirtuosoDataTable.tsx
+++ b/packages/data-table/src/core/VirtuosoDataTable.tsx
@@ -38,7 +38,7 @@ import {
   stickyHeaderWrapper$,
 } from './components'
 import { computeRowKey$, defaultComputeRowKey } from './content'
-import { context$, data$, groupLevelMap$, groupStickyConfig$, initialData$ } from './data'
+import { context$, data$, dataOperation$, groupLevelMap$, groupStickyConfig$, initialData$ } from './data'
 import { loadingState$ } from './loading'
 import { dispatchModelAction$, modelActionState$ } from './model-actions'
 
@@ -118,6 +118,7 @@ function VirtuosoDataTableComponent(props: VirtuosoDataTableProps<unknown, unkno
         e.register(groupLevelMap$)
         e.register(viewportRange$)
         e.register(data$)
+        e.register(dataOperation$)
         e.register(loadingState$)
         e.register(initialData$)
         e.register(dataModel$)

--- a/packages/data-table/src/core/data.ts
+++ b/packages/data-table/src/core/data.ts
@@ -5,12 +5,16 @@ import { processStickyConfig } from '../sizing/stickyItems'
 import { loadingState$ } from './loading'
 
 import type { DataArray } from '../interfaces'
+import type { DataOperation } from '../model/types'
 import type { ProcessedStickyGroup, StickyItemsConfig } from '../sizing/stickyItems'
 
 export const totalCount$ = Cell(0)
 export const context$ = Cell<unknown>(null)
 
 export const data$ = Cell<DataArray | null>(null)
+
+/** The operation that produced the current `data$` value — `'replace'` unless a model tagged it `'update'`. */
+export const dataOperation$ = Cell<DataOperation>('replace')
 
 export const initialData$ = Cell<DataArray | null>(null)
 

--- a/packages/data-table/src/core/tests/node/data.test.ts
+++ b/packages/data-table/src/core/tests/node/data.test.ts
@@ -2,7 +2,7 @@ import { Engine } from '@virtuoso.dev/reactive-engine-core'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { itemHeight$, ranges$, sizeState$, totalHeight$ } from '../../../resize/sizes'
-import { data$, totalCount$ } from '../../data'
+import { data$, dataOperation$, totalCount$ } from '../../data'
 
 const HUNDRED_ITEMS = Array.from({ length: 100 }, (_, i) => i)
 describe('data logic', () => {
@@ -13,6 +13,7 @@ describe('data logic', () => {
     e.register(totalHeight$)
     e.register(itemHeight$)
     e.register(data$)
+    e.register(dataOperation$)
     e.register(totalCount$)
   })
 
@@ -38,7 +39,7 @@ describe('data logic', () => {
     expect(e.getValue(totalCount$)).toBe(103)
   })
 
-  it('data change resets per-index sizes but preserves default row size', () => {
+  it('replace: data change resets per-index sizes but preserves default row size', () => {
     e.pub(data$, HUNDRED_ITEMS)
     e.pub(ranges$, [{ size: 30, startIndex: 0, endIndex: 0 }])
 
@@ -46,7 +47,7 @@ describe('data logic', () => {
     expect(heightBefore).toBe(30 * 100)
 
     const sizeStateBefore = e.getValue(sizeState$)
-    expect(sizeStateBefore.offsetTree.length).toBeGreaterThan(0)
+    expect(sizeStateBefore.offsetTree).toMatchObject([{ size: 30, index: 0, offset: 0 }])
 
     e.pub(
       data$,
@@ -58,6 +59,38 @@ describe('data logic', () => {
 
     const heightAfter = e.getValue(totalHeight$)
     expect(heightAfter).toBe(30 * 102)
+  })
+
+  it('update: same-length data swap preserves the size/offset tree', () => {
+    e.pub(data$, HUNDRED_ITEMS)
+    e.pub(ranges$, [{ size: 30, startIndex: 0, endIndex: 0 }])
+
+    const sizeStateBefore = e.getValue(sizeState$)
+    expect(sizeStateBefore.offsetTree).toMatchObject([{ size: 30, index: 0, offset: 0 }])
+    expect(e.getValue(totalHeight$)).toBe(30 * 100)
+
+    e.pubIn({
+      [data$]: Array.from({ length: 100 }, (_, i) => i + 1000),
+      [dataOperation$]: 'update',
+    })
+
+    const sizeStateAfter = e.getValue(sizeState$)
+    expect(sizeStateAfter.offsetTree).toStrictEqual(sizeStateBefore.offsetTree)
+    expect(e.getValue(totalHeight$)).toBe(30 * 100)
+  })
+
+  it('replace: same-length data swap still resets the size/offset tree', () => {
+    e.pub(data$, HUNDRED_ITEMS)
+    e.pub(ranges$, [{ size: 30, startIndex: 0, endIndex: 0 }])
+
+    expect(e.getValue(sizeState$).offsetTree).toMatchObject([{ size: 30, index: 0, offset: 0 }])
+
+    e.pubIn({
+      [data$]: Array.from({ length: 100 }, (_, i) => i + 1000),
+      [dataOperation$]: 'replace',
+    })
+
+    expect(e.getValue(sizeState$).offsetTree).toHaveLength(0)
   })
 
   it('resolves the known item height from the current size state', () => {

--- a/packages/data-table/src/index.ts
+++ b/packages/data-table/src/index.ts
@@ -75,6 +75,7 @@ export { remoteModel, defaultOffsetViewportHandler, defaultAppendViewportHandler
 export type {
   DataModelHandle,
   DataModelPersistenceCapability,
+  DataOperation,
   DataResult,
   MessageEnvelope,
   ModelPersistenceState,

--- a/packages/data-table/src/model/local-model.ts
+++ b/packages/data-table/src/model/local-model.ts
@@ -350,13 +350,32 @@ export function localModel<T, G = never>(config: LocalModelConfig<T, G>): DataMo
     },
   }
 
-  model.setData = (data: T[], groups?: { index: number; level: number }[]) => {
+  let warnedUpdateDataWithPipeline = false
+
+  function replaceSourceData(data: T[], groups?: { index: number; level: number }[]) {
     sourceData = data
     if (groups !== undefined) {
       currentGroups = groups
     }
     invalidateAllViewStages()
+  }
+
+  model.setData = (data: T[], groups?: { index: number; level: number }[]) => {
+    replaceSourceData(data, groups)
     model.send({ action: 'refresh', viewId: 'default' })
+  }
+
+  model.updateData = (data: T[]) => {
+    if (pipeline.length > 0 && !warnedUpdateDataWithPipeline) {
+      warnedUpdateDataWithPipeline = true
+      warnModelActionInDev(
+        'updateData() was called on a model with a pipeline. A sort/filter stage can reorder rows at the same indices, ' +
+          'which would misattribute cached row heights. updateData() requires the caller to guarantee that each index ' +
+          'still holds the same logical row; use setData() otherwise.'
+      )
+    }
+    replaceSourceData(data)
+    model.send({ action: 'refresh', payload: { operation: 'update' }, viewId: 'default' })
   }
 
   return model

--- a/packages/data-table/src/model/model-bridge.ts
+++ b/packages/data-table/src/model/model-bridge.ts
@@ -1,10 +1,10 @@
 import { Cell } from '@virtuoso.dev/reactive-engine-core'
 
-import { data$, groupIndices$ } from '../core/data'
+import { data$, dataOperation$, groupIndices$ } from '../core/data'
 import { EMPTY_LOADING_STATE, loadingState$ } from '../core/loading'
 import { dispatchModelAction$, modelActionState$ } from '../core/model-actions'
 import { viewportRange$ } from '../rows/row-state'
-import { RESERVED_ACTION_NAMES, warnReservedModelActionInDev } from './reserved-actions'
+import { RESERVED_ACTION_NAMES, warnModelActionInDev, warnReservedModelActionInDev } from './reserved-actions'
 
 import type { DataTableLoadingState } from '../interfaces'
 import type { RemoteModelLoadingEvent, RemoteModelLoadingReason } from './remote-model'
@@ -82,9 +82,16 @@ export function bridgeModelToEngine(model: DataModelHandle, engine: Engine, view
 
     if (msg.type === 'result') {
       const result = msg.payload as DataResult
+      const nextData = [...result.data]
+      let operation = result.operation ?? 'replace'
+      if (operation === 'update' && nextData.length !== engine.getValue(data$)?.length) {
+        warnModelActionInDev("A model result tagged operation: 'update' changed the row count; falling back to a full replace.")
+        operation = 'replace'
+      }
       engine.pubIn({
-        [data$]: [...result.data],
+        [data$]: nextData,
         [groupIndices$]: result.groups,
+        [dataOperation$]: operation,
       })
     }
   })

--- a/packages/data-table/src/model/model-core.ts
+++ b/packages/data-table/src/model/model-core.ts
@@ -1,4 +1,4 @@
-import type { DataModelHandle, DataResult, FrameAdapter, MessageEnvelope } from './types'
+import type { DataModelHandle, DataOperation, DataResult, FrameAdapter, MessageEnvelope } from './types'
 
 interface InFlightRequest {
   requestId: string
@@ -161,7 +161,7 @@ export function createModel<T, G = never>(adapter: FrameAdapter<T, G>): DataMode
       emitError(viewId, action, message, requestId)
 
       if (view.lastKnownGood) {
-        emitResult(viewId, view.lastKnownGood as DataResult<T, G>, view.operationVersion)
+        emitResult(viewId, { ...view.lastKnownGood, operation: 'replace' } as DataResult<T, G>, view.operationVersion)
       }
       return true
     }
@@ -187,7 +187,8 @@ export function createModel<T, G = never>(adapter: FrameAdapter<T, G>): DataMode
       const view = getOrCreateView(viewId)
       const requestId = msg.requestId ?? nextRequestId()
       const result = adapter.handleHandshake(viewId)
-      emitResult(viewId, result, view.operationVersion, requestId)
+      const operation = (msg.payload as { operation?: DataOperation } | undefined)?.operation
+      emitResult(viewId, operation === undefined ? result : { ...result, operation }, view.operationVersion, requestId)
       return
     }
 
@@ -348,7 +349,7 @@ export function createModel<T, G = never>(adapter: FrameAdapter<T, G>): DataMode
     }
 
     if (view.lastKnownGood) {
-      emitResult(viewId, view.lastKnownGood as DataResult<T, G>, view.operationVersion)
+      emitResult(viewId, { ...view.lastKnownGood, operation: 'replace' } as DataResult<T, G>, view.operationVersion)
     }
   })
 

--- a/packages/data-table/src/model/tests/node/model-action-bridge.test.ts
+++ b/packages/data-table/src/model/tests/node/model-action-bridge.test.ts
@@ -1,9 +1,10 @@
 import { Engine } from '@virtuoso.dev/reactive-engine-core'
 import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest'
 
-import { data$, groupIndices$ } from '../../../core/data'
+import { data$, dataOperation$, groupIndices$ } from '../../../core/data'
 import { loadingState$ } from '../../../core/loading'
 import { dispatchModelAction$, modelActionState$ } from '../../../core/model-actions'
+import { ranges$, sizeState$ } from '../../../resize/sizes'
 import { localModel } from '../../local-model'
 import { bridgeModelToEngine, dataModel$, dataModelViewId$ } from '../../model-bridge'
 
@@ -30,12 +31,14 @@ const groupHandler: PipelineHandler<Item> = ({ data, payload }) => ({
 function createEngine() {
   const engine = new Engine()
   engine.register(data$)
+  engine.register(dataOperation$)
   engine.register(groupIndices$)
   engine.register(loadingState$)
   engine.register(dataModel$)
   engine.register(dataModelViewId$)
   engine.register(dispatchModelAction$)
   engine.register(modelActionState$)
+  engine.register(sizeState$)
   return engine
 }
 
@@ -194,5 +197,86 @@ describe('model action bridge', () => {
 
     expect(send).toHaveBeenCalledWith({ action: 'refresh', payload: undefined, viewId: 'default' })
     expect(engine.getValue(modelActionState$)).toStrictEqual({})
+  })
+
+  it('downgrades an update result to replace when the row count changes, resetting sizes', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let listener: ((msg: MessageEnvelope) => void) | null = null
+    const model: DataModelHandle<Item> = {
+      destroy: vi.fn(),
+      send: vi.fn((msg: Parameters<DataModelHandle<Item>['send']>[0]) => {
+        if (msg.action === 'grow') {
+          listener?.({
+            action: 'result',
+            payload: { data: [...ITEMS, { id: 3, status: 'open' }], groups: [], operation: 'update' } satisfies DataResult<Item>,
+            requestId: 'grow',
+            type: 'result',
+            viewId: 'default',
+          })
+        }
+      }),
+      subscribe(nextListener) {
+        listener = nextListener
+        nextListener({
+          action: 'result',
+          payload: { data: ITEMS, groups: [] } satisfies DataResult<Item>,
+          requestId: 'initial',
+          type: 'result',
+          viewId: 'default',
+        })
+        return vi.fn()
+      },
+    }
+
+    bridgeModelToEngine(model, engine, 'default')
+    engine.pub(ranges$, [{ size: 20, startIndex: 0, endIndex: 0 }])
+    expect(engine.getValue(sizeState$).offsetTree).toMatchObject([{ size: 20, index: 0, offset: 0 }])
+
+    model.send({ action: 'grow', viewId: 'default' })
+
+    expect(engine.getValue(dataOperation$)).toBe('replace')
+    expect(engine.getValue(sizeState$).offsetTree).toHaveLength(0)
+    expect(warn).toHaveBeenCalledOnce()
+  })
+
+  it('updateData sets dataOperation$ to update and preserves the offset tree', () => {
+    const model = localModel<Item>({ data: ITEMS })
+    bridgeModelToEngine(model, engine, 'default')
+
+    engine.pub(ranges$, [{ size: 20, startIndex: 0, endIndex: 0 }])
+    const offsetTreeBefore = engine.getValue(sizeState$).offsetTree
+    expect(offsetTreeBefore).toMatchObject([{ size: 20, index: 0, offset: 0 }])
+
+    model.updateData?.([
+      { id: 1, status: 'closed' },
+      { id: 2, status: 'done' },
+    ])
+
+    expect(engine.getValue(dataOperation$)).toBe('update')
+    expect(engine.getValue(sizeState$).offsetTree).toStrictEqual(offsetTreeBefore)
+  })
+
+  it('replays lastKnownGood as replace after an action error, even if it was tagged update', () => {
+    const model = localModel<Item>({
+      data: ITEMS,
+      actions: {
+        boom: {
+          handler: () => {
+            throw new Error('boom')
+          },
+        },
+      },
+    })
+    bridgeModelToEngine(model, engine, 'default')
+
+    model.updateData?.([
+      { id: 1, status: 'closed' },
+      { id: 2, status: 'done' },
+    ])
+    expect(engine.getValue(dataOperation$)).toBe('update')
+
+    model.send({ action: 'boom', viewId: 'default' })
+
+    expect(engine.getValue(dataOperation$)).toBe('replace')
   })
 })

--- a/packages/data-table/src/model/tests/node/model-action-bridge.test.ts
+++ b/packages/data-table/src/model/tests/node/model-action-bridge.test.ts
@@ -7,9 +7,10 @@ import { dispatchModelAction$, modelActionState$ } from '../../../core/model-act
 import { ranges$, sizeState$ } from '../../../resize/sizes'
 import { localModel } from '../../local-model'
 import { bridgeModelToEngine, dataModel$, dataModelViewId$ } from '../../model-bridge'
+import { createModel } from '../../model-core'
 
 import type { PipelineHandler, SourceMutator } from '../../local-model'
-import type { DataModelHandle, DataResult, MessageEnvelope } from '../../types'
+import type { AsyncErrorEmitter, DataModelHandle, DataResult, MessageEnvelope } from '../../types'
 
 interface Item {
   id: number
@@ -256,6 +257,20 @@ describe('model action bridge', () => {
     expect(engine.getValue(sizeState$).offsetTree).toStrictEqual(offsetTreeBefore)
   })
 
+  it('updateData preserves static group metadata', () => {
+    const groups = [{ index: 0, level: 0 }]
+    const model = localModel<Item>({ data: ITEMS, groups })
+    bridgeModelToEngine(model, engine, 'default')
+
+    model.updateData?.([
+      { id: 1, status: 'closed' },
+      { id: 2, status: 'done' },
+    ])
+
+    expect(engine.getValue(dataOperation$)).toBe('update')
+    expect(engine.getValue(groupIndices$)).toStrictEqual(groups)
+  })
+
   it('replays lastKnownGood as replace after an action error, even if it was tagged update', () => {
     const model = localModel<Item>({
       data: ITEMS,
@@ -278,5 +293,34 @@ describe('model action bridge', () => {
     model.send({ action: 'boom', viewId: 'default' })
 
     expect(engine.getValue(dataOperation$)).toBe('replace')
+  })
+
+  it('replays lastKnownGood as replace after an async action error', () => {
+    const emitAsyncError = vi.fn<AsyncErrorEmitter>()
+    const updatedItems = [
+      { id: 1, status: 'closed' },
+      { id: 2, status: 'done' },
+    ]
+    const model = createModel<Item>({
+      handleAction(_viewId, action) {
+        return action === 'update' ? { data: updatedItems, groups: [], operation: 'update' } : null
+      },
+      handleHandshake() {
+        return { data: ITEMS, groups: [] }
+      },
+      setAsyncErrorEmitter(emitter) {
+        emitAsyncError.mockImplementation(emitter)
+      },
+    })
+    bridgeModelToEngine(model, engine, 'default')
+
+    model.send({ action: 'update', requestId: 'update', viewId: 'default' })
+    expect(engine.getValue(dataOperation$)).toBe('update')
+
+    model.send({ action: 'load', requestId: 'load', viewId: 'default' })
+    emitAsyncError('default', 'load failed', 'load')
+
+    expect(engine.getValue(dataOperation$)).toBe('replace')
+    expect(engine.getValue(data$)).toStrictEqual(updatedItems)
   })
 })

--- a/packages/data-table/src/model/types.ts
+++ b/packages/data-table/src/model/types.ts
@@ -17,6 +17,13 @@ export interface MessageEnvelope<P = unknown> {
 }
 
 /**
+ * Distinguishes a full data reset (`'replace'`) from an in-place same-index update (`'update'`).
+ *
+ * @group Data Models
+ */
+export type DataOperation = 'replace' | 'update'
+
+/**
  * A normalized table data result returned by data models.
  *
  * @group Data Models
@@ -24,6 +31,7 @@ export interface MessageEnvelope<P = unknown> {
 export interface DataResult<T = unknown, G = never> {
   data: (T | G)[]
   groups: { index: number; level: number }[]
+  operation?: DataOperation
 }
 
 /**
@@ -60,6 +68,7 @@ export interface DataModelHandle<T = unknown> {
   persistence?: DataModelPersistenceCapability
   subscribeToActionState?(handler: (state: ModelActionState) => void): () => void
   setData?(data: T[], groups?: { index: number; level: number }[]): void
+  updateData?(data: T[]): void
 }
 
 /**

--- a/packages/data-table/src/resize/sizes.ts
+++ b/packages/data-table/src/resize/sizes.ts
@@ -1,6 +1,6 @@
 import { Cell, DerivedCell, e, Stream } from '@virtuoso.dev/reactive-engine-core'
 
-import { data$, groupIndices$, groupIndexSet$, totalCount$ } from '../core/data'
+import { data$, dataOperation$, groupIndices$, groupIndexSet$, totalCount$ } from '../core/data'
 import { findMaxKeyValue } from '../sizing/AATree'
 import { computeTotalSize } from '../sizing/offsetOf'
 import { EMPTY_SIZE_STATE, updateSizeState } from '../sizing/SizeState'
@@ -54,7 +54,10 @@ function expandGroupHeaderRanges(ranges: SizeRange[], groupIndicesList: { index:
   }
   return extra.length > 0 ? [...ranges, ...extra] : ranges
 }
-e.changeWith(sizeState$, data$, (current) => ({ ...EMPTY_SIZE_STATE, lastSize: current.lastSize }))
+const dataWithOperation$ = e.pipe(data$, e.withLatestFrom(dataOperation$))
+e.changeWith(sizeState$, dataWithOperation$, (current, [, operation]) =>
+  operation === 'update' ? current : { ...EMPTY_SIZE_STATE, lastSize: current.lastSize }
+)
 
 export const totalHeight$ = DerivedCell(
   0,

--- a/packages/data-table/src/rows/tests/browser/model-update-data.test.tsx
+++ b/packages/data-table/src/rows/tests/browser/model-update-data.test.tsx
@@ -1,0 +1,194 @@
+import { useMemo } from 'react'
+
+import { expect, test, describe } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { Cell, VirtuosoDataTable } from '../../..'
+import { Column } from '../../../columns/Column'
+import { ColumnHeader } from '../../../columns/ColumnHeader'
+import { localModel } from '../../../model/local-model'
+
+const HEADER_HEIGHT = 40
+const ROW_HEIGHT = 30
+const CONTAINER_HEIGHT = 300
+const CONTAINER_WIDTH = 300
+const COLUMN_WIDTH = 150
+
+interface DataItem {
+  id: number
+  name: string
+}
+
+const ITEM_COUNT = 100
+const VISIBLE_ROW_COUNT = Math.ceil((CONTAINER_HEIGHT - HEADER_HEIGHT) / ROW_HEIGHT)
+// The anchor row (index 0) survives a size-tree reset either way, since row-state.ts re-seeds a
+// probe commit at the anchor. The regression only shows up on the other visible rows, which get
+// dropped from that commit and unmount.
+const NON_ANCHOR_ROW_INDEX = Math.min(3, VISIBLE_ROW_COUNT - 1)
+
+function buildItems(prefix: string): DataItem[] {
+  return Array.from({ length: ITEM_COUNT }, (_, i) => ({ id: i, name: `${prefix}${i}` }))
+}
+
+const INITIAL_ITEMS = buildItems('initial-')
+const UPDATED_ITEMS = buildItems('updated-')
+const REPLACED_ITEMS = buildItems('replaced-')
+
+const readySelector = '[data-testid=virtuoso-table-root][data-ready]'
+const tableBodySelector = '[data-testid=virtuoso-table-body]'
+const rowSelector = '[data-testid=virtuoso-table-row]'
+const cellTextSelector = '[data-testid=cell-text]'
+const cellInputSelector = '[data-testid=cell-input]'
+const nonAnchorRowSelector = `[data-testid=virtuoso-table-row][data-index="${NON_ANCHOR_ROW_INDEX}"]`
+
+async function waitForReady(screen: Awaited<ReturnType<typeof render>>) {
+  await expect.poll(() => screen.container.querySelector(readySelector)).not.toBeNull()
+}
+
+function TestComponent() {
+  const model = useMemo(() => localModel<DataItem>({ data: INITIAL_ITEMS }), [])
+
+  return (
+    <>
+      <button data-testid="update" onClick={() => model.updateData?.(UPDATED_ITEMS)}>
+        Update
+      </button>
+      <button data-testid="replace" onClick={() => model.setData?.(REPLACED_ITEMS)}>
+        Replace
+      </button>
+      <VirtuosoDataTable style={{ height: CONTAINER_HEIGHT, width: CONTAINER_WIDTH }} model={model}>
+        <Column field="name">
+          <ColumnHeader>{() => <div style={{ width: COLUMN_WIDTH, height: HEADER_HEIGHT }}>Name</div>}</ColumnHeader>
+          <Cell>
+            {({ cellValue }) => (
+              <div style={{ height: ROW_HEIGHT }}>
+                <span data-testid="cell-text">{String(cellValue ?? '')}</span>
+                <input data-testid="cell-input" defaultValue="" />
+              </div>
+            )}
+          </Cell>
+        </Column>
+      </VirtuosoDataTable>
+    </>
+  )
+}
+
+describe('model updateData vs setData', () => {
+  test('updateData preserves DOM nodes and cell state on the anchor row', async () => {
+    const screen = await render(<TestComponent />)
+    await waitForReady(screen)
+
+    const capturedRow = screen.container.querySelector(rowSelector) as HTMLElement
+    const capturedInput = capturedRow.querySelector(cellInputSelector) as HTMLInputElement
+    const originalKnownSize = capturedRow.dataset.knownSize
+
+    capturedInput.focus()
+    capturedInput.value = 'typed-value'
+    capturedInput.dispatchEvent(new Event('input', { bubbles: true }))
+    const activeElementBeforeUpdate = document.activeElement
+
+    expect(activeElementBeforeUpdate).toBe(capturedInput)
+
+    const updateButton = screen.container.querySelector('[data-testid="update"]') as HTMLButtonElement
+    updateButton.click()
+
+    await expect.poll(() => capturedRow.querySelector(cellTextSelector)?.textContent).toBe(UPDATED_ITEMS[0]!.name)
+
+    expect(screen.container.querySelector(rowSelector)).toBe(capturedRow)
+    expect(capturedRow.querySelector(cellInputSelector)).toBe(capturedInput)
+    expect(capturedInput.value).toBe('typed-value')
+    expect(document.activeElement).toBe(capturedInput)
+    expect(capturedRow.dataset.knownSize).toBe(originalKnownSize)
+  })
+
+  test('updateData preserves DOM nodes and cell state on a non-anchor row', async () => {
+    const screen = await render(<TestComponent />)
+    await waitForReady(screen)
+
+    expect(screen.container.querySelector(nonAnchorRowSelector)).not.toBeNull()
+
+    const capturedRow = screen.container.querySelector(nonAnchorRowSelector) as HTMLElement
+    const capturedInput = capturedRow.querySelector(cellInputSelector) as HTMLInputElement
+    const originalKnownSize = capturedRow.dataset.knownSize
+
+    capturedInput.focus()
+    capturedInput.value = 'typed-value'
+    capturedInput.dispatchEvent(new Event('input', { bubbles: true }))
+    const activeElementBeforeUpdate = document.activeElement
+
+    expect(activeElementBeforeUpdate).toBe(capturedInput)
+
+    const updateButton = screen.container.querySelector('[data-testid="update"]') as HTMLButtonElement
+    updateButton.click()
+
+    await expect.poll(() => capturedRow.querySelector(cellTextSelector)?.textContent).toBe(UPDATED_ITEMS[NON_ANCHOR_ROW_INDEX]!.name)
+
+    expect(capturedRow.isConnected).toBe(true)
+    expect(screen.container.querySelector(nonAnchorRowSelector)).toBe(capturedRow)
+    expect(capturedRow.querySelector(cellInputSelector)).toBe(capturedInput)
+    expect(capturedInput.value).toBe('typed-value')
+    expect(document.activeElement).toBe(capturedInput)
+    expect(capturedRow.dataset.knownSize).toBe(originalKnownSize)
+  })
+
+  test('total body height never dips while updateData is applied', async () => {
+    const screen = await render(<TestComponent />)
+    await waitForReady(screen)
+
+    const tableBody = () => screen.container.querySelector(tableBodySelector) as HTMLElement
+    const capturedRow = () => screen.container.querySelector(rowSelector) as HTMLElement
+    const expectedHeight = `${ITEM_COUNT * ROW_HEIGHT}px`
+
+    expect(tableBody().style.height).toBe(expectedHeight)
+
+    const updateButton = screen.container.querySelector('[data-testid="update"]') as HTMLButtonElement
+    updateButton.click()
+
+    // updateData never resets sizeState$, so the height check right after the synchronous
+    // click-driven render is as meaningful as a mid-flight sample would be.
+    expect(tableBody().style.height).toBe(expectedHeight)
+
+    await expect.poll(() => capturedRow().querySelector(cellTextSelector)?.textContent).toBe(UPDATED_ITEMS[0]!.name)
+
+    expect(tableBody().style.height).toBe(expectedHeight)
+  })
+
+  test('setData still resets the known row-size tree and unmounts non-anchor rows', async () => {
+    const screen = await render(<TestComponent />)
+    await waitForReady(screen)
+
+    expect(screen.container.querySelector(nonAnchorRowSelector)).not.toBeNull()
+
+    const anchorRow = screen.container.querySelector(rowSelector) as HTMLElement
+    const originalAnchorKnownSize = anchorRow.dataset.knownSize
+    expect(originalAnchorKnownSize).toBe(String(ROW_HEIGHT))
+
+    const nonAnchorRow = screen.container.querySelector(nonAnchorRowSelector) as HTMLElement
+
+    // The reset lands asynchronously (an unmeasured-probe commit followed by remeasurement), so a
+    // synchronous read right after the click can miss it — observe every attribute change instead.
+    const observedAnchorKnownSizes: (string | undefined)[] = []
+    const anchorObserver = new MutationObserver(() => {
+      observedAnchorKnownSizes.push(anchorRow.dataset.knownSize)
+    })
+    anchorObserver.observe(anchorRow, { attributes: true, attributeFilter: ['data-known-size'] })
+
+    const replaceButton = screen.container.querySelector('[data-testid="replace"]') as HTMLButtonElement
+    replaceButton.click()
+
+    // The anchor row is re-seeded in place (same key), so it only ever gets a size-attribute
+    // update. Every other visible row is absent from that seed commit and is unmounted outright.
+    await expect.poll(() => nonAnchorRow.isConnected).toBe(false)
+    anchorObserver.disconnect()
+
+    expect(observedAnchorKnownSizes).toContain('0')
+
+    await expect.poll(() => anchorRow.querySelector(cellTextSelector)?.textContent).toBe(REPLACED_ITEMS[0]!.name)
+    await expect.poll(() => anchorRow.dataset.knownSize).toBe(String(ROW_HEIGHT))
+
+    const remountedNonAnchorRow = screen.container.querySelector(nonAnchorRowSelector)
+    expect(remountedNonAnchorRow).not.toBeNull()
+    expect(remountedNonAnchorRow).not.toBe(nonAnchorRow)
+    expect(remountedNonAnchorRow?.querySelector(cellTextSelector)?.textContent).toBe(REPLACED_ITEMS[NON_ANCHOR_ROW_INDEX]!.name)
+  })
+})

--- a/packages/data-table/src/rows/tests/browser/model-update-data.test.tsx
+++ b/packages/data-table/src/rows/tests/browser/model-update-data.test.tsx
@@ -144,8 +144,8 @@ describe('model updateData vs setData', () => {
     const updateButton = screen.container.querySelector('[data-testid="update"]') as HTMLButtonElement
     updateButton.click()
 
-    // updateData never resets sizeState$, so the height check right after the synchronous
-    // click-driven render is as meaningful as a mid-flight sample would be.
+    // Guards the lastSize fallback in computeTotalSize, not updateData specifically — a same-length
+    // setData holds this height steady too, so this does not on its own distinguish the two paths.
     expect(tableBody().style.height).toBe(expectedHeight)
 
     await expect.poll(() => capturedRow().querySelector(cellTextSelector)?.textContent).toBe(UPDATED_ITEMS[0]!.name)

--- a/packages/data-table/src/rows/tests/browser/model-update-data.test.tsx
+++ b/packages/data-table/src/rows/tests/browser/model-update-data.test.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useState } from 'react'
 
 import { expect, test, describe } from 'vitest'
 import { render } from 'vitest-browser-react'
@@ -10,11 +10,13 @@ import { localModel } from '../../../model/local-model'
 
 const HEADER_HEIGHT = 40
 const ROW_HEIGHT = 30
+const RESIZED_ROW_HEIGHT = 60
 const CONTAINER_HEIGHT = 300
 const CONTAINER_WIDTH = 300
 const COLUMN_WIDTH = 150
 
 interface DataItem {
+  height: number
   id: number
   name: string
 }
@@ -27,12 +29,15 @@ const VISIBLE_ROW_COUNT = Math.ceil((CONTAINER_HEIGHT - HEADER_HEIGHT) / ROW_HEI
 const NON_ANCHOR_ROW_INDEX = Math.min(3, VISIBLE_ROW_COUNT - 1)
 
 function buildItems(prefix: string): DataItem[] {
-  return Array.from({ length: ITEM_COUNT }, (_, i) => ({ id: i, name: `${prefix}${i}` }))
+  return Array.from({ length: ITEM_COUNT }, (_, i) => ({ height: ROW_HEIGHT, id: i, name: `${prefix}${i}` }))
 }
 
 const INITIAL_ITEMS = buildItems('initial-')
 const UPDATED_ITEMS = buildItems('updated-')
 const REPLACED_ITEMS = buildItems('replaced-')
+const RESIZED_ITEMS = INITIAL_ITEMS.map((item, index) =>
+  index === NON_ANCHOR_ROW_INDEX ? { ...item, height: RESIZED_ROW_HEIGHT, name: `resized-${index}` } : item
+)
 
 const readySelector = '[data-testid=virtuoso-table-root][data-ready]'
 const tableBodySelector = '[data-testid=virtuoso-table-body]'
@@ -46,7 +51,7 @@ async function waitForReady(screen: Awaited<ReturnType<typeof render>>) {
 }
 
 function TestComponent() {
-  const model = useMemo(() => localModel<DataItem>({ data: INITIAL_ITEMS }), [])
+  const [model] = useState(() => localModel<DataItem>({ data: INITIAL_ITEMS }))
 
   return (
     <>
@@ -56,12 +61,15 @@ function TestComponent() {
       <button data-testid="replace" onClick={() => model.setData?.(REPLACED_ITEMS)}>
         Replace
       </button>
+      <button data-testid="resize" onClick={() => model.updateData?.(RESIZED_ITEMS)}>
+        Resize
+      </button>
       <VirtuosoDataTable style={{ height: CONTAINER_HEIGHT, width: CONTAINER_WIDTH }} model={model}>
         <Column field="name">
           <ColumnHeader>{() => <div style={{ width: COLUMN_WIDTH, height: HEADER_HEIGHT }}>Name</div>}</ColumnHeader>
           <Cell>
-            {({ cellValue }) => (
-              <div style={{ height: ROW_HEIGHT }}>
+            {({ cellValue, row }) => (
+              <div style={{ height: (row.data as DataItem).height }}>
                 <span data-testid="cell-text">{String(cellValue ?? '')}</span>
                 <input data-testid="cell-input" defaultValue="" />
               </div>
@@ -151,6 +159,26 @@ describe('model updateData vs setData', () => {
     await expect.poll(() => capturedRow().querySelector(cellTextSelector)?.textContent).toBe(UPDATED_ITEMS[0]!.name)
 
     expect(tableBody().style.height).toBe(expectedHeight)
+  })
+
+  test('updateData remeasures changed row heights without remounting the row', async () => {
+    const screen = await render(<TestComponent />)
+    await waitForReady(screen)
+
+    const capturedRow = screen.container.querySelector(nonAnchorRowSelector) as HTMLElement
+    expect(capturedRow.dataset.knownSize).toBe(String(ROW_HEIGHT))
+
+    const resizeButton = screen.container.querySelector('[data-testid="resize"]') as HTMLButtonElement
+    resizeButton.click()
+
+    await expect.poll(() => capturedRow.querySelector(cellTextSelector)?.textContent).toBe(RESIZED_ITEMS[NON_ANCHOR_ROW_INDEX]!.name)
+    await expect.poll(() => capturedRow.dataset.knownSize).toBe(String(RESIZED_ROW_HEIGHT))
+
+    expect(capturedRow.isConnected).toBe(true)
+    expect(screen.container.querySelector(nonAnchorRowSelector)).toBe(capturedRow)
+    expect((screen.container.querySelector(tableBodySelector) as HTMLElement).style.height).toBe(
+      `${ITEM_COUNT * ROW_HEIGHT + RESIZED_ROW_HEIGHT - ROW_HEIGHT}px`
+    )
   })
 
   test('setData still resets the known row-size tree and unmounts non-anchor rows', async () => {

--- a/packages/reactive-engine-core/src/operators/withLatestFrom.test.ts
+++ b/packages/reactive-engine-core/src/operators/withLatestFrom.test.ts
@@ -289,4 +289,30 @@ describe('withLatestFrom operator', () => {
     expect(spy1.history).toHaveLength(1)
     expect(spy2.history).toHaveLength(1)
   })
+
+  it('picks up the pulled node new value when published together with the source in one pubIn (source key first)', () => {
+    const source = Stream<number>()
+    const pulled = Cell('old')
+    const combined = e.pipe(source, e.withLatestFrom(pulled))
+    const { history, spy } = createSpyWithHistory<[number, string]>()
+
+    e.sub(combined, spy)
+
+    // A projection is registered under both its sources and its pulls (Engine.ts:264-266), and
+    // calculateExecutionMap orders a pulled root before its sink regardless of key order (Engine.ts:1145-1183)
+    eng.pubIn({ [source]: 1, [pulled]: 'new' })
+    expect(history).toEqual([[1, 'new']])
+  })
+
+  it('picks up the pulled node new value when published together with the source in one pubIn (pulled key first)', () => {
+    const source = Stream<number>()
+    const pulled = Cell('old')
+    const combined = e.pipe(source, e.withLatestFrom(pulled))
+    const { history, spy } = createSpyWithHistory<[number, string]>()
+
+    e.sub(combined, spy)
+
+    eng.pubIn({ [pulled]: 'new', [source]: 1 })
+    expect(history).toEqual([[1, 'new']])
+  })
 })

--- a/packages/virtuoso-skills/skills/data-table/references/2.data-model/01.local-data-model.md
+++ b/packages/virtuoso-skills/skills/data-table/references/2.data-model/01.local-data-model.md
@@ -128,8 +128,9 @@ React.useEffect(() => {
 
 - the row count is unchanged
 - each index still holds the same logical row — no insertions, deletions, or reorders
+- `computeRowKey` returns the same key for each row before and after the update
 - group markers are unaffected — `updateData` never takes a `groups` argument, since group placement is index/level metadata a value-only update can't legitimately change
-- row values may change freely
+- row values that do not determine the row key may change freely
 
 Cached sizes are retained as estimates for the new values and corrected by `ResizeObserver` for any row that's actually mounted. If the row count doesn't match, the table falls back to a full reset and logs a dev warning.
 

--- a/packages/virtuoso-skills/skills/data-table/references/2.data-model/01.local-data-model.md
+++ b/packages/virtuoso-skills/skills/data-table/references/2.data-model/01.local-data-model.md
@@ -114,6 +114,29 @@ For grouped rows, `model.setData(nextRows, nextGroups)` updates rows and markers
 
 If the row schema changes intentionally, remount the table with a new `key` so runtime columns can discover the new first result. See [Runtime Columns](/data-table/columns/runtime-columns/#rediscovering-columns).
 
+### Updating rows in place
+
+`setData` resets the table's size tracking along with the rows — every row is measured again, which briefly unmounts and remounts visible cells. When a refresh only changes row values — a live price tick, a status flip — and the row set is otherwise identical, `model.updateData(nextRows)` skips that reset:
+
+```tsx
+React.useEffect(() => {
+  model.updateData?.(products)
+}, [model, products])
+```
+
+`updateData` requires the caller to guarantee a strict contract between `nextRows` and the current rows:
+
+- the row count is unchanged
+- each index still holds the same logical row — no insertions, deletions, or reorders
+- group markers are unaffected — `updateData` never takes a `groups` argument, since group placement is index/level metadata a value-only update can't legitimately change
+- row values may change freely
+
+Cached sizes are retained as estimates for the new values and corrected by `ResizeObserver` for any row that's actually mounted. If the row count doesn't match, the table falls back to a full reset and logs a dev warning.
+
+A pipeline stage that sorts or filters on a field the update just changed can reorder rows at the same indices, which breaks the "same logical row per index" contract and misattributes cached heights to the wrong row. `updateData` on a model with a `pipeline` logs a dev warning for this reason — use `setData` there instead.
+
+A custom model (built directly on the model protocol rather than `localModel`) opts into the same behavior by returning `operation: 'update'` on the `DataResult` it emits.
+
 ## Grouping
 
 When rows naturally cluster — sales by region, products by category, employees by department — group headers belong between the rows they introduce. The library keeps those headers inside the same flat `data` array rather than nesting rows under each header, so the pipeline, sizing, and virtualization treat them as ordinary rows. A separate `groups` array tells the table which entries are headers and how deeply they nest.

--- a/plugins/virtuoso-skills/skills/data-table/references/2.data-model/01.local-data-model.md
+++ b/plugins/virtuoso-skills/skills/data-table/references/2.data-model/01.local-data-model.md
@@ -128,8 +128,9 @@ React.useEffect(() => {
 
 - the row count is unchanged
 - each index still holds the same logical row — no insertions, deletions, or reorders
+- `computeRowKey` returns the same key for each row before and after the update
 - group markers are unaffected — `updateData` never takes a `groups` argument, since group placement is index/level metadata a value-only update can't legitimately change
-- row values may change freely
+- row values that do not determine the row key may change freely
 
 Cached sizes are retained as estimates for the new values and corrected by `ResizeObserver` for any row that's actually mounted. If the row count doesn't match, the table falls back to a full reset and logs a dev warning.
 

--- a/plugins/virtuoso-skills/skills/data-table/references/2.data-model/01.local-data-model.md
+++ b/plugins/virtuoso-skills/skills/data-table/references/2.data-model/01.local-data-model.md
@@ -114,6 +114,29 @@ For grouped rows, `model.setData(nextRows, nextGroups)` updates rows and markers
 
 If the row schema changes intentionally, remount the table with a new `key` so runtime columns can discover the new first result. See [Runtime Columns](/data-table/columns/runtime-columns/#rediscovering-columns).
 
+### Updating rows in place
+
+`setData` resets the table's size tracking along with the rows — every row is measured again, which briefly unmounts and remounts visible cells. When a refresh only changes row values — a live price tick, a status flip — and the row set is otherwise identical, `model.updateData(nextRows)` skips that reset:
+
+```tsx
+React.useEffect(() => {
+  model.updateData?.(products)
+}, [model, products])
+```
+
+`updateData` requires the caller to guarantee a strict contract between `nextRows` and the current rows:
+
+- the row count is unchanged
+- each index still holds the same logical row — no insertions, deletions, or reorders
+- group markers are unaffected — `updateData` never takes a `groups` argument, since group placement is index/level metadata a value-only update can't legitimately change
+- row values may change freely
+
+Cached sizes are retained as estimates for the new values and corrected by `ResizeObserver` for any row that's actually mounted. If the row count doesn't match, the table falls back to a full reset and logs a dev warning.
+
+A pipeline stage that sorts or filters on a field the update just changed can reorder rows at the same indices, which breaks the "same logical row per index" contract and misattributes cached heights to the wrong row. `updateData` on a model with a `pipeline` logs a dev warning for this reason — use `setData` there instead.
+
+A custom model (built directly on the model protocol rather than `localModel`) opts into the same behavior by returning `operation: 'update'` on the `DataResult` it emits.
+
 ## Grouping
 
 When rows naturally cluster — sales by region, products by category, employees by department — group headers belong between the rows they introduce. The library keeps those headers inside the same flat `data` array rather than nesting rows under each header, so the pipeline, sizing, and virtualization treat them as ordinary rows. A separate `groups` array tells the table which entries are headers and how deeply they nest.

--- a/skills/data-table/references/2.data-model/01.local-data-model.md
+++ b/skills/data-table/references/2.data-model/01.local-data-model.md
@@ -128,8 +128,9 @@ React.useEffect(() => {
 
 - the row count is unchanged
 - each index still holds the same logical row — no insertions, deletions, or reorders
+- `computeRowKey` returns the same key for each row before and after the update
 - group markers are unaffected — `updateData` never takes a `groups` argument, since group placement is index/level metadata a value-only update can't legitimately change
-- row values may change freely
+- row values that do not determine the row key may change freely
 
 Cached sizes are retained as estimates for the new values and corrected by `ResizeObserver` for any row that's actually mounted. If the row count doesn't match, the table falls back to a full reset and logs a dev warning.
 

--- a/skills/data-table/references/2.data-model/01.local-data-model.md
+++ b/skills/data-table/references/2.data-model/01.local-data-model.md
@@ -114,6 +114,29 @@ For grouped rows, `model.setData(nextRows, nextGroups)` updates rows and markers
 
 If the row schema changes intentionally, remount the table with a new `key` so runtime columns can discover the new first result. See [Runtime Columns](/data-table/columns/runtime-columns/#rediscovering-columns).
 
+### Updating rows in place
+
+`setData` resets the table's size tracking along with the rows — every row is measured again, which briefly unmounts and remounts visible cells. When a refresh only changes row values — a live price tick, a status flip — and the row set is otherwise identical, `model.updateData(nextRows)` skips that reset:
+
+```tsx
+React.useEffect(() => {
+  model.updateData?.(products)
+}, [model, products])
+```
+
+`updateData` requires the caller to guarantee a strict contract between `nextRows` and the current rows:
+
+- the row count is unchanged
+- each index still holds the same logical row — no insertions, deletions, or reorders
+- group markers are unaffected — `updateData` never takes a `groups` argument, since group placement is index/level metadata a value-only update can't legitimately change
+- row values may change freely
+
+Cached sizes are retained as estimates for the new values and corrected by `ResizeObserver` for any row that's actually mounted. If the row count doesn't match, the table falls back to a full reset and logs a dev warning.
+
+A pipeline stage that sorts or filters on a field the update just changed can reorder rows at the same indices, which breaks the "same logical row per index" contract and misattributes cached heights to the wrong row. `updateData` on a model with a `pipeline` logs a dev warning for this reason — use `setData` there instead.
+
+A custom model (built directly on the model protocol rather than `localModel`) opts into the same behavior by returning `operation: 'update'` on the `DataResult` it emits.
+
 ## Grouping
 
 When rows naturally cluster — sales by region, products by category, employees by department — group headers belong between the rows they introduce. The library keeps those headers inside the same flat `data` array rather than nesting rows under each header, so the pipeline, sizing, and virtualization treat them as ordinary rows. A separate `groups` array tells the table which entries are headers and how deeply they nest.


### PR DESCRIPTION
## Issue

Closes #1489.

A table fed by a websocket receives a full snapshot roughly once a second. The frames are reformatted, so every row object is a fresh reference even when the row set is identical — same ids, same order, only values move.

Any publish to `data$` wiped the size tree. With an empty tree, `row-state.ts` commits a single probe row at the anchor, so every other visible row is absent for that commit and React unmounts it. Cells holding editable inputs, tooltips, and row-action popovers lose their DOM nodes and local state. Array reference identity is the sole trigger — reusing row objects makes no difference.

The table does not diff old data against new: the operation is ambiguous, and an O(n) key comparison is wrong for a virtualized table holding tens of thousands of rows. The caller states the operation instead:

| Call | Meaning |
| --- | --- |
| `model.setData(next, groups)` | arbitrary replacement; reset known sizes (unchanged) |
| `model.updateData(next)` | same logical rows at the same indices; preserve known sizes |

`updateData` is a trusted contract, not a verified one: unchanged row count, each index still the same logical row, no insertions/deletions/reorders/group-structure changes, values free to change. Cached sizes are kept as estimates and `ResizeObserver` corrects mounted rows. Models that declare no operation keep today's behaviour, and a custom model opts in by returning `operation: 'update'` on its `DataResult`.

Two guards, since the contract can't be checked in full:

- the bridge downgrades an `'update'` whose row count moved back to `'replace'` — O(1), catches an accidental insert or delete
- `updateData` on a model with a pipeline warns in dev: a sort or filter stage keyed on a field the snapshot just changed can reorder rows at the same indices, which the length guard cannot catch

## Changes

- feat(data-table): preserve row sizes on same-shape data updates
- test(data-table): cover updateData size preservation
- test(reactive-engine-core): cover pubIn ordering for pulled cells
- docs(data-table): document updateData
- test(data-table): note the height case does not discriminate

## Testing

- [ ] Render a table whose cells contain focused `<input>`s, drive `model.updateData(next)` on an interval with same-length data, and confirm the caret is not lost and row heights do not flicker
- [ ] Confirm `model.setData(next)` still resets sizes and remeasures
- [ ] Call `updateData` with a different-length array and confirm it falls back to a full replace with a dev warning
- [ ] Call `updateData` on a model configured with a `pipeline` and confirm the dev warning fires

## Checklist

- [ ] Branch name (preferable) or PR title references the linear ticket (if applicable)
- [x] Added unit tests for new functionality or edge cases
- [x] Updated documentation (if applicable)