### PR TITLE
fix: apply prepend compensation in the same frame as the deviation

### DIFF
--- a/.changeset/quiet-pandas-compensate.md
+++ b/.changeset/quiet-pandas-compensate.md
@@ -1,0 +1,16 @@
+---
+'react-virtuoso': patch
+---
+
+Fix the transcript blanking for a frame when an older page is prepended.
+
+The compensation for a prepend was a deviation that grows the content followed, one
+`requestAnimationFrame` later, by the scroll that cancels it. In between there is a painted frame in
+which the list is displaced by the whole page — and because prepends fire near `scrollTop` 0, that
+displacement is the entire viewport.
+
+The scroll now runs as soon as the renderer acknowledges, from a layout effect, that the deviation
+has reached the DOM: after the mutation, before paint. Both land in the same paint, and because the
+content has already grown the scroll can no longer be clamped to the old maximum. If nothing
+acknowledges by the next frame the previous deferred behaviour still applies, so the worst case is
+unchanged.

--- a/packages/react-virtuoso/e2e/prepend-items.test.ts
+++ b/packages/react-virtuoso/e2e/prepend-items.test.ts
@@ -34,4 +34,52 @@ test.describe('list with prependable items', () => {
 
     expect(await getScrollTop(page)).toBe(200 * 55)
   })
+
+  /**
+   * Samples every animation frame across a prepend and returns how many of them
+   * had rows rendered while none of them intersected the viewport.
+   */
+  async function blankFramesDuringPrepend(page: Page) {
+    await page.evaluate(() => {
+      const scroller = document.querySelector('[data-testid=virtuoso-scroller]')
+      if (!scroller) throw new Error('no scroller')
+      const w = window as unknown as { __blankFrames: number; __stopSampling: () => void }
+      w.__blankFrames = 0
+      let running = true
+      const sample = () => {
+        if (!running) return
+        const view = scroller.getBoundingClientRect()
+        const rows = Array.from(scroller.querySelectorAll('[data-index]'))
+        if (rows.length > 0) {
+          const anyVisible = rows.some((row) => {
+            const r = row.getBoundingClientRect()
+            return r.bottom > view.top && r.top < view.bottom
+          })
+          if (!anyVisible) w.__blankFrames += 1
+        }
+        requestAnimationFrame(sample)
+      }
+      requestAnimationFrame(sample)
+      w.__stopSampling = () => {
+        running = false
+      }
+    })
+
+    await page.locator('data-testid=prepend-200').click()
+    await page.waitForTimeout(400)
+
+    return page.evaluate(() => {
+      const w = window as unknown as { __blankFrames: number; __stopSampling: () => void }
+      w.__stopSampling()
+      return w.__blankFrames
+    })
+  }
+
+  test('never paints a frame with every row out of view', async ({ page }) => {
+    // The compensation is a deviation that grows the content plus a scroll that
+    // cancels it. If the scroll lands a frame after the growth, one painted
+    // frame has the whole list pushed below the fold — and because prepends
+    // fire near scrollTop 0, that is the entire viewport.
+    expect(await blankFramesDuringPrepend(page)).toBe(0)
+  })
 })

--- a/packages/react-virtuoso/e2e/prepend-items.test.ts
+++ b/packages/react-virtuoso/e2e/prepend-items.test.ts
@@ -42,12 +42,16 @@ test.describe('list with prependable items', () => {
   async function blankFramesDuringPrepend(page: Page) {
     await page.evaluate(() => {
       const scroller = document.querySelector('[data-testid=virtuoso-scroller]')
-      if (!scroller) throw new Error('no scroller')
+      if (!scroller) {
+        throw new Error('no scroller')
+      }
       const w = window as unknown as { __blankFrames: number; __stopSampling: () => void }
       w.__blankFrames = 0
       let running = true
       const sample = () => {
-        if (!running) return
+        if (!running) {
+          return
+        }
         const view = scroller.getBoundingClientRect()
         const rows = Array.from(scroller.querySelectorAll('[data-index]'))
         if (rows.length > 0) {
@@ -55,7 +59,9 @@ test.describe('list with prependable items', () => {
             const r = row.getBoundingClientRect()
             return r.bottom > view.top && r.top < view.bottom
           })
-          if (!anyVisible) w.__blankFrames += 1
+          if (!anyVisible) {
+            w.__blankFrames += 1
+          }
         }
         requestAnimationFrame(sample)
       }

--- a/packages/react-virtuoso/examples/prepend-stress-styles.ts
+++ b/packages/react-virtuoso/examples/prepend-stress-styles.ts
@@ -1,0 +1,138 @@
+export const stressStyles = `
+.prepend-stress {
+  color: #17212e;
+  font:
+    14px/1.45 system-ui,
+    sans-serif;
+}
+.prepend-stress > p {
+  max-width: 950px;
+}
+.prepend-controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.prepend-controls button {
+  background: #17212e;
+  color: white;
+  border: 0;
+  border-radius: 4px;
+  padding: 9px 12px;
+  cursor: pointer;
+}
+.prepend-controls button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.prepend-controls label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.prepend-result {
+  display: block;
+  min-height: 24px;
+  padding: 12px 0;
+  font-family: monospace;
+}
+.prepend-stage {
+  position: relative;
+  border: 3px solid #17212e;
+}
+.prepend-guide {
+  position: absolute;
+  top: 84px;
+  left: -3px;
+  right: -3px;
+  border-top: 2px dashed #ffe600;
+  pointer-events: none;
+  z-index: 10;
+}
+.prepend-message {
+  box-sizing: border-box;
+  background: #102c42;
+  color: #f1f7fb;
+  border-left: 12px solid #39e4d0;
+  border-bottom: 3px solid #39e4d0;
+  padding: 14px 18px;
+  overflow-wrap: anywhere;
+}
+.prepend-message[data-tone='1'] {
+  background: #292348;
+  border-color: #b1a1ff;
+}
+.prepend-message header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  color: #cef8ff;
+}
+.prepend-message header strong {
+  font: 900 25px/1.2 monospace;
+  color: white;
+}
+.prepend-message p {
+  margin: 12px 0;
+}
+.prepend-message blockquote {
+  border-left: 4px solid #ffca68;
+  padding: 12px;
+  margin: 12px 0;
+  background: #ffffff12;
+}
+.prepend-message pre {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  background: #080f1d;
+  color: #7ff1b9;
+  padding: 14px;
+  font: 12px/1.6 monospace;
+}
+.prepend-message table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 12px;
+}
+.prepend-message th,
+.prepend-message td {
+  border: 1px solid #658299;
+  text-align: left;
+  padding: 6px;
+}
+.prepend-message footer {
+  color: #c2d1e4;
+  font-size: 11px;
+  border-top: 1px solid #ffffff30;
+  padding-top: 10px;
+}
+.prepend-message summary {
+  cursor: pointer;
+  padding: 12px 0;
+  color: #ffdb85;
+}
+.prepend-attachments {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin: 12px 0;
+}
+.prepend-attachments figure {
+  margin: 0;
+  padding: 8px;
+  background: #080f1d;
+}
+.prepend-attachments figcaption {
+  font-size: 11px;
+  margin-top: 8px;
+}
+.prepend-preview {
+  display: grid;
+  place-items: center;
+  background: repeating-linear-gradient(135deg, #316380 0 9px, #183b59 9px 18px);
+  color: white;
+  font: bold 25px monospace;
+}
+`

--- a/packages/react-virtuoso/examples/prepend-stress.tsx
+++ b/packages/react-virtuoso/examples/prepend-stress.tsx
@@ -1,0 +1,280 @@
+import * as React from 'react'
+
+import { TableVirtuoso, Virtuoso } from '../src'
+import { stressStyles } from './prepend-stress-styles'
+
+const START = 100000
+const authors = ['Mira / support', 'Jon / engineering', 'Alex / customer', 'Sam / operations']
+const paragraphs = [
+  'The attachment finished uploading, but the preview still shows yesterday’s version. I retried on a narrow screen and the long filenames wrapped onto three lines.',
+  'Please keep the original request open. There are two separate exports, several screenshots, and a reply from the customer further up this conversation.',
+  'Reproduction: open the workspace, select the archived project, expand all details, then return to the conversation. The summary below contains the exact values we received.',
+  'Update from the overnight run: most jobs completed, three are waiting for a retry, and one returned a different result. We need to compare the output before closing this thread.',
+]
+
+function Message({ id }: { id: number }) {
+  const variant = id % 6
+  return (
+    <article className="prepend-message" data-stress-row={id} data-tone={id % 2}>
+      <header>
+        <strong>#{id}</strong>
+        <span>{authors[id % authors.length]}</span>
+        <span>09:{String(id % 60).padStart(2, '0')}</span>
+      </header>
+      <p>{paragraphs[id % paragraphs.length]}</p>
+      {variant === 0 && (
+        <blockquote>
+          “This only happens after opening the older messages. Can you check the attached report?”<p>{paragraphs[1]}</p>
+        </blockquote>
+      )}
+      {variant === 1 && (
+        <pre>{`POST /api/workspaces/production/exports\nrequest_id: req_${id}_retry_03\nstatus: waiting_for_attachment\n\n{\n  "files": ["report-final-v7.csv", "trace.json"],\n  "attempt": 3,\n  "message": "Upstream response took too long"\n}`}</pre>
+      )}
+      {variant === 2 && (
+        <div className="prepend-attachments">
+          {['Latency trace', 'Mobile screenshot', 'Export preview'].map((title, index) => (
+            <figure key={title}>
+              <div style={{ height: 65 + index * 23 }} className="prepend-preview">
+                {id % 100} / {index + 1}
+              </div>
+              <figcaption>
+                {title}
+                <br />
+                customer-workspace-{id}-final.png
+              </figcaption>
+            </figure>
+          ))}
+        </div>
+      )}
+      {variant === 3 && (
+        <table>
+          <thead>
+            <tr>
+              <th>Job</th>
+              <th>Result</th>
+              <th>Duration</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from({ length: 5 }, (_, index) => (
+              <tr key={index}>
+                <td>export-{id + index}</td>
+                <td>{index % 2 ? 'Waiting for retry' : 'Complete'}</td>
+                <td>{17 + index * 31} ms</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {variant === 4 && (
+        <>
+          <p>{paragraphs[(id + 1) % paragraphs.length]}</p>
+          <ul>
+            <li>Compare the original attachment with the regenerated version.</li>
+            <li>Keep the full request and response, including the retry headers.</li>
+            <li>Check the customer’s follow-up before marking this resolved.</li>
+          </ul>
+        </>
+      )}
+      {variant === 5 && (
+        <details>
+          <summary>Expand diagnostic details (changes row height)</summary>
+          <pre>{Array.from({ length: 12 }, (_, index) => `[${index}] worker-${id % 9}: received ${index * 137} bytes`).join('\n')}</pre>
+          <p>{paragraphs[2]}</p>
+        </details>
+      )}
+      <footer>
+        Reply to #{id - 3} · {(id % 7) + 1} replies · {(id % 4) + 1} attachments
+      </footer>
+    </article>
+  )
+}
+
+interface Result {
+  anchor: string
+  blank: number
+  missing: number
+  drift: number
+  frames: number
+}
+
+function Stress({ table = false, pinned = false }: { table?: boolean; pinned?: boolean }) {
+  const [range, setRange] = React.useState({ first: START, count: 20 })
+  const [generation, setGeneration] = React.useState(0)
+  const [width, setWidth] = React.useState(720)
+  const [result, setResult] = React.useState<Result | null>(null)
+  const [running, setRunning] = React.useState(false)
+  const scroller = React.useRef<HTMLElement | null>(null)
+  const frame = React.useRef(0)
+  const burstFrame = React.useRef(0)
+  const cancel = React.useCallback(() => {
+    cancelAnimationFrame(frame.current)
+    cancelAnimationFrame(burstFrame.current)
+  }, [])
+  React.useEffect(() => cancel, [cancel])
+
+  const captureScroller = React.useCallback((element: HTMLElement | null | Window) => {
+    scroller.current = element instanceof HTMLElement ? element : null
+  }, [])
+
+  function prepend(count: number) {
+    setRange((current) => ({ first: current.first - count, count: current.count + count }))
+  }
+
+  function run(count: number, secondCount = 0) {
+    const element = scroller.current
+    if (!element) {
+      return
+    }
+    cancel()
+    const bounds = element.getBoundingClientRect()
+    // Only inspect the scrolling list: a pinned row must not hide a blank viewport.
+    const rows = () => Array.from(element.querySelectorAll<HTMLElement>('[data-testid="virtuoso-item-list"] [data-stress-row]'))
+    const visible = rows().filter((row) => {
+      const rect = row.getBoundingClientRect()
+      return rect.bottom > bounds.top && rect.top < bounds.bottom
+    })
+    const anchor = visible.find((row) => row.getBoundingClientRect().top >= bounds.top + (pinned ? 80 : 0)) ?? visible[0]
+    if (!anchor) {
+      return
+    }
+    const id = anchor.dataset.stressRow!
+    const initialTop = anchor.getBoundingClientRect().top - bounds.top
+    const measurement: Result = { anchor: id, blank: 0, missing: 0, drift: 0, frames: 0 }
+    const started = performance.now()
+    setRunning(true)
+    setResult(null)
+    const sample = () => {
+      const view = element.getBoundingClientRect()
+      const currentRows = rows()
+      measurement.frames++
+      if (
+        !currentRows.some((row) => {
+          const rect = row.getBoundingClientRect()
+          return rect.bottom > view.top && rect.top < view.bottom
+        })
+      ) {
+        measurement.blank++
+      }
+      const currentAnchor = currentRows.find((row) => row.dataset.stressRow === id)
+      if (currentAnchor) {
+        measurement.drift = Math.max(measurement.drift, Math.abs(currentAnchor.getBoundingClientRect().top - view.top - initialTop))
+      } else {
+        measurement.missing++
+      }
+      if (performance.now() - started < 700) {
+        frame.current = requestAnimationFrame(sample)
+      } else {
+        setResult(measurement)
+        setRunning(false)
+      }
+    }
+    // Register before the prepend so the sampler can observe its intermediate layout.
+    frame.current = requestAnimationFrame(sample)
+    prepend(count)
+    if (secondCount) {
+      burstFrame.current = requestAnimationFrame(() => prepend(secondCount))
+    }
+  }
+
+  const props = {
+    skipAnimationFrameInResizeObserver: true,
+    firstItemIndex: range.first,
+    totalCount: range.count,
+    scrollerRef: captureScroller,
+    style: { height: 520, background: '#ff00a8' },
+  }
+
+  return (
+    <div className="prepend-stress">
+      <style>{stressStyles}</style>
+      <h2>Prepend stress / {table ? 'table' : pinned ? 'pinned row' : 'message feed'}</h2>
+      <p>
+        Start with 20 mixed-height messages. Watch the numbered rails and the yellow guide while adding a much larger page. Exposed magenta
+        means missing content.
+      </p>
+      <div className="prepend-controls">
+        <button disabled={running} onClick={() => run(100)}>
+          Prepend 100
+        </button>
+        <button disabled={running} onClick={() => run(200)}>
+          Prepend 200
+        </button>
+        <button disabled={running} onClick={() => run(100, 100)}>
+          Burst 100 + 100
+        </button>
+        <button disabled={running} onClick={() => run(100, 37)}>
+          Burst 100 + 37
+        </button>
+        <button disabled={running} onClick={() => scroller.current?.scrollTo({ top: 0 })}>
+          Back to top
+        </button>
+        <button
+          onClick={() => {
+            cancel()
+            setRunning(false)
+            setResult(null)
+            setRange({ first: START, count: 20 })
+            setGeneration((value) => value + 1)
+          }}
+        >
+          Reset to 20
+        </button>
+        <label>
+          Width{' '}
+          <input
+            aria-label="Feed width"
+            type="range"
+            min={360}
+            max={1000}
+            value={width}
+            disabled={running}
+            onChange={(event) => setWidth(Number(event.target.value))}
+          />{' '}
+          {width}px
+        </label>
+      </div>
+      <output aria-live="polite" className="prepend-result">
+        {running
+          ? 'Sampling for 700ms — do not scroll or resize…'
+          : result
+            ? `Anchor #${result.anchor} · max movement ${result.drift.toFixed(1)}px · blank samples ${result.blank} · missing anchor samples ${result.missing} · ${result.frames} frames sampled`
+            : 'Ready. Reset before each large-prepend comparison.'}
+      </output>
+      <div className="prepend-stage" style={{ width, maxWidth: '100%' }}>
+        {table ? (
+          <TableVirtuoso
+            {...props}
+            key={generation}
+            itemContent={(id) => (
+              <td style={{ padding: 0 }}>
+                <Message id={id} />
+              </td>
+            )}
+          />
+        ) : (
+          <Virtuoso {...props} key={generation} topItemCount={pinned ? 1 : 0} itemContent={(id) => <Message id={id} />} />
+        )}
+        <div className="prepend-guide" aria-hidden="true" />
+      </div>
+      <p>
+        {range.count} messages · No overscan, external images, or random content. Burst requests arrive in separate animation-frame updates.
+        Expand details or narrow the feed to challenge measurement.
+      </p>
+      <p>
+        Frame samples report geometry, not proof of a painted frame. Compare the same story on the base and PR branches; use a browser
+        recording to inspect flashes.
+      </p>
+    </div>
+  )
+}
+
+export function MessyMessages() {
+  return <Stress />
+}
+export function MessyTable() {
+  return <Stress table />
+}
+export function PinnedMessage() {
+  return <Stress pinned />
+}

--- a/packages/react-virtuoso/src/TableVirtuoso.tsx
+++ b/packages/react-virtuoso/src/TableVirtuoso.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import useChangedListContentsSizes from './hooks/useChangedChildSizes'
+import useIsomorphicLayoutEffect from './hooks/useIsomorphicLayoutEffect'
 import useSize from './hooks/useSize'
 import useWindowViewportRectRef from './hooks/useWindowViewportRect'
 import { listSystem } from './listSystem'
@@ -216,6 +217,14 @@ const TableBody = /*#__PURE__*/ React.memo(function TableVirtuosoBody() {
       setDeviation(value)
     }
   })
+
+  // Same acknowledgement as the list renderer: the padding below carries the
+  // deviation through React, so a prepend's compensating scroll waits for this
+  // commit rather than for a whole frame. See `upwardScrollFixSystem`.
+  const deviationCommitted = usePublisher('deviationCommitted')
+  useIsomorphicLayoutEffect(() => {
+    deviationCommitted(deviation)
+  }, [deviation, deviationCommitted])
   const EmptyPlaceholder = useEmitterValue('EmptyPlaceholder')
   const FillerRow = useEmitterValue('FillerRow') ?? DefaultFillerRow
   const TableBodyComponent = useEmitterValue('TableBodyComponent')!

--- a/packages/react-virtuoso/src/Virtuoso.tsx
+++ b/packages/react-virtuoso/src/Virtuoso.tsx
@@ -104,10 +104,18 @@ const Items = /*#__PURE__*/ React.memo(function VirtuosoItems({ showTopList = fa
   const [deviation, setDeviation] = React.useState(0)
   useEmitter('deviation', (value) => {
     if (deviation !== value) {
-      // ref.current!.style.marginTop = `${value}px`
       setDeviation(value)
     }
   })
+
+  // The margin below is what grows the scrollable content for a prepend, and it
+  // is applied by React. This runs once that commit is in the DOM and before
+  // paint, which is the point at which `upwardScrollFixSystem` can safely
+  // scroll to cancel it without being clamped.
+  const deviationCommitted = usePublisher('deviationCommitted')
+  useIsomorphicLayoutEffect(() => {
+    deviationCommitted(deviation)
+  }, [deviation, deviationCommitted])
 
   const EmptyPlaceholder = useEmitterValue('EmptyPlaceholder')
   const ScrollSeekPlaceholder = useEmitterValue('ScrollSeekPlaceholder') ?? DefaultScrollSeekPlaceholder

--- a/packages/react-virtuoso/src/domIOSystem.ts
+++ b/packages/react-virtuoso/src/domIOSystem.ts
@@ -7,6 +7,10 @@ export const domIOSystem = u.system(
     const scrollContainerState = u.stream<ScrollContainerState>()
     const scrollTop = u.stream<number>()
     const deviation = u.statefulStream(0)
+    // Published by the list renderer from a layout effect once a `deviation`
+    // has actually reached the DOM. `upwardScrollFixSystem` waits for it before
+    // scrolling, so the scroll never runs against the pre-deviation layout.
+    const deviationCommitted = u.stream<number>()
     const smoothScrollTargetReached = u.stream<true>()
     const statefulScrollTop = u.statefulStream(0)
     const viewportHeight = u.stream<number>()
@@ -41,6 +45,7 @@ export const domIOSystem = u.system(
 
     return {
       deviation,
+      deviationCommitted,
       fixedFooterHeight,
       fixedHeaderHeight,
       footerHeight,

--- a/packages/react-virtuoso/src/hooks/useScrollTop.ts
+++ b/packages/react-virtuoso/src/hooks/useScrollTop.ts
@@ -173,15 +173,19 @@ export default function useScrollTop(
     scrollerElement.scrollTo(location)
   }
 
-  function scrollByCallback(location: ScrollToOptions) {
-    if (horizontalDirection === true) {
-      location = {
-        ...(location.behavior === undefined ? {} : { behavior: location.behavior }),
-        ...(location.top === undefined ? {} : { left: getPhysicalScrollLeft(scrollerRef.current!, location.top) }),
+  // Keep the subscription attached when a child layout effect publishes prepend compensation.
+  const scrollByCallback = React.useCallback(
+    (location: ScrollToOptions) => {
+      if (horizontalDirection === true) {
+        location = {
+          ...(location.behavior === undefined ? {} : { behavior: location.behavior }),
+          ...(location.top === undefined ? {} : { left: getPhysicalScrollLeft(scrollerRef.current!, location.top) }),
+        }
       }
-    }
-    scrollerRef.current!.scrollBy(location)
-  }
+      scrollerRef.current!.scrollBy(location)
+    },
+    [horizontalDirection]
+  )
 
   return { scrollByCallback, scrollerRef, scrollToCallback }
 }

--- a/packages/react-virtuoso/src/upwardScrollFixSystem.ts
+++ b/packages/react-virtuoso/src/upwardScrollFixSystem.ts
@@ -112,7 +112,9 @@ export const upwardScrollFixSystem = u.system(
     let pendingPrepend: { acknowledgeable: boolean; offset: number } | null = null
 
     function compensatePrepend() {
-      if (pendingPrepend === null) return
+      if (pendingPrepend === null) {
+        return
+      }
       const { offset } = pendingPrepend
       pendingPrepend = null
       u.publish(scrollBy, { top: offset })
@@ -123,12 +125,16 @@ export const upwardScrollFixSystem = u.system(
     }
 
     u.subscribe(deviationCommitted, (committed) => {
-      if (pendingPrepend === null || !pendingPrepend.acknowledgeable) return
+      if (pendingPrepend === null || !pendingPrepend.acknowledgeable) {
+        return
+      }
       // `deviation` is also published by the resize and mobile-Safari paths, so
       // the commit has to carry the pending offset. That is only unambiguous
       // because a pending compensation is `acknowledgeable` exclusively when
       // its own publish changed the value — see the publish site.
-      if (committed !== pendingPrepend.offset) return
+      if (committed !== pendingPrepend.offset) {
+        return
+      }
       compensatePrepend()
     })
 

--- a/packages/react-virtuoso/src/upwardScrollFixSystem.ts
+++ b/packages/react-virtuoso/src/upwardScrollFixSystem.ts
@@ -20,7 +20,7 @@ type UpwardFixState = [number, ListItem<any>[], number, number]
  */
 export const upwardScrollFixSystem = u.system(
   ([
-    { deviation, scrollBy, scrollingInProgress, scrollTop },
+    { deviation, deviationCommitted, scrollBy, scrollingInProgress, scrollTop },
     { isAtBottom, isScrolling, lastJumpDueToItemResize, scrollDirection },
     { listState },
     { beforeUnshiftWith, gap, shiftWithOffset, sizes },
@@ -104,6 +104,34 @@ export const upwardScrollFixSystem = u.system(
       scrollBy
     )
 
+    // A prepend's compensation is pending from the moment its deviation is
+    // published until it is applied — exactly once, by whichever comes first:
+    // the renderer's acknowledgement that the deviation reached the DOM, or the
+    // next-frame fallback. A second prepend replaces a pending one, which is
+    // correct: `deviation` is absolute, so the later offset already subsumes it.
+    let pendingPrepend: { acknowledgeable: boolean; offset: number } | null = null
+
+    function compensatePrepend() {
+      if (pendingPrepend === null) return
+      const { offset } = pendingPrepend
+      pendingPrepend = null
+      u.publish(scrollBy, { top: offset })
+      requestAnimationFrame(() => {
+        u.publish(deviation, 0)
+        u.publish(recalcInProgress, false)
+      })
+    }
+
+    u.subscribe(deviationCommitted, (committed) => {
+      if (pendingPrepend === null || !pendingPrepend.acknowledgeable) return
+      // `deviation` is also published by the resize and mobile-Safari paths, so
+      // the commit has to carry the pending offset. That is only unambiguous
+      // because a pending compensation is `acknowledgeable` exclusively when
+      // its own publish changed the value — see the publish site.
+      if (committed !== pendingPrepend.offset) return
+      compensatePrepend()
+    })
+
     u.subscribe(
       u.pipe(
         beforeUnshiftWith,
@@ -145,18 +173,39 @@ export const upwardScrollFixSystem = u.system(
       ),
       (offset) => {
         // The deviation makes room for the prepended items by pushing the list
-        // DOWN; the scroll cancels that push. Both have to land in the same
-        // frame. Deferring the scroll by a `requestAnimationFrame` leaves one
+        // DOWN; the scroll cancels that push. Both have to reach the DOM before
+        // the same paint. Deferring the scroll by a whole frame leaves one
         // painted frame in which the content is displaced by the full size of
-        // the page with nothing compensating it — and because prepends
-        // typically fire near scrollTop 0, that displacement is the whole
-        // viewport, so the list renders empty for a frame.
+        // the page with nothing compensating it — and because prepends fire
+        // near scrollTop 0, that displacement is the whole viewport, so the
+        // list paints empty.
+        //
+        // They cannot just be published together either. `deviation` reaches
+        // the DOM through React state, so until that commit lands the content
+        // has not grown and `scrollBy` is clamped to the old maxScrollTop,
+        // silently losing part of the compensation — the upward jump on a large
+        // prepend into a short list that the deferral was introduced to fix.
+        //
+        // So the scroll waits for the renderer to acknowledge the committed
+        // deviation from a layout effect: after the DOM mutation, still before
+        // paint. Ordering is then structural rather than a timing assumption.
+        //
+        // Acknowledgements are matched by value, so a compensation may only wait
+        // for one when this publish actually changes the rendered deviation. If
+        // it does not — a second prepend of the same size before the first has
+        // been cleared — no commit and no acknowledgement can follow, and
+        // waiting would leave it releasable by the *previous* prepend's
+        // acknowledgement, which carries the same value. Such a compensation
+        // takes the fallback instead, which is the behaviour before this change:
+        // the blank frame is not removed in that case, but nothing regresses,
+        // and no acknowledgement can be misattributed.
+        pendingPrepend = { acknowledgeable: u.getValue(deviation) !== offset, offset }
         u.publish(deviation, offset)
-        u.publish(scrollBy, { top: offset })
-        requestAnimationFrame(() => {
-          u.publish(deviation, 0)
-          u.publish(recalcInProgress, false)
-        })
+        // If nothing acknowledges by the next frame — no renderer mounted, a
+        // subtree without layout effects, SSR — fall back to the historic
+        // deferred scroll. The worst case is the behaviour before this change,
+        // never worse.
+        requestAnimationFrame(compensatePrepend)
       }
     )
 

--- a/packages/react-virtuoso/src/upwardScrollFixSystem.ts
+++ b/packages/react-virtuoso/src/upwardScrollFixSystem.ts
@@ -144,13 +144,18 @@ export const upwardScrollFixSystem = u.system(
         })
       ),
       (offset) => {
+        // The deviation makes room for the prepended items by pushing the list
+        // DOWN; the scroll cancels that push. Both have to land in the same
+        // frame. Deferring the scroll by a `requestAnimationFrame` leaves one
+        // painted frame in which the content is displaced by the full size of
+        // the page with nothing compensating it — and because prepends
+        // typically fire near scrollTop 0, that displacement is the whole
+        // viewport, so the list renders empty for a frame.
         u.publish(deviation, offset)
+        u.publish(scrollBy, { top: offset })
         requestAnimationFrame(() => {
-          u.publish(scrollBy, { top: offset })
-          requestAnimationFrame(() => {
-            u.publish(deviation, 0)
-            u.publish(recalcInProgress, false)
-          })
+          u.publish(deviation, 0)
+          u.publish(recalcInProgress, false)
         })
       }
     )

--- a/packages/react-virtuoso/test/upwardScrollFixSystem.test.ts
+++ b/packages/react-virtuoso/test/upwardScrollFixSystem.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { domIOSystem } from '../src/domIOSystem'
+import { sizeSystem } from '../src/sizeSystem'
+import { upwardScrollFixSystem } from '../src/upwardScrollFixSystem'
+import { init, publish, subscribe, system, tup } from '../src/urx'
+
+const testSystem = system(
+  ([upward, dom, size]) => ({ ...upward, ...dom, ...size }),
+  tup(upwardScrollFixSystem, domIOSystem, sizeSystem)
+)
+
+const ITEM_SIZE = 30
+const UNSHIFTED = 10
+const EXPECTED_OFFSET = ITEM_SIZE * UNSHIFTED
+
+function setup() {
+  const s = init(testSystem)
+  // establish a default item size, so the unshift offset is computable
+  publish(s.sizeRanges, [{ endIndex: 0, size: ITEM_SIZE, startIndex: 0 }])
+  const scrolls: { top: number }[] = []
+  const deviations: number[] = []
+  subscribe(s.scrollBy, (v) => scrolls.push(v as { top: number }))
+  subscribe(s.deviation, (v) => deviations.push(v))
+  return { deviations, scrolls, system: s }
+}
+
+describe('upwardScrollFixSystem — prepend compensation', () => {
+  it('publishes the compensating scroll in the same task as the deviation', () => {
+    // A requestAnimationFrame that never runs its callback: whatever is only
+    // reachable from inside a frame callback will not have happened.
+    const raf = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation(() => 0)
+    const { deviations, scrolls, system: s } = setup()
+
+    publish(s.beforeUnshiftWith, UNSHIFTED)
+
+    expect(deviations).toContain(EXPECTED_OFFSET)
+    // The regression: deferring this by a frame leaves one painted frame in
+    // which the list is displaced by the full page height with nothing
+    // compensating it, so the viewport renders empty.
+    expect(scrolls).toEqual([{ top: EXPECTED_OFFSET }])
+
+    raf.mockRestore()
+  })
+
+  it('still clears the deviation on the next frame', () => {
+    const callbacks: FrameRequestCallback[] = []
+    const raf = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
+      callbacks.push(cb)
+      return 0
+    })
+    const { deviations, system: s } = setup()
+
+    publish(s.beforeUnshiftWith, UNSHIFTED)
+    expect(deviations.at(-1)).toBe(EXPECTED_OFFSET)
+
+    expect(callbacks).toHaveLength(1)
+    callbacks.forEach((cb) => { cb(0) })
+    expect(deviations.at(-1)).toBe(0)
+
+    raf.mockRestore()
+  })
+})

--- a/packages/react-virtuoso/test/upwardScrollFixSystem.test.ts
+++ b/packages/react-virtuoso/test/upwardScrollFixSystem.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { domIOSystem } from '../src/domIOSystem'
+import { recalcSystem } from '../src/recalcSystem'
 import { sizeSystem } from '../src/sizeSystem'
 import { upwardScrollFixSystem } from '../src/upwardScrollFixSystem'
 import { init, publish, subscribe, system, tup } from '../src/urx'
 
 const testSystem = system(
-  ([upward, dom, size]) => ({ ...upward, ...dom, ...size }),
-  tup(upwardScrollFixSystem, domIOSystem, sizeSystem)
+  ([upward, dom, size, recalc]) => ({ ...upward, ...dom, ...size, ...recalc }),
+  tup(upwardScrollFixSystem, domIOSystem, sizeSystem, recalcSystem)
 )
 
 const ITEM_SIZE = 30
@@ -25,39 +26,148 @@ function setup() {
   return { deviations, scrolls, system: s }
 }
 
+/** A `requestAnimationFrame` whose callbacks only run when told to. */
+function heldFrames() {
+  const callbacks: FrameRequestCallback[] = []
+  const raf = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
+    callbacks.push(cb)
+    return 0
+  })
+  return {
+    restore: () => {
+      raf.mockRestore()
+    },
+    runNext: () => {
+      const cb = callbacks.shift()
+      if (cb) cb(0)
+    },
+    get pending() {
+      return callbacks.length
+    },
+  }
+}
+
+/**
+ * These cover the *protocol*: a prepend arms the compensation, and the scroll is
+ * released by whichever arrives first — the renderer's acknowledgement that the
+ * deviation reached the DOM, or the next-frame fallback — but never twice.
+ *
+ * They deliberately do not claim anything about DOM ordering or retained scroll
+ * position; jsdom has no layout, so it cannot answer either. That is what
+ * `e2e/prepend-items.test.ts` is for.
+ */
 describe('upwardScrollFixSystem — prepend compensation', () => {
-  it('publishes the compensating scroll in the same task as the deviation', () => {
-    // A requestAnimationFrame that never runs its callback: whatever is only
-    // reachable from inside a frame callback will not have happened.
-    const raf = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation(() => 0)
+  it('publishes the deviation but holds the scroll until it is acknowledged', () => {
+    const frames = heldFrames()
     const { deviations, scrolls, system: s } = setup()
 
     publish(s.beforeUnshiftWith, UNSHIFTED)
 
     expect(deviations).toContain(EXPECTED_OFFSET)
-    // The regression: deferring this by a frame leaves one painted frame in
-    // which the list is displaced by the full page height with nothing
-    // compensating it, so the viewport renders empty.
+    // Scrolling now would run against the pre-deviation layout: the content has
+    // not grown yet, so the browser clamps the scroll to the old maximum and
+    // part of the compensation is silently lost.
+    expect(scrolls).toEqual([])
+
+    publish(s.deviationCommitted, EXPECTED_OFFSET)
     expect(scrolls).toEqual([{ top: EXPECTED_OFFSET }])
 
-    raf.mockRestore()
+    frames.restore()
   })
 
-  it('still clears the deviation on the next frame', () => {
-    const callbacks: FrameRequestCallback[] = []
-    const raf = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
-      callbacks.push(cb)
-      return 0
-    })
-    const { deviations, system: s } = setup()
+  it('ignores a deviation commit that is not the armed prepend', () => {
+    const frames = heldFrames()
+    const { scrolls, system: s } = setup()
 
     publish(s.beforeUnshiftWith, UNSHIFTED)
+    // The resize and mobile-Safari paths publish deviations of their own.
+    publish(s.deviationCommitted, EXPECTED_OFFSET - 1)
+    publish(s.deviationCommitted, 0)
+
+    expect(scrolls).toEqual([])
+
+    frames.restore()
+  })
+
+  it('falls back to the deferred scroll when no acknowledgement arrives', () => {
+    const frames = heldFrames()
+    const { scrolls, system: s } = setup()
+
+    publish(s.beforeUnshiftWith, UNSHIFTED)
+    expect(scrolls).toEqual([])
+
+    // No renderer acknowledged it — behave exactly as before this change.
+    frames.runNext()
+    expect(scrolls).toEqual([{ top: EXPECTED_OFFSET }])
+
+    frames.restore()
+  })
+
+  it('compensates exactly once, whichever of the two arrives first', () => {
+    const frames = heldFrames()
+    const { scrolls, system: s } = setup()
+
+    publish(s.beforeUnshiftWith, UNSHIFTED)
+    publish(s.deviationCommitted, EXPECTED_OFFSET)
+    // The fallback frame still fires afterwards; it must not scroll again.
+    frames.runNext()
+    expect(scrolls).toEqual([{ top: EXPECTED_OFFSET }])
+
+    const late = init(testSystem)
+    publish(late.sizeRanges, [{ endIndex: 0, size: ITEM_SIZE, startIndex: 0 }])
+    const lateScrolls: { top: number }[] = []
+    subscribe(late.scrollBy, (v) => lateScrolls.push(v as { top: number }))
+    publish(late.beforeUnshiftWith, UNSHIFTED)
+    frames.runNext()
+    // A late acknowledgement, after the fallback already compensated.
+    publish(late.deviationCommitted, EXPECTED_OFFSET)
+    expect(lateScrolls).toEqual([{ top: EXPECTED_OFFSET }])
+
+    frames.restore()
+  })
+
+  it('clears the deviation and releases recalc on the frame after compensating', () => {
+    const frames = heldFrames()
+    const { deviations, system: s } = setup()
+    const recalcs: boolean[] = []
+    subscribe(s.recalcInProgress, (v) => recalcs.push(v))
+
+    publish(s.beforeUnshiftWith, UNSHIFTED)
+    publish(s.deviationCommitted, EXPECTED_OFFSET)
     expect(deviations.at(-1)).toBe(EXPECTED_OFFSET)
 
-    expect(callbacks).toHaveLength(1)
-    callbacks.forEach((cb) => { cb(0) })
+    // The fallback frame is still queued; the clear is the one after it.
+    frames.runNext()
+    frames.runNext()
     expect(deviations.at(-1)).toBe(0)
+    expect(recalcs.at(-1)).toBe(false)
 
-    raf.mockRestore()
+    frames.restore()
+  })
+
+  it('does not let a repeated prepend be released by the previous acknowledgement', () => {
+    const frames = heldFrames()
+    const { scrolls, system: s } = setup()
+
+    publish(s.beforeUnshiftWith, UNSHIFTED)
+    publish(s.deviationCommitted, EXPECTED_OFFSET)
+    expect(scrolls).toEqual([{ top: EXPECTED_OFFSET }])
+
+    // A second page of the same size, before the deviation has been cleared.
+    // Publishing it changes nothing, so no commit and no acknowledgement can
+    // follow — and an acknowledgement carrying that same value is necessarily
+    // the previous prepend's. It must not release this one.
+    publish(s.beforeUnshiftWith, UNSHIFTED)
+    publish(s.deviationCommitted, EXPECTED_OFFSET)
+    expect(scrolls).toEqual([{ top: EXPECTED_OFFSET }])
+
+    // The fallback is what compensates it, exactly once.
+    frames.runNext()
+    expect(scrolls).toEqual([{ top: EXPECTED_OFFSET }, { top: EXPECTED_OFFSET }])
+    frames.runNext()
+    frames.runNext()
+    expect(scrolls).toEqual([{ top: EXPECTED_OFFSET }, { top: EXPECTED_OFFSET }])
+
+    frames.restore()
   })
 })

--- a/packages/react-virtuoso/test/upwardScrollFixSystem.test.ts
+++ b/packages/react-virtuoso/test/upwardScrollFixSystem.test.ts
@@ -39,7 +39,9 @@ function heldFrames() {
     },
     runNext: () => {
       const cb = callbacks.shift()
-      if (cb) cb(0)
+      if (cb) {
+        cb(0)
+      }
     },
     get pending() {
       return callbacks.length


### PR DESCRIPTION
## The bug

Prepending a page blanks the transcript for a frame.

The compensation is applied in two steps one frame apart: `deviation` makes room by pushing the list
**down** (`margin-top`), and `scrollBy` cancels that push a `requestAnimationFrame` later. In between
there is a painted frame in which the list is displaced by the full size of the page with nothing
compensating it — and because pagination fires near `scrollTop: 0`, that displacement is the whole
viewport.

Reproduced frame by frame in this repo's own e2e example, in a production app, and in a design
system that bundles this package.

## The fix

The compensating scroll cannot simply move into the same task as the deviation. `deviation` reaches
the DOM through React state — `List` renders it as `marginTop`, and the synchronous style write
removed in b32e5fc is still there, commented out, directly above `setDeviation`
([Virtuoso.tsx#L107-L108](https://github.com/petyosi/react-virtuoso/blob/da1420a12bd7d103857e4828a934b0d56256298a/packages/react-virtuoso/src/Virtuoso.tsx#L107-L108)).
`scrollBy` on the other hand has a single route to the element, `scrollerRef.current.scrollBy(...)`
in `useScrollTop`. So in one task the scroll runs first, against a scroller whose content has not
grown, and the browser clamps it to the old `maxScrollTop`. On a large prepend into a short list —
"prepend 100 items before 20" — most of the compensation is silently lost, which is the upward jump
the deferral exists to prevent.

So the ordering is kept, and made structural rather than timing-based:

- `domIOSystem` gains a `deviationCommitted` stream.
- `List` and `TableVirtuoso` publish it from a `useIsomorphicLayoutEffect` keyed on the committed
  deviation — after the DOM mutation, before paint.
- `upwardScrollFixSystem` marks the compensation pending **before** publishing the deviation, then
  scrolls when an acknowledgement carrying that offset arrives. Pending-first matters: under legacy
  React outside a batch, the commit — and with it the acknowledgement — can happen synchronously
  inside the publish itself.
- If nothing acknowledges by the next frame (no renderer mounted, a subtree without layout effects,
  SSR), it falls back to the deferred scroll. The worst case is the behaviour before this change,
  never worse.

The acknowledgement lives in `List` because its `marginTop` is what grows the content in both
scroller modes, and the scroller height is additive. `List`'s deviation is a local `useState` fed by
`useEmitter`, not `useEmitterValue`, so the subscription path is identical on React 16 through 19 and
does not touch the `useSyncExternalStore` branch in `react-urx`.

## Limits, stated as limits

A pending compensation only waits for an acknowledgement when its publish actually changes the
rendered deviation. A second prepend of the same size before the first is cleared produces no new
commit, and since acknowledgements are matched by value it could be released by the previous
prepend's — so those take the fallback instead. The blank frame is therefore **not** removed in that
specific case. Removing it properly appears to require deciding whether overlapping prepends should
accumulate the deviation, which this PR does not touch.

## Tests

The previous unit test asserted that the scroll was published in the same task as the deviation,
which pinned the unsafe ordering. It now covers the protocol only — pending, released exactly once by
either path, ignoring the deviations the resize and mobile-Safari paths publish, and not releasing a
repeated prepend on the previous acknowledgement — and states that jsdom can answer neither DOM
ordering nor retained position.

The DOM-level guard is in `e2e/prepend-items.test.ts`:

- The existing retained-position assertions are **untouched**, since a clamped compensation is
  exactly what they break. Both still pass.
- A new case samples every animation frame across a prepend and fails if any painted frame had rows
  rendered while none of them intersected the viewport.

Run with `--repeat-each 20`, because the blank is a race:

| | blank frames |
|---|---|
| `main` | **20 of 20 runs** (one blank frame each) |
| this branch | **0 of 20 runs** |

Locally: `tsgo --noEmit` clean, vitest 203 passed, playwright 44 passed.

## Unrelated observation

Adding a `useWindowScroll` prepend example with a retained-position test did not work out, and the
reason may be worth knowing. On `main`, prepending 200 items grows the document from 5,206 to
15,891px but `window.scrollY` stays at 0 — a clamp would have left it at 4,486 — so the compensation
does not appear to fire at all in window-scroll mode. It behaves identically before and after this
change, so the test was dropped rather than shipped red. There is no e2e coverage for window-scroll
prepend today. Happy to open a separate issue with the repro.
